### PR TITLE
Replaced and removed rnp_key_store_get_key_by_name() in tests.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -170,10 +170,6 @@ pgp_key_t *rnp_key_store_get_key_by_id(const rnp_key_store_t *,
                                        const unsigned char *,
                                        pgp_key_t *);
 
-pgp_key_t *rnp_key_store_get_key_by_name(const rnp_key_store_t *, const char *, pgp_key_t *);
-
-pgp_key_t *rnp_key_store_get_key_by_userid(const rnp_key_store_t *, const char *, pgp_key_t *);
-
 bool rnp_key_store_get_key_grip(const pgp_key_material_t *, uint8_t *);
 
 pgp_key_t *rnp_key_store_get_key_by_grip(const rnp_key_store_t *, const uint8_t *);

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -723,27 +723,6 @@ rnp_key_store_get_key_by_id(const rnp_key_store_t *keyring,
 }
 
 pgp_key_t *
-rnp_key_store_get_key_by_userid(const rnp_key_store_t *keyring,
-                                const char *           userid,
-                                pgp_key_t *            after)
-{
-    if (!keyring || !userid) {
-        return NULL;
-    }
-
-    // if after is provided, make sure it is a member of the appropriate list
-    assert(!after || list_is_member(keyring->keys, (list_item *) after));
-    list_item *start = after ? list_next((list_item *) after) : list_front(keyring->keys);
-    for (list_item *key_item = start; key_item; key_item = list_next(key_item)) {
-        pgp_key_t *key = (pgp_key_t *) key_item;
-        if (pgp_key_has_userid(key, userid)) {
-            return key;
-        }
-    }
-    return NULL;
-}
-
-pgp_key_t *
 rnp_key_store_get_key_by_grip(const rnp_key_store_t *keyring, const uint8_t *grip)
 {
     RNP_DLOG("looking keyring %p", keyring);
@@ -806,108 +785,6 @@ rnp_key_store_get_primary_key(const rnp_key_store_t *keyring, const pgp_key_t *s
     }
 
     return NULL;
-}
-
-/* return the next key which matches, starting searching after *after */
-static bool
-get_key_by_name(const rnp_key_store_t *keyring,
-                const char *           name,
-                pgp_key_t *            after,
-                pgp_key_t **           key)
-{
-    pgp_key_t *kp;
-    unsigned   i = 0;
-    pgp_key_t *keyp;
-    uint8_t    keyid[PGP_FINGERPRINT_SIZE];
-    size_t     len;
-    size_t     binlen = 0;
-
-    *key = NULL;
-
-    if (!keyring || !name) {
-        RNP_LOG("keyring, name and after shouldn't be NULL");
-        return false;
-    }
-    assert(!after || list_is_member(keyring->keys, (list_item *) after));
-    len = strlen(name);
-    RNP_DLOG("[%p] name '%s', len %zu", after, name, len);
-
-    /* first try name as a keyid */
-    (void) memset(keyid, 0x0, sizeof(keyid));
-    if (ishex(name, len) && hex2bin(name, len, keyid, sizeof(keyid), &binlen)) {
-        RNP_DHEX("keyid", keyid, 4);
-
-        if (binlen <= PGP_KEY_ID_SIZE) {
-            kp = rnp_key_store_get_key_by_id(keyring, keyid, after);
-        } else if (binlen <= PGP_FINGERPRINT_SIZE) {
-            pgp_fingerprint_t fp = {};
-            memcpy(fp.fingerprint, keyid, binlen);
-            fp.length = binlen;
-            kp = rnp_key_store_get_key_by_fpr(keyring, &fp);
-        } else {
-            kp = NULL;
-        }
-
-        if (kp) {
-            *key = kp;
-            return true;
-        }
-    }
-    RNP_DLOG("regex match '%s' after %p", name, after);
-
-    /* match on full name or email address as a NOSUB, ICASE regexp */
-#ifndef RNP_USE_STD_REGEX
-    regex_t    r;
-    if (regcomp(&r, name, REG_EXTENDED | REG_ICASE) != 0) {
-        RNP_LOG("Can't compile regex from string: '%s'", name);
-        return false;
-    }
-#else
-    std::regex re(name, std::regex_constants::extended | std::regex_constants::icase);
-#endif
-
-    for (list_item *key_item = after ? list_next((list_item *) after) :
-                                       list_front(keyring->keys);
-         key_item;
-         key_item = list_next(key_item)) {
-        keyp = (pgp_key_t *) key_item;
-
-        for (i = 0; i < pgp_key_get_userid_count(keyp); i++) {
-#ifndef RNP_USE_STD_REGEX
-            if (regexec(&r, (char *) pgp_key_get_userid(keyp, i), 0, NULL, 0) == 0) {
-                RNP_DLOG("MATCHED keyid \"%s\" len %" PRIsize "u",
-                         (char *) pgp_key_get_userid(keyp, i),
-                         len);
-                regfree(&r);
-                *key = keyp;
-                return true;
-            }
-#else
-            const std::string userid = pgp_key_get_userid(keyp, i);
-            if (std::regex_search(userid, re)) {
-                RNP_DLOG("MATCHED keyid \"%s\" len %" PRIsize "u",
-                         (char *) userid.c_str(),
-                         len);
-                *key = keyp;
-                return true;
-            }
-#endif
-        }
-    }
-#ifndef RNP_USE_STD_REGEX
-    regfree(&r);
-#endif
-    return true;
-}
-
-pgp_key_t *
-rnp_key_store_get_key_by_name(const rnp_key_store_t *keyring,
-                              const char *           name,
-                              pgp_key_t *            after)
-{
-    pgp_key_t *key = NULL;
-    get_key_by_name(keyring, name, after, &key);
-    return key;
 }
 
 static bool

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -55,7 +55,7 @@ TEST_F(rnp_tests, test_key_add_userid)
     src_close(&src);
 
     // locate our key
