### PR TITLE
FFI: add rnp_op_encrypt_set_aead() function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,8 @@ cache:
 before_install:
   - . ci/env.inc.sh
   - ./ci/before_install.sh
-  - rvm use 2.4.6 --install --binary
+  - rvm use 2.4.6 --install --disable-binary
+  - rvm 2.4.6 --verbose do gem install bundler -v 1.16.4
 
 install:
   - . ci/env.inc.sh

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -21,11 +21,14 @@ freebsd_install() {
     libtool
     gettext-tools
     python
-    ruby
-    devel/ruby-gems
+    ruby25
 "
   # Note: we assume sudo is already installed
   sudo pkg install -y ${packages}
+
+  cd /usr/ports/devel/ruby-gems
+  sudo make -DBATCH RUBY_VER=2.5 install
+  cd
 
   mkdir -p ~/.gnupg
   echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -26,6 +26,9 @@ freebsd_install() {
 "
   # Note: we assume sudo is already installed
   sudo pkg install -y ${packages}
+
+  mkdir -p ~/.gnupg
+  echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
   dirmngr </dev/null
   dirmngr --daemon
 }

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1823,6 +1823,16 @@ rnp_result_t rnp_op_encrypt_set_cipher(rnp_op_encrypt_t op, const char *cipher);
 rnp_result_t rnp_op_encrypt_set_aead(rnp_op_encrypt_t op, const char *alg);
 
 /**
+ * @brief set chunk length for AEAD mode via number of chunk size bits (refer OpenPGP
+ * specificationf for the details).
+ *
+ * @param op opaque encrypting context. Must be allocated and initialized.
+ * @param bits number of bits, currently it must be between 0 to 56.
+ * @return RNP_SUCCESS or error code if failed
+ */
+rnp_result_t rnp_op_encrypt_set_aead_bits(rnp_op_encrypt_t op, int bits);
+
+/**
  * @brief set the compression algorithm and level for the inner raw data
  *
  * @param op opaque encrypted context. Must be allocated and initialized

--- a/src/lib/crypto/symmetric.h
+++ b/src/lib/crypto/symmetric.h
@@ -101,15 +101,6 @@ typedef struct pgp_crypt_t {
     rng_t *        rng;
 } pgp_crypt_t;
 
-typedef struct pgp_aead_params_t {
-    pgp_symm_alg_t ealg;                       /* underlying symmetric algorithm */
-    pgp_aead_alg_t aalg;                       /* AEAD algorithm, i.e. EAX, OCB, etc */
-    uint8_t        iv[PGP_AEAD_MAX_NONCE_LEN]; /* initial vector for the message */
-    size_t         ivlen;                      /* iv length */
-    uint8_t        ad[PGP_AEAD_MAX_AD_LEN];    /* additional data */
-    size_t         adlen;                      /* length of the additional data */
-} pgp_aead_params_t;
-
 pgp_symm_alg_t pgp_str_to_cipher(const char *name);
 unsigned       pgp_block_size(pgp_symm_alg_t);
 unsigned       pgp_key_size(pgp_symm_alg_t);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2226,6 +2226,19 @@ rnp_op_encrypt_set_aead(rnp_op_encrypt_t op, const char *alg)
 }
 
 rnp_result_t
