### PR TITLE
Cancels inclusion of ‘utils.h’ outside of the library.

### DIFF
--- a/include/rnp.h
+++ b/include/rnp.h
@@ -39,5 +39,6 @@
 #include "crypto/rng.h"
 #include <rnp/rnp_def.h>
 #include <rekey/rnp_key_store.h>
+#include "utils.h"
 
 #endif // RNP_RNP_H

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1963,4 +1963,7 @@ rnp_result_t rnp_identifier_iterator_destroy(rnp_identifier_iterator_t it);
 
 #if defined(__cplusplus)
 }
+
+#include "utils.h"
+
 #endif

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -38,7 +38,6 @@
 
 #include "crypto/common.h"
 #include "pgp-key.h"
-#include "utils.h"
 
 #define G10_CBC_IV_SIZE 16
 

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -27,7 +27,6 @@
 #ifndef RNP_KEY_STORE_G10_H
 #define RNP_KEY_STORE_G10_H
 
-#include "rnp.h"
 #include <rekey/rnp_key_store.h>
 #include <librepgp/stream-common.h>
 

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -35,7 +35,6 @@
 #include "pgp-key.h"
 #include "packet-create.h"
 #include <librepgp/stream-sig.h>
-#include "utils.h"
 
 #define BLOB_SIZE_LIMIT (5 * 1024 * 1024) // same limit with GnuPG 2.1
 

--- a/src/librekey/key_store_kbx.h
+++ b/src/librekey/key_store_kbx.h
@@ -27,7 +27,6 @@
 #ifndef RNP_KEY_STORE_KBX_H
 #define RNP_KEY_STORE_KBX_H
 
-#include "rnp.h"
 #include <rekey/rnp_key_store.h>
 
 bool rnp_key_store_kbx_from_src(rnp_key_store_t *, pgp_source_t *, const pgp_key_provider_t *);

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -68,7 +68,6 @@ __RCSID("$NetBSD: keyring.c,v 1.50 2011/06/25 00:37:44 agc Exp $");
 #include "types.h"
 #include "key_store_pgp.h"
 #include "pgp-key.h"
-#include "utils.h"
 
 void print_packet_hex(const pgp_rawpacket_t *pkt);
 

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -52,7 +52,6 @@
 #include "pgp-key.h"
 #include "fingerprint.h"
 #include "crypto/hash.h"
-#include "utils.h"
 
 // must be placed after include "utils.h"
 #ifndef RNP_USE_STD_REGEX

--- a/src/librepgp/packet-show.cpp
+++ b/src/librepgp/packet-show.cpp
@@ -66,7 +66,6 @@ __RCSID("$NetBSD: packet-show.c,v 1.21 2011/08/14 11:19:51 christos Exp $");
 #include <rnp/rnp_sdk.h>
 
 #include "packet-show.h"
-#include "utils.h"
 
 /*
  * Arrays of value->text maps

--- a/src/librepgp/packet-show.h
+++ b/src/librepgp/packet-show.h
@@ -56,6 +56,7 @@
 #define PACKET_SHOW_H_
 
 #include "types.h"
+#include "rnp.h"
 
 /** pgp_bit_map_t
  */

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -35,7 +35,6 @@
 #include "stream-packet.h"
 #include "crypto/hash.h"
 #include "types.h"
-#include "utils.h"
 
 #define ARMORED_BLOCK_SIZE (4096)
 

--- a/src/librepgp/stream-common.cpp
+++ b/src/librepgp/stream-common.cpp
@@ -39,9 +39,9 @@
 #include <limits.h>
 #endif
 #include <rnp/rnp_def.h>
+#include "rnp.h"
 #include "stream-common.h"
 #include "types.h"
-#include "utils.h"
 #include <algorithm>
 
 ssize_t

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -44,7 +44,6 @@
 #include "pgp-key.h"
 #include "list.h"
 #include "crypto.h"
-#include "utils.h"
 #include "json_utils.h"
 #include <algorithm>
 

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -40,7 +40,6 @@
 #include "fingerprint.h"
 #include "pgp-key.h"
 #include "list.h"
-#include "utils.h"
 #include "crypto.h"
 #include "crypto/signatures.h"
 #include "../librekey/key_store_pgp.h"

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -35,7 +35,6 @@
 #include "crypto.h"
 #include "stream-packet.h"
 #include "stream-key.h"
-#include "utils.h"
 #include <algorithm>
 
 uint32_t

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -46,7 +46,6 @@
 #include "fingerprint.h"
 #include "pgp-key.h"
 #include "list.h"
