### PR TITLE
Add pgp_userid_t type to store uid information in pgp_key_t

### DIFF
--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -208,9 +208,6 @@ pgp_key_new(void)
 static void
 pgp_rawpacket_free(pgp_rawpacket_t *packet)
 {
-    if (packet->raw == NULL) {
-        return;
-    }
     free(packet->raw);
     packet->raw = NULL;
 }
@@ -412,7 +409,7 @@ error:
     return ret;
 }
 
-rnp_result_t
+static rnp_result_t
 pgp_subsig_copy(pgp_subsig_t *dst, const pgp_subsig_t *src)
 {
     memcpy(dst, src, sizeof(*dst));
@@ -839,17 +836,6 @@ pgp_key_get_userid(const pgp_key_t *key, size_t idx)
     return uid ? *((char **) uid) : NULL;
 }
 
-const char *
-pgp_key_get_primary_userid(const pgp_key_t *key)
-{
-    if (key->uid0_set) {
-        return pgp_key_get_userid(key, key->uid0);
-    }
-    if (list_length(key->uids)) {
-        return pgp_key_get_userid(key, 0);
-    }
-    return NULL;
-}
 
 pgp_revoke_t *
 pgp_key_get_userid_revoke(const pgp_key_t *key, size_t uid)

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1318,10 +1318,10 @@ pgp_key_is_protected(const pgp_key_t *key)
 }
 
 bool