+rnp_op_encrypt_set_aead_bits(rnp_op_encrypt_t op, int bits)
+{
+    if (!op) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    if ((bits < 0) || (bits > 56)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    op->rnpctx.abits = bits;
+    return RNP_SUCCESS;
+}
+
+rnp_result_t
 rnp_op_encrypt_set_compression(rnp_op_encrypt_t op, const char *compression, int level)
 {
     // checks

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -301,6 +301,15 @@ typedef struct pgp_literal_hdr_t {
     uint32_t timestamp;
 } pgp_literal_hdr_t;
 
+typedef struct pgp_aead_hdr_t {
+    int            version;                    /* version of the AEAD packet */
+    pgp_symm_alg_t ealg;                       /* underlying symmetric algorithm */
+    pgp_aead_alg_t aalg;                       /* AEAD algorithm, i.e. EAX, OCB, etc */
+    int            csize;                      /* chunk size bits */
+    uint8_t        iv[PGP_AEAD_MAX_NONCE_LEN]; /* initial vector for the message */
+    size_t         ivlen;                      /* iv length */
+} pgp_aead_hdr_t;
+
 /** litdata_type_t */
 typedef enum {
     PGP_LDT_BINARY = 'b',

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -314,6 +314,12 @@ rnp_result_t init_stdout_dest(pgp_dest_t *dst);
  **/
 rnp_result_t init_mem_dest(pgp_dest_t *dst, void *mem, unsigned len);
 
+/** @brief set whether to silently discard bytes which overflow memory of the dst.
+ *  @param dst pre-allocated and initialized memory dest
+ *  @param discard true to discard or false to return an error on overflow.
+ **/
+void mem_dest_discard_overflow(pgp_dest_t *dst, bool discard);
+
 /** @brief get the pointer to the memory where data is written.
  *  Do not retain the result, it may change betweeen calls due to realloc
  *  @param dst pre-allocated and initialized memory dest

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -246,6 +246,14 @@ void packet_body_part_from_mem(pgp_packet_body_t *body, const void *mem, size_t 
 
 /* Packet handling functions */
 
+/** @brief read OpenPGP packet from the stream, and write it's contents to another stream.
+ *  @param src source with packet data
+ *  @param dst destination to write packet contents. All write failures on dst
+ *             will be ignored. Can be NULL if you need just to skip packet.
+ *  @return RNP_SUCCESS or error code if operation failed.
+ */
+rnp_result_t stream_read_packet(pgp_source_t *src, pgp_dest_t *dst);
+
 rnp_result_t stream_skip_packet(pgp_source_t *src);
 
 /* Symmetric-key encrypted session key */

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -95,4 +95,11 @@ rnp_result_t init_literal_src(pgp_source_t *src, pgp_source_t *readsrc);
  */
 bool get_literal_src_hdr(pgp_source_t *src, pgp_literal_hdr_t *hdr);
 
+/* @brief Get the AEAD-encrypted packet information fields (not the OpenPGP packet header)
+ * @param src AEAD-encrypted data source (starting from packet data itself, not the header)
+ * @param hdr pointer to header structure, where result will be stored
+ * @return true on success or false otherwise
+ */
+bool get_aead_src_hdr(pgp_source_t *src, pgp_aead_hdr_t *hdr);
+
 #endif

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -250,6 +250,8 @@ void test_ffi_literal_filename(void **state);
 
 void test_ffi_op_set_hash(void **state);
 
+void test_ffi_aead_params(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -256,6 +256,8 @@ void test_dsa_verify_negative(void **state);
 
 void test_stream_memory(void **state);
 
+void test_stream_memory_discard(void **state);
+
 void test_stream_file(void **state);
 
 void test_stream_signatures(void **state);

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -600,3 +600,36 @@ fmt(const char *format, ...)
     buf.resize(size);
     return buf;
 }
+
+bool
+check_json_field_str(json_object *obj, const std::string &field, const std::string &value)
+{
+    if (!obj || !json_object_is_type(obj, json_type_object)) {
+      return false;
+    }
+    json_object *fld = NULL;
+    if (!json_object_object_get_ex(obj, field.c_str(), &fld)) {
+      return false;
+    }
+    if (!json_object_is_type(fld, json_type_string)) {
+        return false;
+    }
+    const char *jsoval = json_object_get_string(fld);
+    return jsoval && (value == jsoval);
+}
+
+bool
+check_json_field_int(json_object *obj, const std::string &field, int value)
+{
+    if (!obj || !json_object_is_type(obj, json_type_object)) {
+      return false;
+    }
+    json_object *fld = NULL;
+    if (!json_object_object_get_ex(obj, field.c_str(), &fld)) {
+      return false;
+    }
+    if (!json_object_is_type(fld, json_type_int)) {
+        return false;
+    }
+    return json_object_get_int(fld) == value;
+}

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -168,3 +168,6 @@ bool starts_with(const std::string &data, const std::string &match);
 bool ends_with(const std::string &data, const std::string &match);
 
 std::string fmt(const char *format, ...);
+
+bool check_json_field_str(json_object *obj, const std::string &field, const std::string &value);
+bool check_json_field_int(json_object *obj, const std::string &field, int value);


### PR DESCRIPTION
This PR adds a single function to FFI which would allow to set AEAD chunk size bits from the CLI.
However, since we didn't have a way to dump AEAD encrypted packet details before, it required a lot of lower layer additions and changes (including some refactoring).