-#include "utils.h"
 
 #ifdef HAVE_ZLIB_H
 #include <zlib.h>

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -31,7 +31,6 @@
 #include <string.h>
 #include <rnp/rnp_def.h>
 #include "types.h"
-#include "utils.h"
 #include "stream-sig.h"
 #include "stream-packet.h"
 #include "pgp-key.h"

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -45,7 +45,6 @@
 #include "stream-armor.h"
 #include "stream-sig.h"
 #include "list.h"
-#include "utils.h"
 #include "pgp-key.h"
 #include "fingerprint.h"
 #include "types.h"

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -46,7 +46,6 @@
 #include <time.h>
 #include "config.h"
 #include "fficli.h"
-#include "utils.h"
 
 // must be placed after include "utils.h"
 #ifndef RNP_USE_STD_REGEX

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -34,7 +34,6 @@
 #include <errno.h>
 
 #include "rnpcfg.h"
-#include "utils.h"
 #include "defaults.h"
 #include <rnp/rnp_sdk.h>
 #include <rekey/rnp_key_store.h>

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include "list.h"
+#include "rnp/rnp.h"
 
 /* cfg variables known by rnp */
 #define CFG_OVERWRITE "overwrite" /* overwrite output file if it is already exist or fail */

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -37,7 +37,6 @@
 #include "../rnp/fficli.h"
 #include "rnpkeys.h"
 #include "config.h"
-#include "utils.h"
 
 // must be placed after include "utils.h"
 #ifndef RNP_USE_STD_REGEX

--- a/src/rnpkeys/tui.cpp
+++ b/src/rnpkeys/tui.cpp
@@ -2,7 +2,6 @@
 #include <errno.h>
 #include "rnp/rnpcfg.h"
 #include "rnpkeys.h"
-#include "utils.h"
 #include "defaults.h"
 
 /* -----------------------------------------------------------------------------

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -34,7 +34,6 @@
 #include "rnp_tests.h"
 #include "support.h"
 #include "fingerprint.h"
-#include "utils.h"
 
 extern rng_t global_rng;
 

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -27,7 +27,6 @@
 #include <sys/wait.h>
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 
 int rnp_main(int argc, char **argv);
 int rnpkeys_main(int argc, char **argv);

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -32,7 +32,6 @@
 #include "rnp_tests.h"
 #include "support.h"
 #include "librepgp/stream-common.h"
-#include "utils.h"
 #include <json.h>
 #include <vector>
 #include <string>

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -38,7 +38,6 @@
 #include "librepgp/stream-sig.h"
 #include "librepgp/stream-key.h"
 #include "defaults.h"
-#include "utils.h"
 #include <fstream>
 
 extern rng_t global_rng;

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -29,7 +29,6 @@
 
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 #include "crypto/hash.h"
 
 /* This test loads a pgp keyring and adds a few userids to the key.

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -29,7 +29,6 @@
 
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 #include "crypto/hash.h"
 
 static bool

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -26,7 +26,6 @@
 
 #include "../librekey/key_store_pgp.h"
 #include "pgp-key.h"
-#include "utils.h"
 
 #include "rnp_tests.h"
 #include "support.h"

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -30,7 +30,6 @@
 #include "ffi-priv-types.h"
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 #include "crypto/hash.h"
 #include <fstream>
 

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -29,7 +29,6 @@
 
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 #include "../librepgp/stream-packet.h"
 
 static bool

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -28,7 +28,6 @@
 #include <crypto/rng.h>
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 
 static char original_dir[PATH_MAX];
 

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -26,7 +26,6 @@
 
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 #include "rnp.h"
 #include "crypto/hash.h"
 #include "crypto/signatures.h"

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -28,7 +28,6 @@
 #include <rekey/rnp_key_store.h>
 #include "rnp_tests.h"
 #include "support.h"
-#include "utils.h"
 #include "pgp-key.h"
 
 static const pgp_subsig_t *

--- a/src/tests/utils-list.cpp
+++ b/src/tests/utils-list.cpp
@@ -27,7 +27,6 @@
 #include "rnp_tests.h"
 #include "support.h"
 #include "list.h"
-#include "utils.h"
 
 static void
 validate_int_list(list l, const int *expected, size_t count)

--- a/src/tests/utils-rnpcfg.cpp
+++ b/src/tests/utils-rnpcfg.cpp
@@ -27,7 +27,6 @@
 #include "rnp_tests.h"
 #include "support.h"
 #include "list.h"
-#include "utils.h"
 #include <rnp/rnpcfg.h>
 
 TEST_F(rnp_tests, test_rnpcfg)


### PR DESCRIPTION
Closes #949