### PR TITLE
tests: Relax cli_tests gpg good signature regex.

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -83,7 +83,7 @@ r'pub\s+rsa.+' \
 r'\s+([0-9A-F]{40})\s*' \
 r'uid\s+.+rsakey@gpg.*'
 
-RE_GPG_GOOD_SIGNATURE = r'(?s)^\s*' \
+RE_GPG_GOOD_SIGNATURE = r'(?s)^.*' \
 r'gpg: Signature made .*' \
 r'gpg: Good signature from "(.*)".*'
 


### PR DESCRIPTION
Newer version of gpg can have some extraneous output that prevents
matching with the previous regex.