### PR TITLE
FFI: add function rnp_guess_contents()

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -774,6 +774,17 @@ rnp_result_t rnp_key_export(rnp_key_handle_t key, rnp_output_t output, uint32_t 
  */
 rnp_result_t rnp_key_remove(rnp_key_handle_t key, uint32_t flags);
 
+/** guess contents of the OpenPGP data stream.
+ *
+ * @param input stream with data. Must be opened and cannot be NULL.
+ * @param contents string with guessed data format will be stored here.
+ *                 Possible values: 'message', 'public key', 'secret key', 'signature',
+ * 'unknown'. May be used as type in rnp_enarmor() function. Must be deallocated with
+ * rnp_buffer_destroy() call.
+ * @return 0 on success, or any other value on error.
+ */
+rnp_result_t rnp_guess_contents(rnp_input_t input, char **contents);
+
 /** Add ASCII Armor
  *
  *  @param input stream to read data from

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -6493,6 +6493,25 @@ rnp_identifier_iterator_destroy(rnp_identifier_iterator_t it)
 }
 
 rnp_result_t
+rnp_guess_contents(rnp_input_t input, char **contents)
+{
+    if (!input || !contents) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+
+    pgp_armored_msg_t msgtype = rnp_armor_guess_type(&input->src);
+    const char *      msg = "unknown";
+    ARRAY_LOOKUP_BY_ID(armor_type_map, type, string, msgtype, msg);
+    size_t len = strlen(msg);
+    *contents = (char *) calloc(1, len + 1);
+    if (!*contents) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    memcpy(*contents, msg, len);
+    return RNP_SUCCESS;
+}
+
+rnp_result_t
 rnp_enarmor(rnp_input_t input, rnp_output_t output, const char *type)
 {
     pgp_armored_msg_t msgtype = PGP_ARMORED_UNKNOWN;

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -497,8 +497,10 @@ rnp_armor_guess_type(pgp_source_t *src)
     case PGP_PTAG_CT_LITDATA:
         return PGP_ARMORED_MESSAGE;
     case PGP_PTAG_CT_PUBLIC_KEY:
+    case PGP_PTAG_CT_PUBLIC_SUBKEY:
         return PGP_ARMORED_PUBLIC_KEY;
     case PGP_PTAG_CT_SECRET_KEY:
+    case PGP_PTAG_CT_SECRET_SUBKEY:
         return PGP_ARMORED_SECRET_KEY;
     case PGP_PTAG_CT_SIGNATURE:
         return PGP_ARMORED_SIGNATURE;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5409,3 +5409,55 @@ TEST_F(rnp_tests, test_ffi_output_to_armor)
     rnp_output_destroy(memory);
     rnp_ffi_destroy(ffi);
 }
+
+TEST_F(rnp_tests, test_ffi_rnp_guess_contents)
+{
+    char *      msgt = NULL;
+    rnp_input_t input = NULL;
+    assert_rnp_failure(rnp_guess_contents(NULL, &msgt));
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_key_merge/key-pub.pgp"));
+    assert_rnp_failure(rnp_guess_contents(input, NULL));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "public key"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_stream_key_merge/key-pub-just-subkey-1.pgp"));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "public key"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_key_merge/key-pub.asc"));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "unknown"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_key_merge/key-sec.pgp"));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "secret key"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_stream_key_merge/key-sec-just-subkey-1.pgp"));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "secret key"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_z/128mb.zip"));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "message"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_stream_signatures/source.txt.sig"));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_int_equal(strcmp(msgt, "signature"), 0);
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -244,6 +244,8 @@ void test_ffi_rnp_key_get_primary_grip(void **state);
 
 void test_ffi_output_to_armor(void **state);
 
+void test_ffi_rnp_guess_contents(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
Wrote this for CLI enarmor command for automatic armor header detection but then realized that it is already available in `rnp_dearmor` when passing NULL as armor type.
Anyway, it may be usable in other library usage scenarios.