### PR TITLE
s2k iterations tests, documentation and packet dump

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1807,10 +1807,13 @@ rnp_result_t rnp_op_encrypt_set_expiration_time(rnp_op_encrypt_t op, uint32_t ex
  *                 via password provider.
  * @param s2k_hash hash algorithm, used in key-from-password derivation. Pass NULL for default
  *        value. See rnp_op_encrypt_set_hash for possible values.
- * @param iterations number of iterations, used in key derivation function. Pass 0 for default
- *        value. Only 256 distinct values within the range [1024..0x3e00000] can be encoded.
- *        Thus, the number will be increased to the closest encodable value.
- *        In case it exceeds the maximum encodable value, it will be decreased to the maximum encodable value.
+ * @param iterations number of iterations, used in key derivation function.
+ *        According to RFC 4880, chapter 3.7.1.3, only 256 distinct values within the range
+ *        [1024..0x3e00000] can be encoded. Thus, the number will be increased to the closest
+ *        encodable value. In case it exceeds the maximum encodable value, it will be decreased
+ *        to the maximum encodable value.
+ *        If 0 is passed, an optimal number (greater or equal to 1024) will be calculated based
+ *        on performance measurement.
  * @param s2k_cipher symmetric cipher, used for key encryption. Pass NULL for default value.
  * See rnp_op_encrypt_set_cipher for possible values.
  * @return RNP_SUCCESS or error code if failed

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1807,8 +1807,10 @@ rnp_result_t rnp_op_encrypt_set_expiration_time(rnp_op_encrypt_t op, uint32_t ex
  *                 via password provider.
  * @param s2k_hash hash algorithm, used in key-from-password derivation. Pass NULL for default
  *        value. See rnp_op_encrypt_set_hash for possible values.
- * @param iterations number of iterations, used iin key derivation function. Pass 0 for default
- *        value.
+ * @param iterations number of iterations, used in key derivation function. Pass 0 for default
+ *        value. Only 256 distinct values within the range [1024..0x3e00000] can be encoded.
+ *        Thus, the number will be increased to the closest encodable value.
+ *        In case it exceeds the maximum encodable value, it will be decreased to the maximum encodable value.
  * @param s2k_cipher symmetric cipher, used for key encryption. Pass NULL for default value.
  * See rnp_op_encrypt_set_cipher for possible values.
  * @return RNP_SUCCESS or error code if failed

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -441,7 +441,7 @@ dst_print_s2k(pgp_dest_t *dst, pgp_s2k_t *s2k)
     }
     if (s2k->specifier == PGP_S2KS_ITERATED_AND_SALTED) {
         size_t real_iter = pgp_s2k_decode_iterations(s2k->iterations);
-        dst_printf(dst, "s2k iterations: %d (%zu)\n", (int) s2k->iterations, real_iter);
+        dst_printf(dst, "s2k iterations: %zu (encoded as %u)\n", real_iter, s2k->iterations);
     }
 }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(rnp_tests
   load-pgp.cpp
   partial-length.cpp
   rnp_tests.cpp
+  s2k-iterations.cpp
   streams.cpp
   support.cpp
   user-prefs.cpp

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -696,7 +696,30 @@ TEST_F(rnp_tests, s2k_iteration_tuning)
     /// TODO test that hashing iters_xx data takes roughly requested time
 }
 
