### PR TITLE
Fix possible crash on rnp_op_verify_t misuse.

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2595,6 +2595,9 @@ rnp_verify_src_provider(pgp_parse_handler_t *handler, pgp_source_t *src)
 {
     /* this one is called only when input for detached signature is needed */
     rnp_op_verify_t op = (rnp_op_verify_t) handler->param;
+    if (!op->detached_input) {
+        return false;
+    }
     *src = op->detached_input->src;
     /* we should give ownership on src to caller */
     memset(&op->detached_input->src, 0, sizeof(op->detached_input->src));

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5858,3 +5858,23 @@ TEST_F(rnp_tests, test_ffi_aead_params)
     // final cleanup
     rnp_ffi_destroy(ffi);
 }
+
+TEST_F(rnp_tests, test_ffi_detached_verify_input)
+{
+    rnp_ffi_t       ffi = NULL;
+    rnp_input_t     input = NULL;
+    rnp_output_t    output = NULL;
+
+    // init ffi
+    test_ffi_init(&ffi);
+    /* verify detached signature via rnp_op_verify_create - should not crash */
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_signatures/source.txt.sig"));
+    assert_rnp_success(rnp_output_to_null(&output));
+    rnp_op_verify_t verify = NULL;
+    assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
+    assert_rnp_failure(rnp_op_verify_execute(verify));
+    rnp_op_verify_destroy(verify);
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -256,6 +256,8 @@ void test_ffi_op_set_hash(void **state);
 
 void test_ffi_aead_params(void **state);
 
+void test_ffi_detached_verify_input(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
While it's some sort of misuse (trying to verify detached signature via rnp_op_verify_create()), we still should not crash but return an error.