-    assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
+    assert_non_null(key = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
     assert_non_null(key);
 
     // unlock the key
@@ -133,7 +133,7 @@ TEST_F(rnp_tests, test_key_add_userid)
     assert_rnp_success(rnp_key_store_pgp_read_from_src(ks, &src));
     src_close(&src);
     dst_close(&dst, true);
-    assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
+    assert_non_null(key = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
 
     // confirm that the counts have increased as expected
     assert_int_equal(pgp_key_get_userid_count(key), uidc + 2);

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -66,7 +66,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
         for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
             pgp_key_t * key = NULL;
             const char *keyid = keyids[i];
-            assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyid, NULL));
+            assert_non_null(key = rnp_tests_get_key_by_id(ks, keyid, NULL));
             assert_non_null(key);
             // all keys in this keyring are encrypted and thus should be both protected and
             // locked initially
@@ -75,7 +75,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
         }
 
         pgp_key_t *tmp = NULL;
-        assert_non_null(tmp = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
+        assert_non_null(tmp = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
         assert_non_null(tmp);
 
         // steal this key from the store
@@ -147,7 +147,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
         // grab the first key
         pgp_key_t *reloaded_key = NULL;
-        assert_non_null(reloaded_key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
+        assert_non_null(reloaded_key = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
         assert_non_null(reloaded_key);
 
         // should not be locked, nor protected

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -122,7 +122,7 @@ TEST_F(rnp_tests, test_key_store_search)
             list        seen_keys = NULL;
             pgp_key_t * key = NULL;
             const char *userid = testdata[i].userids[uidn];
-            key = rnp_tests_key_search(store, userid, NULL);
+            key = rnp_tests_key_search(store, userid);
             while (key) {
                 // check that the userid actually matches
                 bool found = false;
@@ -199,34 +199,34 @@ TEST_F(rnp_tests, test_key_store_search_by_name)
 
     /* Find keys and subkeys by fingerprint, id and userid */
     primsec = rnp_tests_get_key_by_fpr(
-      sec_store, "4F2E62B74E6A4CD333BC19004BE147BB22DF1E60", NULL);
+      sec_store, "4F2E62B74E6A4CD333BC19004BE147BB22DF1E60");
     assert_non_null(primsec);
     key = rnp_tests_get_key_by_id(sec_store, "4BE147BB22DF1E60", NULL);
     assert_true(key == primsec);
     subsec = rnp_tests_get_key_by_fpr(
-      sec_store, "10793E367EE867C32E358F2AA49BAE05C16E8BC8", NULL);
+      sec_store, "10793E367EE867C32E358F2AA49BAE05C16E8BC8");
     assert_non_null(subsec);
     assert_true(primsec != subsec);
     key = rnp_tests_get_key_by_id(sec_store, "A49BAE05C16E8BC8", NULL);
     assert_true(key == subsec);
 
     primpub = rnp_tests_get_key_by_fpr(
-      pub_store, "4F2E62B74E6A4CD333BC19004BE147BB22DF1E60", NULL);
+      pub_store, "4F2E62B74E6A4CD333BC19004BE147BB22DF1E60");
     assert_non_null(primpub);
     assert_true(primsec != primpub);
     subpub = rnp_tests_get_key_by_fpr(
-      pub_store, "10793E367EE867C32E358F2AA49BAE05C16E8BC8", NULL);
+      pub_store, "10793E367EE867C32E358F2AA49BAE05C16E8BC8");
     assert_true(primpub != subpub);
     assert_true(subpub != subsec);
-    key = rnp_tests_key_search(pub_store, "test1", NULL);
+    key = rnp_tests_key_search(pub_store, "test1");
     assert_true(key == primpub);
 
     /* Try other searches */
     key = rnp_tests_get_key_by_fpr(
-      sec_store, "4f2e62b74e6a4cd333bc19004be147bb22df1e60", NULL);
+      sec_store, "4f2e62b74e6a4cd333bc19004be147bb22df1e60");
     assert_true(key = primsec);
     key = rnp_tests_get_key_by_fpr(
-      sec_store, "0x4f2e62b74e6a4cd333bc19004be147bb22df1e60", NULL);
+      sec_store, "0x4f2e62b74e6a4cd333bc19004be147bb22df1e60");
     assert_true(key = primsec);
     key = rnp_tests_get_key_by_id(pub_store, "4BE147BB22DF1E60", NULL);
     assert_true(key = primsec);
