### PR TITLE
Fix possible crashes when input directory instead of file is specified.

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1565,6 +1565,8 @@ rnp_input_from_path(rnp_input_t *input, const char *path)
             free(ob);
             return RNP_ERROR_OUT_OF_MEMORY;
         }
+        // return error on attempt to read from this source
+        (void) init_null_src(&ob->src);
     } else {
         // simple input from a file
         rnp_result_t ret = init_file_src(&ob->src, path);

--- a/src/librepgp/stream-common.cpp
+++ b/src/librepgp/stream-common.cpp
@@ -138,7 +138,6 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
 {
     ssize_t             read;
     pgp_source_cache_t *cache = src->cache;
-    bool                readahead = cache->readahead;
 
     if (!cache || (len > sizeof(cache->buf))) {
         return -1;
@@ -148,6 +147,7 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
         return 0;
     }
 
+    bool readahead = cache->readahead;
     // Do not read more then available if source size is known
     if (src->knownsize && (src->readb + len > src->size)) {
         len = src->size - src->readb;
@@ -496,6 +496,22 @@ init_mem_src(pgp_source_t *src, const void *mem, size_t len, bool free)
     src->knownsize = 1;
     src->type = PGP_STREAM_MEMORY;
 
+    return RNP_SUCCESS;
+}
+
+static ssize_t
+null_src_read(pgp_source_t *src, void *buf, size_t len)
+{
+    return -1;
+}
+
+rnp_result_t
+init_null_src(pgp_source_t *src)
+{
+    memset(src, 0, sizeof(*src));
+    src->read = null_src_read;
+    src->type = PGP_STREAM_NULL;
+    src->error = true;
     return RNP_SUCCESS;
 }
 

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -191,6 +191,12 @@ rnp_result_t init_stdin_src(pgp_source_t *src);
  **/
 rnp_result_t init_mem_src(pgp_source_t *src, const void *mem, size_t len, bool free);
 
+/** @brief init NULL source, which doesn't allow to read anything and always returns an error.
+ *  @param src pre-allocated source structure
+ *  @return always RNP_SUCCESS
+ **/
+rnp_result_t init_null_src(pgp_source_t *src);
+
 /** @brief init memory source with contents of other source
  *  @param src pre-allocated source structure
  *  @param readsrc opened source with data

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -491,5 +491,12 @@ TEST_F(rnp_tests, test_cli_dump)
     status = system(cmd);
     assert_true(WIFEXITED(status));
     assert_int_equal(WEXITSTATUS(status), 0);
+    /* run dump on directory - must fail but not crash */
+    chnum = snprintf(cmd, sizeof(cmd), "%s \"%s\"", dump_path, KEYS "/1/");
+    assert_true(chnum < (int) sizeof(cmd));
+    status = system(cmd);
+    assert_true(WIFEXITED(status));
+    assert_int_not_equal(WEXITSTATUS(status), 0);
+
     free(dump_path);
 }


### PR DESCRIPTION
Fixes #906 and other possible crashes due to uninitialized rnp_input_t.src field.