### PR TITLE
Allow to use password provider in rnp_op_encrypt_add_password

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1777,7 +1777,8 @@ rnp_result_t rnp_op_encrypt_set_expiration_time(rnp_op_encrypt_t op, uint32_t ex
  * @brief Add password which is used to encrypt data. Multiple passwords can be added.
  *
  * @param op opaque encrypting context. Must be allocated and initialized.
- * @param password NULL-terminated password string
+ * @param password NULL-terminated password string, or NULL if password should be requested
+ *                 via password provider.
  * @param s2k_hash hash algorithm, used in key-from-password derivation. Pass NULL for default
  *        value. See rnp_op_encrypt_set_hash for possible values.
  * @param iterations number of iterations, used iin key derivation function. Pass 0 for default

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -190,6 +190,8 @@ void test_ffi_save_keys(void **state);
 
 void test_ffi_encrypt_pass(void **state);
 
+void test_ffi_encrypt_pass_provider(void **state);
+
 void test_ffi_encrypt_pk(void **state);
 
 void test_ffi_encrypt_and_sign(void **state);


### PR DESCRIPTION
Sometimes (in CLI for example) it is useful to be able to request password(s) for symmetric encryption via the configured pass provider instead of specifying it directly.