-bool
+TEST_F(rnp_tests, s2k_iteration_encode_decode)
+{
+    const size_t MAX_ITER = 0x3e00000; // 0x1F << (0xF + 6);
+    // encoding tests
+    assert_int_equal(pgp_s2k_encode_iterations(0), 0);
+    assert_int_equal(pgp_s2k_encode_iterations(512), 0);
+    assert_int_equal(pgp_s2k_encode_iterations(1024), 0);
+    assert_int_equal(pgp_s2k_encode_iterations(1024), 0);
+    assert_int_equal(pgp_s2k_encode_iterations(1025), 1);
+    assert_int_equal(pgp_s2k_encode_iterations(1088), 1);
+    assert_int_equal(pgp_s2k_encode_iterations(1089), 2);
+    assert_int_equal(pgp_s2k_encode_iterations(2048), 16);
+    assert_int_equal(pgp_s2k_encode_iterations(MAX_ITER - 1), 0xFF);
+    assert_int_equal(pgp_s2k_encode_iterations(MAX_ITER), 0xFF);
+    assert_int_equal(pgp_s2k_encode_iterations(MAX_ITER + 1), 0xFF);
+    assert_int_equal(pgp_s2k_encode_iterations(SIZE_MAX), 0xFF);
+    // decoding tests
+    assert_int_equal(pgp_s2k_decode_iterations(0), 1024);
+    assert_int_equal(pgp_s2k_decode_iterations(1), 1088);
+    assert_int_equal(pgp_s2k_decode_iterations(16), 2048);
+    assert_int_equal(pgp_s2k_decode_iterations(0xFF), MAX_ITER);
+}
+
+static bool
 read_key_pkt(pgp_key_pkt_t *key, const char *path)
 {
     pgp_source_t src = {};

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5815,22 +5815,6 @@ TEST_F(rnp_tests, test_ffi_op_set_compression)
     rnp_ffi_destroy(ffi);
 }
 
-static bool
-check_json_pkt_type(json_object *pkt, int tag)
-{
-    if (!pkt || !json_object_is_type(pkt, json_type_object)) {
-      return false;
-    }
-    json_object *hdr = NULL;
-    if (!json_object_object_get_ex(pkt, "header", &hdr)) {
-      return false;
-    }
-    if (!json_object_is_type(hdr, json_type_object)) {
-      return false;
-    }
-    return check_json_field_int(hdr, "tag", tag);
-}
-
 TEST_F(rnp_tests, test_ffi_aead_params)
 {
     rnp_ffi_t        ffi = NULL;

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -89,6 +89,9 @@ void generatekey_multipleUserIds_ShouldFail(void **state);
 void generatekeyECDSA_explicitlySetUnknownDigest_ShouldFail(void **state);
 
 void s2k_iteration_tuning(void **state);
+void s2k_iteration_encode_decode(void **state);
+
+void test_s2k_iterations(void **state);
 
 void test_validate_key_material(void **state);
 

--- a/src/tests/s2k-iterations.cpp
+++ b/src/tests/s2k-iterations.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <rnp/rnp.h>
+#include "rnp_tests.h"
+#include "support.h"
+#include "utils.h"
+#include "librepgp/stream-common.h"
+#include "librepgp/stream-packet.h"
+
+static void
+test_s2k_iterations_value(rnp_ffi_t ffi, size_t input_iterations, size_t expected_iterations, bool exact_match)
+{
+    rnp_input_t      input = NULL;
+    rnp_output_t     output = NULL;
+    rnp_op_encrypt_t op = NULL;
+    const char *     message = "RNP encryption sample message";
+    assert_rnp_success(
+      rnp_input_from_memory(&input, (uint8_t *) message, strlen(message), false));
+    assert_rnp_success(rnp_output_to_memory(&output, 1024));
+    // create encrypt operation
+    assert_rnp_success(rnp_op_encrypt_create(&op, ffi, input, output));
+    // add password and specify iterations for key derivation here
+    assert_rnp_success(rnp_op_encrypt_add_password(op, "pass1", NULL, input_iterations, NULL));
+    assert_rnp_success(rnp_op_encrypt_execute(op));
+    // testing the saved packets
+    {
+        rnp_input_t input_dump = NULL;
+        char *      json = NULL;
+        uint8_t *   mem = NULL;
+        size_t      len = 0;
+        // get the output and dump it to JSON
+        assert_rnp_success(rnp_output_memory_get_buf(output, &mem, &len, false));
+        assert_rnp_success(rnp_input_from_memory(&input_dump, mem, len, false));
+        assert_rnp_success(rnp_dump_packets_to_json(input_dump, 0, &json));
+        assert_non_null(json);
+        json_object *jso = json_tokener_parse(json);
+        rnp_buffer_destroy(json);
+        assert_non_null(jso);
+        assert_true(json_object_is_type(jso, json_type_array));
+        // check the symmetric-key encrypted session key packet
+        json_object *pkt = json_object_array_get_idx(jso, 0);
+        assert_true(check_json_pkt_type(pkt, PGP_PTAG_CT_SK_SESSION_KEY));
+        json_object *s2k = json_object_object_get(pkt, "s2k");
+        json_object *fld = NULL;
+        assert_true(json_object_object_get_ex(s2k, "iterations", &fld));
+        assert_true(json_object_is_type(fld, json_type_int));
+        // there was already decoded value in JSON
+        size_t extracted_value = (size_t) json_object_get_int(fld);
+        if (exact_match) {
+            assert_int_equal(extracted_value, expected_iterations);
+        } else {
+            assert_true(extracted_value >= expected_iterations);
+        }
+        // cleanup
+        json_object_put(jso); // release the JSON object
+        assert_rnp_success(rnp_input_destroy(input_dump));
+    }
+    assert_rnp_success(rnp_op_encrypt_destroy(op));
+    assert_rnp_success(rnp_output_destroy(output));
+    assert_rnp_success(rnp_input_destroy(input));
+}
+
+TEST_F(rnp_tests, test_s2k_iterations)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    test_s2k_iterations_value(ffi, 0, 1024, false);
+    test_s2k_iterations_value(ffi, 1024, 1024, true);
+    test_s2k_iterations_value(ffi, 1088, 1088, true);
+    const size_t MAX_ITER = 0x3e00000; // 0x1F << (0xF + 6);
+    test_s2k_iterations_value(ffi, MAX_ITER - 1, MAX_ITER, true);
+    test_s2k_iterations_value(ffi, MAX_ITER, MAX_ITER, true);
+    test_s2k_iterations_value(ffi, MAX_ITER + 1, MAX_ITER, true);
+    test_s2k_iterations_value(ffi, SIZE_MAX, MAX_ITER, true);
+    assert_rnp_success(rnp_ffi_destroy(ffi));
+}

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -734,6 +734,22 @@ check_json_field_bool(json_object *obj, const std::string &field, bool value)
     return json_object_get_boolean(fld) == value;
 }
 