-pgp_key_add_userid(pgp_key_t *              key,
-                   const pgp_key_pkt_t *    seckey,
-                   pgp_hash_alg_t           hash_alg,
-                   rnp_selfsig_cert_info_t *cert)
+pgp_key_add_userid_certified(pgp_key_t *              key,
+                             const pgp_key_pkt_t *    seckey,
+                             pgp_hash_alg_t           hash_alg,
+                             rnp_selfsig_cert_info_t *cert)
 {
     bool                      ret = false;
     pgp_transferable_userid_t uid = {};

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -251,8 +251,6 @@ size_t pgp_key_get_userid_count(const pgp_key_t *);
 
 const char *pgp_key_get_userid(const pgp_key_t *, size_t);
 
-const char *pgp_key_get_primary_userid(const pgp_key_t *);
-
 pgp_revoke_t *pgp_key_get_userid_revoke(const pgp_key_t *, size_t userid);
 
 bool pgp_key_has_userid(const pgp_key_t *, const char *);
@@ -270,8 +268,6 @@ pgp_subsig_t *pgp_key_add_subsig(pgp_key_t *);
 size_t pgp_key_get_subsig_count(const pgp_key_t *);
 
 pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
-
-rnp_result_t pgp_subsig_copy(pgp_subsig_t *dst, const pgp_subsig_t *src);
 
 void pgp_subsig_free(pgp_subsig_t *subsig);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -383,7 +383,7 @@ bool pgp_key_unprotect(pgp_key_t *key, const pgp_password_provider_t *password_p
  **/
 bool pgp_key_is_protected(const pgp_key_t *key);
 
-/** add a new userid to a key
+/** add a new certified userid to a key
  *
  *  @param key
  *  @param seckey the decrypted seckey for signing
@@ -391,10 +391,10 @@ bool pgp_key_is_protected(const pgp_key_t *key);
  *  @param cert the self-signature information
  *  @return true if the userid was added, false otherwise
  */
-bool pgp_key_add_userid(pgp_key_t *              key,
-                        const pgp_key_pkt_t *    seckey,
-                        pgp_hash_alg_t           hash_alg,
-                        rnp_selfsig_cert_info_t *cert);
+bool pgp_key_add_userid_certified(pgp_key_t *              key,
+                                  const pgp_key_pkt_t *    seckey,
+                                  pgp_hash_alg_t           hash_alg,
+                                  rnp_selfsig_cert_info_t *cert);
 
 bool pgp_key_write_packets(const pgp_key_t *key, pgp_dest_t *dst);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -249,13 +249,13 @@ bool pgp_key_link_subkey_grip(pgp_key_t *key, pgp_key_t *subkey);
 
 size_t pgp_key_get_userid_count(const pgp_key_t *);
 
-const char *pgp_key_get_userid(const pgp_key_t *, size_t);
+pgp_userid_t *pgp_key_get_userid(const pgp_key_t *, size_t);
 
 pgp_revoke_t *pgp_key_get_userid_revoke(const pgp_key_t *, size_t userid);
 
 bool pgp_key_has_userid(const pgp_key_t *, const char *);
 
-unsigned char *pgp_key_add_userid(pgp_key_t *, const unsigned char *);
+pgp_userid_t *pgp_key_add_userid(pgp_key_t *);
 
 pgp_revoke_t *pgp_key_add_revoke(pgp_key_t *);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -4547,11 +4547,11 @@ rnp_key_add_uid(rnp_key_handle_t handle,
         }
         seckey = decrypted_seckey;
     }
-    if (public_key && !pgp_key_add_userid(public_key, seckey, hash_alg, &info)) {
+    if (public_key && !pgp_key_add_userid_certified(public_key, seckey, hash_alg, &info)) {
         goto done;
     }
     if ((secret_key && secret_key->format != G10_KEY_STORE) &&
-        !pgp_key_add_userid(secret_key, seckey, hash_alg, &info)) {
+        !pgp_key_add_userid_certified(secret_key, seckey, hash_alg, &info)) {
         goto done;
     }
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -4484,7 +4484,7 @@ key_get_uid_at(pgp_key_t *key, size_t idx, char **uid)
     if (idx >= pgp_key_get_userid_count(key)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    const char *keyuid = pgp_key_get_userid(key, idx);
+    const char *keyuid = pgp_key_get_userid(key, idx)->str;
     size_t      len = strlen(keyuid);
     *uid = (char *) calloc(1, len + 1);
     if (!*uid) {
@@ -6049,7 +6049,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
         }
         json_object_object_add(jso, "userids", jsouids_arr);
         for (unsigned i = 0; i < pgp_key_get_userid_count(key); i++) {
-            json_object *jsouid = json_object_new_string(pgp_key_get_userid(key, i));
+            json_object *jsouid = json_object_new_string(pgp_key_get_userid(key, i)->str);
             if (!jsouid || json_object_array_add(jsouids_arr, jsouid)) {
                 json_object_put(jsouid);
                 return RNP_ERROR_OUT_OF_MEMORY;
@@ -6352,11 +6352,14 @@ key_iter_get_item(const rnp_identifier_iterator_t it, char *buf, size_t buf_len)
         }
         break;
     case PGP_KEY_SEARCH_USERID: {
-        const char *userid = pgp_key_get_userid(key, it->uididx);
-        if (strlen(userid) >= buf_len) {
+        pgp_userid_t *uid = pgp_key_get_userid(key, it->uididx);
+        if (!uid) {
             return false;
         }
-        strcpy(buf, userid);
+        if (strlen(uid->str) >= buf_len) {
+            return false;
+        }
+        strcpy(buf, uid->str);
     } break;
     default:
         assert(false);

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -380,6 +380,11 @@ typedef struct pgp_subsig_t {
     pgp_user_prefs_t prefs;       /* user preferences for certification sig */
 } pgp_subsig_t;
 
+typedef struct pgp_userid_t {
+    pgp_userid_pkt_t pkt; /* User ID or User Attribute packet as it was loaded */
+    char *           str; /* Human-readable representation of the userid */
+} pgp_userid_t;
+
 struct rnp_keygen_ecc_params_t {
     pgp_curve_t curve;
 };

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -109,12 +109,12 @@ TEST_F(rnp_tests, test_key_add_userid)
 
     // check the userids array
     // added1
-    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc), "added1"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc)->str, "added1"));
     assert_int_equal(uidc, pgp_key_get_subsig(key, subsigc)->uid);
     assert_int_equal(0xAB, pgp_key_get_subsig(key, subsigc)->key_flags);
     assert_int_equal(123456789, pgp_key_get_expiration(key));
     // added2
-    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1), "added2"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1)->str, "added2"));
     assert_int_equal(uidc + 1, pgp_key_get_subsig(key, subsigc + 1)->uid);
     assert_int_equal(0xCD, pgp_key_get_subsig(key, subsigc + 1)->key_flags);
 
