### PR TITLE
added instructions for building and installation on Ubuntu 18

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -22,6 +22,35 @@ curl -L https://github.com/riboseinc/yum/raw/master/ribose.repo > /etc/yum.repos
 yum install -y rnp
 ----
 
+== On Ubuntu 18
+
+[source,console]
+----
+# Clone the repository by version tag (or omit it to get the latest sources)
+sudo apt install git
+git clone https://github.com/rnpgp/rnp.git -b v0.12.0
+
+# Install required packages
+sudo apt install g++-8 cmake libbz2-dev zlib1g-dev libjson-c-dev build-essential python-minimal
+
+# Download, build and install Botan2
+wget -qO- https://botan.randombit.net/releases/Botan-2.12.1.tar.xz | tar xvJ
+cd Botan-2.12.1
+./configure.py --prefix=/usr
+make
+sudo make install
+cd ..
+
+# Cmake recommend out-of-source builds
+mkdir rnp-build
+cd rnp-build
+
+# Cmake it
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off ../rnp/
+make
+sudo make install
+----
+
 == On Debian
 
 [source,console]


### PR DESCRIPTION
I have tested these instructions on Ubuntu 18.04.3
Should also work for Ubuntu 18.10
For Ubuntu 19 we can pull botan2 (version 2.9.0) from package.

I used the URL of the latest release of Botan from randombit repository -- 2.12.1
We could also use `git clone` but it would take more time to process.

Fixes #981 