@@ -248,9 +248,9 @@ TEST_F(rnp_tests, test_key_store_search_by_name)
     assert_true(key = primsec);
     /* Try negative searches */
     assert_null(rnp_tests_get_key_by_fpr(
-      sec_store, "4f2e62b74e6a4cd333bc19004be147bb22df1e", NULL));
+      sec_store, "4f2e62b74e6a4cd333bc19004be147bb22df1e"));
     assert_null(rnp_tests_get_key_by_fpr(
-      sec_store, "2e62b74e6a4cd333bc19004be147bb22df1e60", NULL));
+      sec_store, "2e62b74e6a4cd333bc19004be147bb22df1e60"));
     assert_null(rnp_tests_get_key_by_id(sec_store, "4be147bb22dfle60", NULL));
     assert_null(rnp_tests_get_key_by_id(sec_store, "", NULL));
     assert_null(rnp_tests_get_key_by_id(sec_store, "test11", NULL));

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -94,7 +94,7 @@ TEST_F(rnp_tests, test_key_store_search)
     for (size_t i = 0; i < ARRAY_SIZE(testdata); i++) {
         list       seen_keys = NULL;
         pgp_key_t *key = NULL;
-        key = rnp_key_store_get_key_by_name(store, testdata[i].keyid, NULL);
+        key = rnp_tests_get_key_by_id(store, testdata[i].keyid, NULL);
         while (key) {
             // check that the keyid actually matches
             uint8_t expected_keyid[PGP_KEY_ID_SIZE];
@@ -108,7 +108,7 @@ TEST_F(rnp_tests, test_key_store_search)
             assert_non_null(list_append(&seen_keys, &key, sizeof(key)));
 
             // this only returns false on error, regardless of whether it found a match
-            key = rnp_key_store_get_key_by_name(store, testdata[i].keyid, key);
+            key = rnp_tests_get_key_by_id(store, testdata[i].keyid, key);
         }
         // check the count
         assert_int_equal(list_length(seen_keys), testdata[i].count);
@@ -122,7 +122,7 @@ TEST_F(rnp_tests, test_key_store_search)
             list        seen_keys = NULL;
             pgp_key_t * key = NULL;
             const char *userid = testdata[i].userids[uidn];
-            key = rnp_key_store_get_key_by_name(store, userid, NULL);
+            key = rnp_tests_key_search(store, userid, NULL);
             while (key) {
                 // check that the userid actually matches
                 bool found = false;
@@ -137,7 +137,7 @@ TEST_F(rnp_tests, test_key_store_search)
                 // keep track of what key pointers we have seen
                 assert_non_null(list_append(&seen_keys, &key, sizeof(key)));
 
-                key = rnp_key_store_get_key_by_name(store, testdata[i].keyid, key);
+                key = rnp_tests_get_key_by_id(store, testdata[i].keyid, key);
             }
             // check the count
             assert_int_equal(list_length(seen_keys), testdata[i].count);
@@ -146,6 +146,7 @@ TEST_F(rnp_tests, test_key_store_search)
         }
     }
 