+bool
+check_json_pkt_type(json_object *pkt, int tag)
+{
+    if (!pkt || !json_object_is_type(pkt, json_type_object)) {
+      return false;
+    }
+    json_object *hdr = NULL;
+    if (!json_object_object_get_ex(pkt, "header", &hdr)) {
+      return false;
+    }
+    if (!json_object_is_type(hdr, json_type_object)) {
+      return false;
+    }
+    return check_json_field_int(hdr, "tag", tag);
+}
+
 pgp_key_t*
 rnp_tests_get_key_by_id(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after)
 {

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -219,6 +219,7 @@ bool check_json_field_str(json_object *      obj,
                           const std::string &value);
 bool check_json_field_int(json_object *obj, const std::string &field, int value);
 bool check_json_field_bool(json_object *obj, const std::string &field, bool value);
+bool check_json_pkt_type(json_object *pkt, int tag);
 
 pgp_key_t* rnp_tests_get_key_by_id(const rnp_key_store_t* keyring, const std::string& keyid, pgp_key_t* after);
 pgp_key_t* rnp_tests_get_key_by_fpr(const rnp_key_store_t* keyring, const std::string& keyid);


### PR DESCRIPTION
- Added tests to ensure that correct iteration count is actually used when user calls rnp_op_encrypt_add_password(). Check is done via packet dumping to JSON and checking of output.
- Added tests for s2k iterations encode/decode functions
- Corrected packet dump output
- Corrected `rnp_op_encrypt_ad_password()` function's documentation.
Closes #982 
Closes #999 