@@ -144,12 +144,12 @@ TEST_F(rnp_tests, test_key_add_userid)
 
     // check the userids array
     // added1
-    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc), "added1"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc)->str, "added1"));
     assert_int_equal(uidc, pgp_key_get_subsig(key, subsigc)->uid);
     assert_int_equal(0xAB, pgp_key_get_subsig(key, subsigc)->key_flags);
     assert_int_equal(123456789, pgp_key_get_expiration(key));
     // added2
-    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1), "added2"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1)->str, "added2"));
     assert_int_equal(uidc + 1, pgp_key_get_subsig(key, subsigc + 1)->uid);
     assert_int_equal(0xCD, pgp_key_get_subsig(key, subsigc + 1)->key_flags);
 

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -74,7 +74,8 @@ TEST_F(rnp_tests, test_key_add_userid)
     selfsig.key_flags = 0xAB;
     selfsig.key_expiration = 123456789;
     selfsig.primary = 1;
-    assert_true(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig));
+    assert_true(
+      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig));
 
     // make sure this userid has been marked as primary
     assert_int_equal(pgp_key_get_userid_count(key) - 1, key->uid0);
@@ -83,21 +84,24 @@ TEST_F(rnp_tests, test_key_add_userid)
     rnp_selfsig_cert_info_t dup_selfsig;
     memset(&dup_selfsig, 0, sizeof(dup_selfsig));
     strcpy((char *) dup_selfsig.userid, "added1");
-    assert_false(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &dup_selfsig));
+    assert_false(
+      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &dup_selfsig));
 
     // try to add another primary userid (should fail)
     rnp_selfsig_cert_info_t selfsig2;
     memset(&selfsig2, 0, sizeof(selfsig2));
     strcpy((char *) selfsig2.userid, "added2");
     selfsig2.primary = 1;
-    assert_false(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
+    assert_false(
+      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
 
     strcpy((char *) selfsig2.userid, "added2");
     selfsig2.key_flags = 0xCD;
     selfsig2.primary = 0;
 
     // actually add another userid
-    assert_true(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
+    assert_true(
+      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
 
     // confirm that the counts have increased as expected
     assert_int_equal(pgp_key_get_userid_count(key), uidc + 2);

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -64,8 +64,10 @@ TEST_F(rnp_tests, test_key_store_search)
             key.grip[0] = (uint8_t) n;
             // set the userids
             for (size_t uidn = 0; testdata[i].userids[uidn]; uidn++) {
-                const char *userid = testdata[i].userids[uidn];
-                assert_true(pgp_key_add_userid(&key, (const uint8_t *) userid));
+                pgp_userid_t *userid = pgp_key_add_userid(&key);
+                assert_non_null(userid);
+                userid->str = strdup(testdata[i].userids[uidn]);
+                assert_non_null(userid->str);
             }
             // add to the store
             assert_true(rnp_key_store_add_key(store, &key));
@@ -126,7 +128,7 @@ TEST_F(rnp_tests, test_key_store_search)
                 // check that the userid actually matches
                 bool found = false;
                 for (unsigned j = 0; j < pgp_key_get_userid_count(key); j++) {
-                    if (!strcmp(pgp_key_get_userid(key, j), userid)) {
+                    if (!strcmp(pgp_key_get_userid(key, j)->str, userid)) {
                         found = true;
                     }
                 }

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -36,7 +36,7 @@ find_subsig(const pgp_key_t *key, const char *userid)
     // find the userid index
     int uididx = -1;
     for (unsigned i = 0; i < pgp_key_get_userid_count(key); i++) {
-        if (memcmp(pgp_key_get_userid(key, i), userid, strlen(userid)) == 0) {
+        if (!strcmp(pgp_key_get_userid(key, i)->str, userid)) {
             uididx = i;
             break;
         }


### PR DESCRIPTION
This PR refactors pgp_key_t to use struct (and sometimes later on C++ class) instead of raw char* as it was before.
We'll benefit from it via the other PR which corrects key validation (see the issue #1001).