+#ifdef RNP_KEY_STORE_SEARCH_REGEX
     // userid search (regex)
     {
         list        seen_keys = NULL;
@@ -165,6 +166,7 @@ TEST_F(rnp_tests, test_key_store_search)
         // cleanup
         list_destroy(&seen_keys);
     }
+#endif //RNP_KEY_STORE_SEARCH_REGEX
 
     // cleanup
     rnp_key_store_free(store);
@@ -196,63 +198,63 @@ TEST_F(rnp_tests, test_key_store_search_by_name)
     */
 
     /* Find keys and subkeys by fingerprint, id and userid */
-    primsec = rnp_key_store_get_key_by_name(
+    primsec = rnp_tests_get_key_by_fpr(
       sec_store, "4F2E62B74E6A4CD333BC19004BE147BB22DF1E60", NULL);
     assert_non_null(primsec);
-    key = rnp_key_store_get_key_by_name(sec_store, "4BE147BB22DF1E60", NULL);
+    key = rnp_tests_get_key_by_id(sec_store, "4BE147BB22DF1E60", NULL);
     assert_true(key == primsec);
-    subsec = rnp_key_store_get_key_by_name(
+    subsec = rnp_tests_get_key_by_fpr(
       sec_store, "10793E367EE867C32E358F2AA49BAE05C16E8BC8", NULL);
     assert_non_null(subsec);
     assert_true(primsec != subsec);
-    key = rnp_key_store_get_key_by_name(sec_store, "A49BAE05C16E8BC8", NULL);
+    key = rnp_tests_get_key_by_id(sec_store, "A49BAE05C16E8BC8", NULL);
     assert_true(key == subsec);
 
-    primpub = rnp_key_store_get_key_by_name(
+    primpub = rnp_tests_get_key_by_fpr(
       pub_store, "4F2E62B74E6A4CD333BC19004BE147BB22DF1E60", NULL);
     assert_non_null(primpub);
     assert_true(primsec != primpub);
-    subpub = rnp_key_store_get_key_by_name(
+    subpub = rnp_tests_get_key_by_fpr(
       pub_store, "10793E367EE867C32E358F2AA49BAE05C16E8BC8", NULL);
     assert_true(primpub != subpub);
     assert_true(subpub != subsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "test1", NULL);
+    key = rnp_tests_key_search(pub_store, "test1", NULL);
     assert_true(key == primpub);
 
     /* Try other searches */
-    key = rnp_key_store_get_key_by_name(
+    key = rnp_tests_get_key_by_fpr(
       sec_store, "4f2e62b74e6a4cd333bc19004be147bb22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(
+    key = rnp_tests_get_key_by_fpr(
       sec_store, "0x4f2e62b74e6a4cd333bc19004be147bb22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "4BE147BB22DF1E60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "4BE147BB22DF1E60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "4be147bb22df1e60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "4be147bb22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "0x4be147bb22df1e60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "0x4be147bb22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "22df1e60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "0x22df1e60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "0x22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "4be1 47bb 22df 1e60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "4be1 47bb 22df 1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "4be147bb 22df1e60", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "4be147bb 22df1e60", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "    4be147bb\t22df1e60   ", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "    4be147bb\t22df1e60   ", NULL);
     assert_true(key = primsec);
-    key = rnp_key_store_get_key_by_name(pub_store, "test1", NULL);
+    key = rnp_tests_get_key_by_id(pub_store, "test1", NULL);
     assert_true(key = primsec);
     /* Try negative searches */
-    assert_null(rnp_key_store_get_key_by_name(
+    assert_null(rnp_tests_get_key_by_fpr(
       sec_store, "4f2e62b74e6a4cd333bc19004be147bb22df1e", NULL));
-    assert_null(rnp_key_store_get_key_by_name(
+    assert_null(rnp_tests_get_key_by_fpr(
       sec_store, "2e62b74e6a4cd333bc19004be147bb22df1e60", NULL));
-    assert_null(rnp_key_store_get_key_by_name(sec_store, "4be147bb22dfle60", NULL));
-    assert_null(rnp_key_store_get_key_by_name(sec_store, NULL, NULL));
-    assert_null(rnp_key_store_get_key_by_name(sec_store, "test11", NULL));
-    assert_null(rnp_key_store_get_key_by_name(sec_store, "atest1", NULL));
+    assert_null(rnp_tests_get_key_by_id(sec_store, "4be147bb22dfle60", NULL));
+    assert_null(rnp_tests_get_key_by_id(sec_store, "", NULL));
+    assert_null(rnp_tests_get_key_by_id(sec_store, "test11", NULL));
+    assert_null(rnp_tests_get_key_by_id(sec_store, "atest1", NULL));
 
     // cleanup
     rnp_key_store_free(pub_store);

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -172,7 +172,7 @@ TEST_F(rnp_tests, test_forged_key_validate)
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-material.pgp");
     key = rnp_tests_get_key_by_id(pubring, "C8A10A7D78273E10", NULL);
     assert_null(key);
-    key = rnp_tests_key_search(pubring, "dsa-eg", NULL);
+    key = rnp_tests_key_search(pubring, "dsa-eg");
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
@@ -203,7 +203,7 @@ TEST_F(rnp_tests, test_forged_key_validate)
 
     /* load eddsa key with forged key material */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-forged-material.pgp");
-    key = rnp_tests_key_search(pubring, "ecc-25519", NULL);
+    key = rnp_tests_key_search(pubring, "ecc-25519");
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
@@ -232,7 +232,7 @@ TEST_F(rnp_tests, test_forged_key_validate)
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-material.pgp");
     key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_null(key);
-    key = rnp_tests_key_search(pubring, "ecc-p256", NULL);
+    key = rnp_tests_key_search(pubring, "ecc-p256");
     assert_non_null(key);
     assert_false(key->valid);
     key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
@@ -294,7 +294,7 @@ TEST_F(rnp_tests, test_forged_key_validate)
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-material.pgp");
     key = rnp_tests_get_key_by_id(pubring, "2FB9179118898E8B", NULL);
     assert_null(key);
-    key = rnp_tests_key_search(pubring, "rsa-rsa", NULL);
+    key = rnp_tests_key_search(pubring, "rsa-rsa");
     assert_non_null(key);
     assert_false(key->valid);
     key = rnp_tests_get_key_by_id(pubring, "6E2F73008F8B8D6E", NULL);

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -62,7 +62,7 @@ TEST_F(rnp_tests, test_key_validate)
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     /* this keyring has one expired subkey */
-    assert_non_null(key = rnp_key_store_get_key_by_name(pubring, "1d7e8a5393c997a8", NULL));
+    assert_non_null(key = rnp_tests_get_key_by_id(pubring, "1d7e8a5393c997a8", NULL));
     assert_false(key->valid);
     key->valid = true;
     assert_true(all_keys_valid(pubring));
@@ -71,7 +71,7 @@ TEST_F(rnp_tests, test_key_validate)
     secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/secring.gpg");
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
-    assert_non_null(key = rnp_key_store_get_key_by_name(secring, "1d7e8a5393c997a8", NULL));
+    assert_non_null(key = rnp_tests_get_key_by_id(secring, "1d7e8a5393c997a8", NULL));
     assert_false(key->valid);
     key->valid = true;
     assert_true(all_keys_valid(secring));
@@ -153,201 +153,201 @@ TEST_F(rnp_tests, test_forged_key_validate)
 
     /* load valid dsa-eg key */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "C8A10A7D78273E10", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load dsa-eg key with forged self-signature. Subkey will not be valid as well. */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "C8A10A7D78273E10", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "02A5715C3537717E", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "02A5715C3537717E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load dsa-eg key with forged key material */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "C8A10A7D78273E10", NULL);
     assert_null(key);
-    key = rnp_key_store_get_key_by_name(pubring, "dsa-eg", NULL);
+    key = rnp_tests_key_search(pubring, "dsa-eg", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load dsa-eg keypair with forged subkey binding signature */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "02A5715C3537717E", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "02A5715C3537717E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "C8A10A7D78273E10", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load valid eddsa key */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "CC786278981B0728", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "CC786278981B0728", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load eddsa key with forged self-signature */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "CC786278981B0728", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "CC786278981B0728", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load eddsa key with forged key material */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "ecc-25519", NULL);
+    key = rnp_tests_key_search(pubring, "ecc-25519", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load valid ecdsa/ecdh p-256 keypair */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh key with forged self-signature. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh key with forged key material. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_null(key);
-    key = rnp_key_store_get_key_by_name(pubring, "ecc-p256", NULL);
+    key = rnp_tests_key_search(pubring, "ecc-p256", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair with forged subkey binding signature */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair without certification */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-no-certification.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair without subkey binding */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-no-binding.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load valid rsa/rsa keypair */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "2FB9179118898E8B", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa key with forged self-signature. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "2FB9179118898E8B", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa key with forged key material. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "2FB9179118898E8B", NULL);
     assert_null(key);
-    key = rnp_key_store_get_key_by_name(pubring, "rsa-rsa", NULL);
+    key = rnp_tests_key_search(pubring, "rsa-rsa", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa keypair with forged subkey binding signature */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "2FB9179118898E8B", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa keypair with future creation date */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-future-key.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "3D032D00EE1EC3F5", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "3D032D00EE1EC3F5", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "021085B640CE8DCE", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "021085B640CE8DCE", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load eddsa/rsa keypair with certification with future creation date */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-future-cert.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "D3B746FA852C2BE8", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "D3B746FA852C2BE8", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "EB8C21ACDC15CA14", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "EB8C21ACDC15CA14", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/rsa keypair with expired subkey */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-expired-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair with expired key */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-expired-key.pgp");
-    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
+    key = rnp_tests_get_key_by_id(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -438,8 +438,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_SIGNATURE);
 
     /* both user ids should be present */
-    assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
-    assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-2", NULL));
+    assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-1"));
+    assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-2"));
 
     rnp_key_store_free(key_store);
 }
@@ -520,7 +520,7 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
 
     /* load key + user id 1 with sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-1.pgp"));
@@ -534,7 +534,7 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
 
     /* load key + user id 2 with sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-2.pgp"));
@@ -552,8 +552,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
-    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2"));
 
     /* load key + subkey 1 without sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-subkey-1-no-sigs.pgp"));
@@ -702,8 +702,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
-    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2"));
 
     rnp_key_store_free(key_store);
 }

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -438,8 +438,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_SIGNATURE);
 
     /* both user ids should be present */
-    assert_non_null(rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
-    assert_non_null(rnp_key_store_get_key_by_name(key_store, "key-merge-uid-2", NULL));
+    assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
+    assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-2", NULL));
 
     rnp_key_store_free(key_store);
 }
@@ -520,7 +520,7 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
 
     /* load key + user id 1 with sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-1.pgp"));
@@ -534,7 +534,7 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
 
     /* load key + user id 2 with sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-2.pgp"));
@@ -552,8 +552,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
-    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-2", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2", NULL));
 
     /* load key + subkey 1 without sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-subkey-1-no-sigs.pgp"));
@@ -702,8 +702,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
-    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-2", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2", NULL));
 
     rnp_key_store_free(key_store);
 }

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -677,40 +677,37 @@ pgp_key_t*
 rnp_tests_get_key_by_id(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
 {
     pgp_key_t *key = NULL;
-    uint8_t keyid_bin[PGP_KEY_ID_SIZE];
+    std::vector<uint8_t> keyid_bin(PGP_KEY_ID_SIZE, 0);
     size_t binlen = 0;
 
-    if (!keyring || keyid.length() == 0) {
+    if (!keyring || keyid.empty()) {
         return NULL;
     }
     assert(!after || list_is_member(keyring->keys, (list_item *) after));
 
-    memset(keyid_bin, 0x0, sizeof(keyid_bin));
-    if (ishex(keyid.c_str(), keyid.size()) && hex2bin(keyid.c_str(), keyid.size(), keyid_bin, sizeof(keyid_bin), &binlen)) {
+    if (ishex(keyid.c_str(), keyid.size()) && hex2bin(keyid.c_str(), keyid.size(), keyid_bin.data(), keyid_bin.size(), &binlen)) {
         if (binlen <= PGP_KEY_ID_SIZE) {
-            key = rnp_key_store_get_key_by_id(keyring, keyid_bin, after);
+            key = rnp_key_store_get_key_by_id(keyring, keyid_bin.data(), after);
         }
     }
     return key;
 }
 
 pgp_key_t*
-rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
+rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid)
 {
     pgp_key_t *key = NULL;
-    uint8_t keyid_bin[PGP_FINGERPRINT_SIZE];
+    std::vector<uint8_t> keyid_bin(PGP_FINGERPRINT_SIZE, 0);
     size_t binlen = 0;
 
-    if (!keyring || keyid.length() == 0) {
+    if (!keyring || keyid.empty()) {
         return NULL;
     }
-    assert(!after || list_is_member(keyring->keys, (list_item *) after));
 
-    memset(keyid_bin, 0x0, sizeof(keyid_bin));
-    if (ishex(keyid.c_str(), keyid.size()) && hex2bin(keyid.c_str(), keyid.size(), keyid_bin, sizeof(keyid_bin), &binlen)) {
+    if (ishex(keyid.c_str(), keyid.size()) && hex2bin(keyid.c_str(), keyid.size(), keyid_bin.data(), keyid_bin.size(), &binlen)) {
         if (binlen <= PGP_FINGERPRINT_SIZE) {
             pgp_fingerprint_t fp = { {}, static_cast<unsigned>(binlen) };
-            memcpy(fp.fingerprint, keyid_bin, binlen);
+            memcpy(fp.fingerprint, keyid_bin.data(), binlen);
             key = rnp_key_store_get_key_by_fpr(keyring, &fp);
         } 
     }
@@ -718,14 +715,13 @@ rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyi
 }
 
 pgp_key_t*
-rnp_tests_key_search(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
+rnp_tests_key_search(const rnp_key_store_t* keyring, const std::string& keyid)
 {
-    if (!keyring || keyid.length() == 0) {
+    if (!keyring || keyid.empty()) {
         return NULL;
     }
-    assert(!after || list_is_member(keyring->keys, (list_item *) after));
 
     pgp_key_search_t srch_userid = { PGP_KEY_SEARCH_USERID };
     strncpy(srch_userid.by.userid, keyid.c_str(), sizeof(srch_userid.by.userid));
-    return rnp_key_store_search(keyring, &srch_userid, after);
+    return rnp_key_store_search(keyring, &srch_userid, NULL);
 }

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -672,3 +672,60 @@ check_json_field_bool(json_object *obj, const std::string &field, bool value)
     }
     return json_object_get_boolean(fld) == value;
 }
+
+pgp_key_t*
+rnp_tests_get_key_by_id(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
+{
+    pgp_key_t *key = NULL;
+    uint8_t keyid_bin[PGP_KEY_ID_SIZE];
+    size_t binlen = 0;
+
+    if (!keyring || keyid.length() == 0) {
+        return NULL;
+    }
+    assert(!after || list_is_member(keyring->keys, (list_item *) after));
+
+    memset(keyid_bin, 0x0, sizeof(keyid_bin));
+    if (ishex(keyid.c_str(), keyid.size()) && hex2bin(keyid.c_str(), keyid.size(), keyid_bin, sizeof(keyid_bin), &binlen)) {
+        if (binlen <= PGP_KEY_ID_SIZE) {
+            key = rnp_key_store_get_key_by_id(keyring, keyid_bin, after);
+        }
+    }
+    return key;
+}
+
+pgp_key_t*
+rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
+{
+    pgp_key_t *key = NULL;
+    uint8_t keyid_bin[PGP_FINGERPRINT_SIZE];
+    size_t binlen = 0;
+
+    if (!keyring || keyid.length() == 0) {
+        return NULL;
+    }
+    assert(!after || list_is_member(keyring->keys, (list_item *) after));
+
+    memset(keyid_bin, 0x0, sizeof(keyid_bin));
+    if (ishex(keyid.c_str(), keyid.size()) && hex2bin(keyid.c_str(), keyid.size(), keyid_bin, sizeof(keyid_bin), &binlen)) {
+        if (binlen <= PGP_FINGERPRINT_SIZE) {
+            pgp_fingerprint_t fp = { {}, static_cast<unsigned>(binlen) };
+            memcpy(fp.fingerprint, keyid_bin, binlen);
+            key = rnp_key_store_get_key_by_fpr(keyring, &fp);
+        } 
+    }
+    return key;
+}
+
+pgp_key_t*
+rnp_tests_key_search(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
+{
+    if (!keyring || keyid.length() == 0) {
+        return NULL;
+    }
+    assert(!after || list_is_member(keyring->keys, (list_item *) after));
+
+    pgp_key_search_t srch_userid = { PGP_KEY_SEARCH_USERID };
+    strncpy(srch_userid.by.userid, keyid.c_str(), sizeof(srch_userid.by.userid));
+    return rnp_key_store_search(keyring, &srch_userid, after);
+}

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -197,3 +197,7 @@ bool check_json_field_str(json_object *      obj,
                           const std::string &value);
 bool check_json_field_int(json_object *obj, const std::string &field, int value);
 bool check_json_field_bool(json_object *obj, const std::string &field, bool value);
+
+pgp_key_t* rnp_tests_get_key_by_id(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);
+pgp_key_t* rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);
+pgp_key_t* rnp_tests_key_search(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -199,5 +199,5 @@ bool check_json_field_int(json_object *obj, const std::string &field, int value)
 bool check_json_field_bool(json_object *obj, const std::string &field, bool value);
 
 pgp_key_t* rnp_tests_get_key_by_id(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);
-pgp_key_t* rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);
-pgp_key_t* rnp_tests_key_search(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);
+pgp_key_t* rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid);
+pgp_key_t* rnp_tests_key_search(const rnp_key_store_t* keyring, const std::string& keyid);

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -69,7 +69,7 @@ TEST_F(rnp_tests, test_load_user_prefs)
 
         // find the key
         pgp_key_t *key = NULL;
-        assert_non_null(key = rnp_key_store_get_key_by_name(pubring, userid, NULL));
+        assert_non_null(key = rnp_tests_key_search(pubring, userid, NULL));
         assert_non_null(key);
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);
@@ -114,7 +114,7 @@ TEST_F(rnp_tests, test_load_user_prefs)
 
         // find the key
         pgp_key_t *key = NULL;
-        assert_non_null(key = rnp_key_store_get_key_by_name(pubring, userid, NULL));
+        assert_non_null(key = rnp_tests_key_search(pubring, userid, NULL));
         assert_non_null(key);
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -69,8 +69,7 @@ TEST_F(rnp_tests, test_load_user_prefs)
 
         // find the key
         pgp_key_t *key = NULL;
-        assert_non_null(key = rnp_tests_key_search(pubring, userid, NULL));
-        assert_non_null(key);
+        assert_non_null(key = rnp_tests_key_search(pubring, userid));
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);
         assert_non_null(subsig);
@@ -114,8 +113,7 @@ TEST_F(rnp_tests, test_load_user_prefs)
 
         // find the key
         pgp_key_t *key = NULL;
-        assert_non_null(key = rnp_tests_key_search(pubring, userid, NULL));
-        assert_non_null(key);
+        assert_non_null(key = rnp_tests_key_search(pubring, userid));
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);
         assert_non_null(subsig);


### PR DESCRIPTION
Closes #948.