### PR TITLE
FFI: add function to dump signature packet to JSON

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1517,6 +1517,18 @@ rnp_result_t rnp_op_verify_destroy(rnp_op_verify_t op);
  */
 rnp_result_t rnp_op_verify_signature_get_status(rnp_op_verify_signature_t sig);
 
+/** Get the signature handle from the verified signature. This would allow to query extended
+ * information on the signature.
+ *
+ * @param sig verified signature context, cannot be NULL.
+ * @param handle signature handle will be stored here on success. You must free it after use
+ * with
+ *            the rnp_signature_handle_destroy() function.
+ * @return RNP_SUCCESS or error code if failed.
+ */
+rnp_result_t rnp_op_verify_signature_get_handle(rnp_op_verify_signature_t sig,
+                                                rnp_signature_handle_t *  handle);
+
 /** @brief Get hash function used to calculate signature
  *  @param sig opaque signature context obtained via rnp_op_verify_get_signature_at call.
  *  @param hash pointer to string with hash algorithm name will be put here on success.

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -935,6 +935,19 @@ rnp_result_t rnp_signature_get_keyid(rnp_signature_handle_t sig, char **result);
  */
 rnp_result_t rnp_signature_get_signer(rnp_signature_handle_t sig, rnp_key_handle_t *key);
 
+/** Dump signature packet to JSON, obtaining the whole information about it.
+ *
+ * @param sig sigmature handle, cannot be NULL
+ * @param flags include additional fields in JSON (see RNP_JSON_DUMP_MPI and other
+ *              RNP_JSON_DUMP_* flags)
+ * @param result resulting JSON string will be stored here. You must free it using the
+ *               rnp_buffer_destroy() function.
+ * @return 0 on success, or any other value on error
+ */
+rnp_result_t rnp_signature_packet_to_json(rnp_signature_handle_t sig,
+                                          uint32_t               flags,
+                                          char **                json);
+
 /** Free signature handle.
  *
  * @param sig signature handle.

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -169,8 +169,8 @@ pgp_free_user_prefs(pgp_user_prefs_t *prefs)
     memset(prefs, 0, sizeof(*prefs));
 }
 
-static void
-subsig_free(pgp_subsig_t *subsig)
+void
+pgp_subsig_free(pgp_subsig_t *subsig)
 {
     if (!subsig) {
         return;
@@ -252,7 +252,7 @@ pgp_key_free_data(pgp_key_t *key)
     list_destroy(&key->packets);
 
     for (n = 0; n < pgp_key_get_subsig_count(key); n++) {
-        subsig_free(pgp_key_get_subsig(key, n));
+        pgp_subsig_free(pgp_key_get_subsig(key, n));
     }
     list_destroy(&key->subsigs);
 
@@ -412,7 +412,7 @@ error:
     return ret;
 }
 
-static rnp_result_t
+rnp_result_t
 pgp_subsig_copy(pgp_subsig_t *dst, const pgp_subsig_t *src)
 {
     memcpy(dst, src, sizeof(*dst));

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -271,6 +271,10 @@ size_t pgp_key_get_subsig_count(const pgp_key_t *);
 
 pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
 
+rnp_result_t pgp_subsig_copy(pgp_subsig_t *dst, const pgp_subsig_t *src);
+
+void pgp_subsig_free(pgp_subsig_t *subsig);
+
 pgp_rawpacket_t *pgp_key_add_rawpacket(pgp_key_t *, void *, size_t, pgp_content_enum);
 
 size_t pgp_key_get_rawpacket_count(const pgp_key_t *);

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -204,6 +204,8 @@ void test_ffi_signatures_detached(void **state);
 
 void test_ffi_signatures(void **state);
 
+void test_ffi_signatures_dump(void **state);
+
 void test_ffi_encrypt_pk_key_provider(void **state);
 
 void test_ffi_key_to_json(void **state);

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -601,15 +601,21 @@ fmt(const char *format, ...)
     return buf;
 }
 
-bool
-check_json_field_str(json_object *obj, const std::string &field, const std::string &value)
+static bool
+jso_get_field(json_object *obj, json_object **fld, const std::string &name)
 {
     if (!obj || !json_object_is_type(obj, json_type_object)) {
       return false;
     }
+    return json_object_object_get_ex(obj, name.c_str(), fld);
+}
+
+bool
+check_json_field_str(json_object *obj, const std::string &field, const std::string &value)
+{
     json_object *fld = NULL;
-    if (!json_object_object_get_ex(obj, field.c_str(), &fld)) {
-      return false;
+    if (!jso_get_field(obj, &fld, field)) {
+        return false;
     }
     if (!json_object_is_type(fld, json_type_string)) {
         return false;
@@ -621,15 +627,25 @@ check_json_field_str(json_object *obj, const std::string &field, const std::stri
 bool
 check_json_field_int(json_object *obj, const std::string &field, int value)
 {
-    if (!obj || !json_object_is_type(obj, json_type_object)) {
-      return false;
-    }
     json_object *fld = NULL;
-    if (!json_object_object_get_ex(obj, field.c_str(), &fld)) {
-      return false;
+    if (!jso_get_field(obj, &fld, field)) {
+        return false;
     }
     if (!json_object_is_type(fld, json_type_int)) {
         return false;
     }
     return json_object_get_int(fld) == value;
+}
+
+bool
+check_json_field_bool(json_object *obj, const std::string &field, bool value)
+{
+    json_object *fld = NULL;
+    if (!jso_get_field(obj, &fld, field)) {
+        return false;
+    }
+    if (!json_object_is_type(fld, json_type_boolean)) {
+        return false;
+    }
+    return json_object_get_boolean(fld) == value;
 }

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -169,5 +169,8 @@ bool ends_with(const std::string &data, const std::string &match);
 
 std::string fmt(const char *format, ...);
 
-bool check_json_field_str(json_object *obj, const std::string &field, const std::string &value);
+bool check_json_field_str(json_object *      obj,
+                          const std::string &field,
+                          const std::string &value);
 bool check_json_field_int(json_object *obj, const std::string &field, int value);
+bool check_json_field_bool(json_object *obj, const std::string &field, bool value);


### PR DESCRIPTION
This PR adds function which dumps signature packet information to JSON.
This would allow to get required info via JSON instead of having FFI function for each possible field.

As a side effect also function `rnp_op_verify_signature_get_handle` was added, allowing to have single interface to signature functions.

P.S. It is draft since it uses cherry-picked commits from yet unmerged PR #924 and is a part of #920.