### PR TITLE
Expose RNP_KEYSTORE_* constants via FFI header.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -107,12 +107,12 @@ typedef struct {
     uint32_t blob_created_at;
 } kbx_pgp_blob_t;
 
-typedef enum key_store_format_t {
-    UNKNOW_KEY_STORE = 0,
-    GPG_KEY_STORE,
-    KBX_KEY_STORE,
-    G10_KEY_STORE,
-} key_store_format_t;
+typedef enum pgp_key_store_format_t {
+    PGP_KEY_STORE_UNKNOWN = 0,
+    PGP_KEY_STORE_GPG,
+    PGP_KEY_STORE_KBX,
+    PGP_KEY_STORE_G10,
+} pgp_key_store_format_t;
 
 /* Key import status. Order of elements is important. */
 typedef enum pgp_key_import_status_t {
@@ -130,9 +130,9 @@ typedef enum pgp_key_import_status_t {
 #define RNP_KEYSTORE_GPG21 "GPG21" /* KBX + G10 keystore format */
 
 typedef struct rnp_key_store_t {
-    const char *            path;
-    const char *            format_label;
-    enum key_store_format_t format;
+    const char *           path;
+    const char *           format_label;
+    pgp_key_store_format_t format;
     bool disable_validation; /* do not automatically validate keys, added to this key store */
 
     list keys;  // list of pgp_key_t

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -131,7 +131,6 @@ typedef enum pgp_key_import_status_t {
 
 typedef struct rnp_key_store_t {
     const char *           path;
-    const char *           format_label;
     pgp_key_store_format_t format;
     bool disable_validation; /* do not automatically validate keys, added to this key store */
 
@@ -139,7 +138,7 @@ typedef struct rnp_key_store_t {
     list blobs; // list of kbx_blob_t
 } rnp_key_store_t;
 
-rnp_key_store_t *rnp_key_store_new(const char *format, const char *path);
+rnp_key_store_t *rnp_key_store_new(pgp_key_store_format_t format, const char *path);
 
 bool rnp_key_store_load_from_path(rnp_key_store_t *, const pgp_key_provider_t *key_provider);
 bool rnp_key_store_load_from_src(rnp_key_store_t *,

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -122,13 +122,6 @@ typedef enum pgp_key_import_status_t {
     PGP_KEY_IMPORT_STATUS_NEW,
 } pgp_key_import_status_t;
 
-#define RNP_KEYSTORE_GPG "GPG" /* GPG keystore format */
-#define RNP_KEYSTORE_KBX "KBX" /* KBX keystore format */
-#define RNP_KEYSTORE_G10 "G10" /* G10 keystore format */
-
-// combinated keystores
-#define RNP_KEYSTORE_GPG21 "GPG21" /* KBX + G10 keystore format */
-
 typedef struct rnp_key_store_t {
     const char *           path;
     pgp_key_store_format_t format;

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2021,4 +2021,10 @@ rnp_result_t rnp_identifier_iterator_destroy(rnp_identifier_iterator_t it);
 /* Default symmetric algorithm */
 #define DEFAULT_SYMM_ALG RNP_ALGNAME_AES_256
 
+/* Keystore format: GPG, KBX (pub), G10 (sec), GPG21 ( KBX for pub, G10 for sec) */
+#define RNP_KEYSTORE_GPG ("GPG")
+#define RNP_KEYSTORE_KBX ("KBX")
+#define RNP_KEYSTORE_G10 ("G10")
+#define RNP_KEYSTORE_GPG21 ("GPG21")
+
 #endif

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -77,7 +77,7 @@ bool pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
                               bool                       merge_defaults,
                               pgp_key_t *                primary_sec,
                               pgp_key_t *                primary_pub,
-                              key_store_format_t         secformat);
+                              pgp_key_store_format_t     secformat);
 
 /** generate a new subkey
  *
@@ -101,7 +101,7 @@ bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
                          pgp_key_t *                    subkey_sec,
                          pgp_key_t *                    subkey_pub,
                          const pgp_password_provider_t *password_provider,
-                         key_store_format_t             secformat);
+                         pgp_key_store_format_t         secformat);
 
 /** generate a new primary key and subkey
  *
@@ -124,7 +124,7 @@ bool pgp_generate_keypair(rng_t *                    rng,
                           pgp_key_t *                primary_pub,
                           pgp_key_t *                subkey_sec,
                           pgp_key_t *                subkey_pub,
-                          key_store_format_t         secformat);
+                          pgp_key_store_format_t     secformat);
 
 /**
  * @brief Check two key material for equality. Only public part is checked, so this can be

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -337,7 +337,7 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
                          bool                       merge_defaults,
                          pgp_key_t *                primary_sec,
                          pgp_key_t *                primary_pub,
-                         key_store_format_t         secformat)
+                         pgp_key_store_format_t     secformat)
 {
     bool                       ok = false;
     pgp_transferable_key_t     tkeysec = {};
@@ -390,13 +390,13 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
     }
 
     switch (secformat) {
-    case GPG_KEY_STORE:
-    case KBX_KEY_STORE:
+    case PGP_KEY_STORE_GPG:
+    case PGP_KEY_STORE_KBX:
         if (!rnp_key_from_transferable_key(primary_sec, &tkeysec)) {
             goto end;
         }
         break;
-    case G10_KEY_STORE:
+    case PGP_KEY_STORE_G10:
         if (!load_generated_g10_key(primary_sec, &tkeysec.key, NULL, primary_pub)) {
             RNP_LOG("failed to load generated key");
             goto end;
@@ -460,7 +460,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
                     pgp_key_t *                    subkey_sec,
                     pgp_key_t *                    subkey_pub,
                     const pgp_password_provider_t *password_provider,
-                    key_store_format_t             secformat)
+                    pgp_key_store_format_t         secformat)
 {
     pgp_transferable_subkey_t tskeysec = {};
     pgp_transferable_subkey_t tskeypub = {};
@@ -528,13 +528,13 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
     }
 
     switch (secformat) {
-    case GPG_KEY_STORE:
-    case KBX_KEY_STORE:
+    case PGP_KEY_STORE_GPG:
+    case PGP_KEY_STORE_KBX:
         if (!rnp_key_from_transferable_subkey(subkey_sec, &tskeysec, primary_sec)) {
             goto end;
         }
         break;
-    case G10_KEY_STORE:
+    case PGP_KEY_STORE_G10:
         if (!load_generated_g10_key(subkey_sec, &tskeysec.subkey, primary_sec, subkey_pub)) {
             RNP_LOG("failed to load generated key");
             goto end;
@@ -613,7 +613,7 @@ pgp_generate_keypair(rng_t *                    rng,
                      pgp_key_t *                primary_pub,
                      pgp_key_t *                subkey_sec,
                      pgp_key_t *                subkey_pub,
-                     key_store_format_t         secformat)
+                     pgp_key_store_format_t     secformat)
 {
     bool ok = false;
 

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -335,7 +335,7 @@ pgp_key_copy_g10(pgp_key_t *dst, const pgp_key_t *src, bool pubonly)
         goto done;
     }
 
-    dst->format = G10_KEY_STORE;
+    dst->format = PGP_KEY_STORE_G10;
     ret = RNP_SUCCESS;
 done:
     if (ret) {
@@ -351,7 +351,7 @@ pgp_key_copy(pgp_key_t *dst, const pgp_key_t *src, bool pubonly)
     rnp_result_t tmpret;
     memset(dst, 0, sizeof(*dst));
 
-    if (src->format == G10_KEY_STORE) {
+    if (src->format == PGP_KEY_STORE_G10) {
         return pgp_key_copy_g10(dst, src, pubonly);
     }
 
@@ -758,11 +758,11 @@ pgp_decrypt_seckey(const pgp_key_t *              key,
         goto done;
     }
     switch (key->format) {
-    case GPG_KEY_STORE:
-    case KBX_KEY_STORE:
+    case PGP_KEY_STORE_GPG:
+    case PGP_KEY_STORE_KBX:
         decryptor = pgp_decrypt_seckey_pgp;
         break;
-    case G10_KEY_STORE:
+    case PGP_KEY_STORE_G10:
         decryptor = g10_decrypt_seckey;
         break;
     default:
@@ -1150,11 +1150,11 @@ pgp_key_lock(pgp_key_t *key)
 }
 
 static bool
-write_key_to_rawpacket(pgp_key_pkt_t *    seckey,
-                       pgp_rawpacket_t *  packet,
-                       pgp_content_enum   type,
-                       key_store_format_t format,
-                       const char *       password)
+write_key_to_rawpacket(pgp_key_pkt_t *        seckey,
+                       pgp_rawpacket_t *      packet,
+                       pgp_content_enum       type,
+                       pgp_key_store_format_t format,
+                       const char *           password)
 {
     pgp_dest_t memdst = {};
     bool       ret = false;
@@ -1165,14 +1165,14 @@ write_key_to_rawpacket(pgp_key_pkt_t *    seckey,
 
     // encrypt+write the key in the appropriate format
     switch (format) {
-    case GPG_KEY_STORE:
-    case KBX_KEY_STORE:
+    case PGP_KEY_STORE_GPG:
+    case PGP_KEY_STORE_KBX:
         if (!pgp_write_struct_seckey(&memdst, type, seckey, password)) {
             RNP_LOG("failed to write seckey");
             goto done;
         }
         break;
-    case G10_KEY_STORE:
+    case PGP_KEY_STORE_G10:
         if (!g10_write_seckey(&memdst, seckey, password)) {
             RNP_LOG("failed to write g10 seckey");
             goto done;
@@ -1196,7 +1196,7 @@ done:
 
 bool
 rnp_key_add_protection(pgp_key_t *                    key,
-                       key_store_format_t             format,
+                       pgp_key_store_format_t         format,
                        rnp_key_protection_params_t *  protection,
                        const pgp_password_provider_t *password_provider)
 {
@@ -1224,7 +1224,7 @@ rnp_key_add_protection(pgp_key_t *                    key,
 bool
 pgp_key_protect(pgp_key_t *                  key,
                 pgp_key_pkt_t *              decrypted_seckey,
-                key_store_format_t           format,
+                pgp_key_store_format_t       format,
                 rnp_key_protection_params_t *protection,
                 const char *                 new_password)
 {
@@ -1381,7 +1381,7 @@ pgp_key_add_userid_certified(pgp_key_t *              key,
         goto done;
     }
     // this isn't really valid for this format
-    if (key->format == G10_KEY_STORE) {
+    if (key->format == PGP_KEY_STORE_G10) {
         RNP_LOG("Unsupported key store type");
         goto done;
     }

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -71,15 +71,15 @@ struct pgp_key_t {
     pgp_key_pkt_t pkt;          /* pubkey/seckey data packet */
     uint8_t       key_flags;    /* key flags */
     uint8_t       keyid[PGP_KEY_ID_SIZE];
-    pgp_fingerprint_t  fingerprint;
-    uint8_t            grip[PGP_KEY_GRIP_SIZE];
-    uint32_t           uid0;         /* primary uid index in uids array */
-    unsigned           uid0_set : 1; /* flag for the above */
-    uint8_t            revoked;      /* key has been revoked */
-    pgp_revoke_t       revocation;   /* revocation reason */
-    key_store_format_t format;       /* the format of the key in packets[0] */
-    bool               valid;        /* this key is valid and usable */
-    bool               validated;    /* this key was validated */
+    pgp_fingerprint_t      fingerprint;
+    uint8_t                grip[PGP_KEY_GRIP_SIZE];
+    uint32_t               uid0;         /* primary uid index in uids array */
+    unsigned               uid0_set : 1; /* flag for the above */
+    uint8_t                revoked;      /* key has been revoked */
+    pgp_revoke_t           revocation;   /* revocation reason */
+    pgp_key_store_format_t format;       /* the format of the key in packets[0] */
+    bool                   valid;        /* this key is valid and usable */
+    bool                   validated;    /* this key was validated */
 };
 
 struct pgp_key_t *pgp_key_new(void);
@@ -361,7 +361,7 @@ bool pgp_key_lock(pgp_key_t *key);
  *  @return true if key was successfully protected, false otherwise
  **/
 bool rnp_key_add_protection(pgp_key_t *                    key,
-                            key_store_format_t             format,
+                            pgp_key_store_format_t         format,
                             rnp_key_protection_params_t *  protection,
                             const pgp_password_provider_t *password_provider);
 
@@ -376,7 +376,7 @@ bool rnp_key_add_protection(pgp_key_t *                    key,
  **/
 bool pgp_key_protect(pgp_key_t *                  key,
                      pgp_key_pkt_t *              decrypted_seckey,
-                     key_store_format_t           format,
+                     pgp_key_store_format_t       format,
                      rnp_key_protection_params_t *protection,
                      const char *                 new_password);
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1159,7 +1159,7 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
         RNP_LOG("failed to add packet");
         goto done;
     }
-    key.format = G10_KEY_STORE;
+    key.format = PGP_KEY_STORE_G10;
     if (!rnp_key_store_add_key(key_store, &key)) {
         goto done;
     }
@@ -1569,7 +1569,7 @@ rnp_key_store_g10_key_to_dst(pgp_key_t *key, pgp_dest_t *dest)
     if (!pgp_key_get_rawpacket_count(key)) {
         return false;
     }
-    if (key->format != G10_KEY_STORE) {
+    if (key->format != PGP_KEY_STORE_G10) {
         RNP_LOG("incorrect format: %d", key->format);
         return false;
     }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -111,7 +111,7 @@ create_key_from_pkt(pgp_key_t *key, pgp_key_pkt_t *pkt)
         return false;
     }
 
-    key->format = GPG_KEY_STORE;
+    key->format = PGP_KEY_STORE_GPG;
     key->key_flags = pgp_pk_alg_capabilities(pgp_key_get_alg(key));
     return true;
 }
@@ -456,7 +456,7 @@ do_write(rnp_key_store_t *key_store, pgp_dest_t *dst, bool secret)
             continue;
         }
 
-        if (key->format != GPG_KEY_STORE) {
+        if (key->format != PGP_KEY_STORE_GPG) {
             RNP_LOG("incorrect format (conversions not supported): %d", key->format);
             return false;
         }

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -59,42 +59,22 @@
 #include <regex>
 #endif
 
-static bool
-parse_ks_format(pgp_key_store_format_t *key_store_format, const char *format)
-{
-    if (strcmp(format, RNP_KEYSTORE_GPG) == 0) {
-        *key_store_format = PGP_KEY_STORE_GPG;
-    } else if (strcmp(format, RNP_KEYSTORE_KBX) == 0) {
-        *key_store_format = PGP_KEY_STORE_KBX;
-    } else if (strcmp(format, RNP_KEYSTORE_G10) == 0) {
-        *key_store_format = PGP_KEY_STORE_G10;
-    } else {
-        RNP_LOG("unsupported keystore format: \"%s\"", format);
-        return false;
-    }
-    return true;
-}
-
 rnp_key_store_t *
-rnp_key_store_new(const char *format, const char *path)
+rnp_key_store_new(pgp_key_store_format_t format, const char *path)
 {
-    rnp_key_store_t *      key_store = NULL;
-    pgp_key_store_format_t key_store_format = PGP_KEY_STORE_UNKNOWN;
-
-    if (!parse_ks_format(&key_store_format, format)) {
+    if (format == PGP_KEY_STORE_UNKNOWN) {
+        RNP_LOG("Invalid key store format");
         return NULL;
     }
 
-    key_store = (rnp_key_store_t *) calloc(1, sizeof(*key_store));
-    if (key_store == NULL) {
+    rnp_key_store_t *key_store = (rnp_key_store_t *) calloc(1, sizeof(*key_store));
+    if (!key_store) {
         RNP_LOG("Can't allocate memory");
         return NULL;
     }
 
-    key_store->format = key_store_format;
-    key_store->format_label = strdup(format);
+    key_store->format = format;
     key_store->path = strdup(path);
-
     return key_store;
 }
 
@@ -288,7 +268,6 @@ rnp_key_store_free(rnp_key_store_t *keyring)
 
     rnp_key_store_clear(keyring);
     free((void *) keyring->path);
-    free((void *) keyring->format_label);
     free(keyring);
 }
 

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -54,13 +54,6 @@
 #include <regex>
 #endif
 
-#define RNP_KEYSTORE_GPG ("GPG") /* GPG keystore format */
-#define RNP_KEYSTORE_KBX ("KBX") /* KBX keystore format */
-#define RNP_KEYSTORE_G10 ("G10") /* G10 keystore format */
-
-// combinated keystores
-#define RNP_KEYSTORE_GPG21 ("GPG21") /* KBX + G10 keystore format */
-
 #ifdef HAVE_SYS_RESOURCE_H
 /* When system resource consumption limit controls are available this
  * can be used to attempt to disable core dumps which may leak

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -941,7 +941,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         strcpy((char *) desc.cert.userid, "test");
 
         // generate
-        assert_true(pgp_generate_primary_key(&desc, true, &sec, &pub, GPG_KEY_STORE));
+        assert_true(pgp_generate_primary_key(&desc, true, &sec, &pub, PGP_KEY_STORE_GPG));
 
         // add to our rings
         assert_true(rnp_key_store_add_key(pubring, &pub));
@@ -1061,7 +1061,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
         // generate
         assert_true(pgp_generate_subkey(
-          &desc, true, primary_sec, primary_pub, &sec, &pub, NULL, GPG_KEY_STORE));
+          &desc, true, primary_sec, primary_pub, &sec, &pub, NULL, PGP_KEY_STORE_GPG));
 
         // check packet and subsig counts
         assert_int_equal(2, pgp_key_get_rawpacket_count(&pub));

--- a/src/tests/key-grip.cpp
+++ b/src/tests/key-grip.cpp
@@ -39,11 +39,13 @@ TEST_F(rnp_tests, key_grip)
     rnp_key_store_t *pub_store = NULL;
     rnp_key_store_t *sec_store = NULL;
 
-    pub_store = rnp_key_store_new("KBX", "data/test_stream_key_load/g10/pubring.kbx");
+    pub_store =
+      rnp_key_store_new(PGP_KEY_STORE_KBX, "data/test_stream_key_load/g10/pubring.kbx");
     assert_non_null(pub_store);
     assert_true(rnp_key_store_load_from_path(pub_store, NULL));
 
-    sec_store = rnp_key_store_new("G10", "data/test_stream_key_load/g10/private-keys-v1.d");
+    sec_store =
+      rnp_key_store_new(PGP_KEY_STORE_G10, "data/test_stream_key_load/g10/private-keys-v1.d");
     assert_non_null(sec_store);
     pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store,
                                        .userdata = pub_store};

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -36,7 +36,7 @@
 TEST_F(rnp_tests, test_key_store_search)
 {
     // create our store
-    rnp_key_store_t *store = rnp_key_store_new("GPG", "");
+    rnp_key_store_t *store = rnp_key_store_new(PGP_KEY_STORE_GPG, "");
     assert_non_null(store);
     store->disable_validation = true;
 
@@ -182,11 +182,13 @@ TEST_F(rnp_tests, test_key_store_search_by_name)
     pgp_key_t *      subpub;
 
     // load pubring
-    rnp_key_store_t *pub_store = rnp_key_store_new("KBX", "data/keyrings/3/pubring.kbx");
+    rnp_key_store_t *pub_store =
+      rnp_key_store_new(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx");
     assert_non_null(pub_store);
     assert_true(rnp_key_store_load_from_path(pub_store, NULL));
     // load secring
-    rnp_key_store_t *sec_store = rnp_key_store_new("G10", "data/keyrings/3/private-keys-v1.d");
+    rnp_key_store_t *sec_store =
+      rnp_key_store_new(PGP_KEY_STORE_G10, "data/keyrings/3/private-keys-v1.d");
     assert_non_null(sec_store);
     pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store,
                                        .userdata = pub_store};

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -57,7 +57,7 @@ TEST_F(rnp_tests, test_key_validate)
     rnp_key_store_t *secring;
     pgp_key_t *      key = NULL;
 
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     /* this keyring has one expired subkey */
@@ -68,7 +68,7 @@ TEST_F(rnp_tests, test_key_validate)
     rnp_key_store_free(pubring);
 
     /* secret key doesn't have expired binding signature so considered as valid */
-    secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/secring.gpg");
+    secring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/1/secring.gpg");
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_non_null(key = rnp_tests_get_key_by_id(secring, "1d7e8a5393c997a8", NULL));
@@ -76,24 +76,24 @@ TEST_F(rnp_tests, test_key_validate)
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(secring);
 
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/2/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/2/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_true(all_keys_valid(pubring));
     rnp_key_store_free(pubring);
 
-    secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/2/secring.gpg");
+    secring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/2/secring.gpg");
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(secring);
 
-    pubring = rnp_key_store_new(RNP_KEYSTORE_KBX, "data/keyrings/3/pubring.kbx");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_true(all_keys_valid(pubring));
 
-    secring = rnp_key_store_new(RNP_KEYSTORE_G10, "data/keyrings/3/private-keys-v1.d");
+    secring = rnp_key_store_new(PGP_KEY_STORE_G10, "data/keyrings/3/private-keys-v1.d");
     assert_non_null(secring);
     pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store,
                                        .userdata = pubring};
@@ -102,25 +102,25 @@ TEST_F(rnp_tests, test_key_validate)
     rnp_key_store_free(pubring);
     rnp_key_store_free(secring);
 
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/4/pubring.pgp");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/4/pubring.pgp");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_true(all_keys_valid(pubring));
     rnp_key_store_free(pubring);
 
-    secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/4/secring.pgp");
+    secring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/4/secring.pgp");
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(secring);
 
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/5/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/5/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_true(all_keys_valid(pubring));
     rnp_key_store_free(pubring);
 
-    secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/5/secring.gpg");
+    secring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/5/secring.gpg");
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_true(all_keys_valid(secring));
@@ -147,7 +147,7 @@ TEST_F(rnp_tests, test_forged_key_validate)
     rnp_key_store_t *pubring;
     pgp_key_t *      key = NULL;
 
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "");
     assert_non_null(pubring);
 
     /* load valid dsa-eg key */
@@ -366,7 +366,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice is signed by Basil, but without the Basil's key.
      * Result: Alice [valid]
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case1/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case1/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -379,7 +379,7 @@ TEST_F(rnp_tests, test_key_validity)
      * corrupted.
      * Result: Alice [invalid], Basil [valid]
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case2/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case2/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -393,7 +393,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice is signed by Basil, but doesn't have self-signature
      * Result: Alice [invalid]
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case3/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case3/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -407,7 +407,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice subkey has invalid binding signature
      * Result: Alice [valid], Alice sub [invalid]
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case4/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case4/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -426,7 +426,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Note: to re-generate keyring file, use generate.cpp from case5 folder.
      *       To build it, feed -DBUILD_TESTING_GENERATORS=On to the cmake.
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case5/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case5/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -441,7 +441,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Key Alice has revocation signature by Alice, and subkey doesn't
      * Result: Alice [invalid], Alice sub [invalid]
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case6/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case6/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -456,7 +456,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice subkey has revocation signature by Alice
      * Result: Alice [valid], Alice sub [invalid]
      */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, KEYSIG_PATH "case7/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, KEYSIG_PATH "case7/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));

--- a/src/tests/load-g10.cpp
+++ b/src/tests/load-g10.cpp
@@ -60,10 +60,12 @@ TEST_F(rnp_tests, test_load_g10)
     pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store, .userdata = NULL};
 
     // load pubring
-    assert_non_null(pub_store = rnp_key_store_new("KBX", "data/keyrings/3/pubring.kbx"));
+    assert_non_null(pub_store =
+                      rnp_key_store_new(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx"));
     assert_true(rnp_key_store_load_from_path(pub_store, NULL));
     // load secring
-    assert_non_null(sec_store = rnp_key_store_new("G10", "data/keyrings/3/private-keys-v1.d"));
+    assert_non_null(
+      sec_store = rnp_key_store_new(PGP_KEY_STORE_G10, "data/keyrings/3/private-keys-v1.d"));
     key_provider.userdata = pub_store;
     assert_true(rnp_key_store_load_from_path(sec_store, &key_provider));
 
@@ -76,10 +78,12 @@ TEST_F(rnp_tests, test_load_g10)
     rnp_key_store_free(sec_store);
 
     /* another store */
-    pub_store = rnp_key_store_new("KBX", "data/test_stream_key_load/g10/pubring.kbx");
+    pub_store =
+      rnp_key_store_new(PGP_KEY_STORE_KBX, "data/test_stream_key_load/g10/pubring.kbx");
     assert_non_null(pub_store);
     assert_true(rnp_key_store_load_from_path(pub_store, NULL));
-    sec_store = rnp_key_store_new("G10", "data/test_stream_key_load/g10/private-keys-v1.d");
+    sec_store =
+      rnp_key_store_new(PGP_KEY_STORE_G10, "data/test_stream_key_load/g10/private-keys-v1.d");
     assert_non_null(sec_store);
     key_provider.userdata = pub_store;
     assert_true(rnp_key_store_load_from_path(sec_store, &key_provider));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -196,7 +196,8 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     const pgp_signature_t *sig = NULL;
 
     // load keyring
-    rnp_key_store_t *key_store = rnp_key_store_new("GPG", "data/keyrings/1/pubring.gpg");
+    rnp_key_store_t *key_store =
+      rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_non_null(key_store);
     assert_true(rnp_key_store_load_from_path(key_store, NULL));
 
@@ -360,7 +361,8 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
     const pgp_signature_t *sig = NULL;
 
     // load keyring
-    rnp_key_store_t *key_store = rnp_key_store_new("GPG", "data/keyrings/2/pubring.gpg");
+    rnp_key_store_t *key_store =
+      rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/2/pubring.gpg");
     assert_non_null(key_store);
     assert_true(rnp_key_store_load_from_path(key_store, NULL));
 
@@ -401,7 +403,7 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     rnp_key_store_t *key_store;
 
-    key_store = rnp_key_store_new("GPG", MERGE_PATH "key-both.asc");
+    key_store = rnp_key_store_new(PGP_KEY_STORE_GPG, MERGE_PATH "key-both.asc");
     assert_non_null(key_store);
     assert_true(rnp_key_store_load_from_path(key_store, NULL));
 
@@ -494,7 +496,7 @@ TEST_F(rnp_tests, test_load_merge)
     pgp_password_provider_t   provider = (pgp_password_provider_t){
       .callback = string_copy_password_callback, .userdata = (void *) "password"};
 
-    key_store = rnp_key_store_new("GPG", "");
+    key_store = rnp_key_store_new(PGP_KEY_STORE_GPG, "");
     assert_non_null(key_store);
     assert_true(rnp_hex_decode("9747D2A6B3A63124", keyid, sizeof(keyid)));
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", sub1id, sizeof(sub1id)));
@@ -717,9 +719,9 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     uint8_t          sub2id[PGP_KEY_ID_SIZE];
     rnp_key_store_t *secstore, *pubstore;
 
-    assert_non_null(secstore = rnp_key_store_new("GPG", MERGE_PATH "key-sec.asc"));
+    assert_non_null(secstore = rnp_key_store_new(PGP_KEY_STORE_GPG, MERGE_PATH "key-sec.asc"));
     assert_true(rnp_key_store_load_from_path(secstore, NULL));
-    assert_non_null(pubstore = rnp_key_store_new("GPG", "pubring.gpg"));
+    assert_non_null(pubstore = rnp_key_store_new(PGP_KEY_STORE_GPG, "pubring.gpg"));
 
     assert_true(rnp_hex_decode("9747D2A6B3A63124", keyid, sizeof(keyid)));
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", sub1id, sizeof(sub1id)));
@@ -781,7 +783,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(rnp_key_store_write_to_path(pubstore));
     rnp_key_store_free(pubstore);
     /* reload */
-    assert_non_null(pubstore = rnp_key_store_new("GPG", "pubring.gpg"));
+    assert_non_null(pubstore = rnp_key_store_new(PGP_KEY_STORE_GPG, "pubring.gpg"));
     assert_true(rnp_key_store_load_from_path(pubstore, NULL));
     assert_non_null(key = rnp_key_store_get_key_by_id(pubstore, keyid, NULL));
     assert_non_null(skey1 = rnp_key_store_get_key_by_id(pubstore, sub1id, NULL));
@@ -988,7 +990,7 @@ TEST_F(rnp_tests, test_load_subkey)
     uint8_t          sub2id[PGP_KEY_ID_SIZE];
     rnp_key_store_t *key_store;
 
-    key_store = rnp_key_store_new("GPG", "");
+    key_store = rnp_key_store_new(PGP_KEY_STORE_GPG, "");
     assert_non_null(key_store);
     assert_true(rnp_hex_decode("9747D2A6B3A63124", keyid, sizeof(keyid)));
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", sub1id, sizeof(sub1id)));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -344,7 +344,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     /* we need rng for key validation */
     assert_true(rng_init(&rng, RNG_SYSTEM));
     /* load keys */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/test_stream_signatures/pub.asc");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/test_stream_signatures/pub.asc");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     /* load signature */
@@ -373,7 +373,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     /* now let's create signature and sign file */
 
     /* load secret key */
-    secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/test_stream_signatures/sec.asc");
+    secring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/test_stream_signatures/sec.asc");
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_non_null(key = rnp_key_store_get_key_by_id(secring, keyid, NULL));
@@ -1072,7 +1072,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     assert_true(rng_init(&rng, RNG_SYSTEM));
 
     /* v3 public key */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/4/rsav3-p.asc");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/4/rsav3-p.asc");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
@@ -1095,7 +1095,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     key_sequence_destroy(&keyseq);
 
     /* keyring */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
@@ -1153,7 +1153,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
 static void
 validate_key_sigs(const char *path)
 {
-    rnp_key_store_t *pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, path);
+    rnp_key_store_t *pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, path);
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     for (size_t i = 0; i < rnp_key_store_get_key_count(pubring); i++) {
@@ -1171,7 +1171,7 @@ TEST_F(rnp_tests, test_stream_key_signature_validate)
     pgp_key_t *      pkey = NULL;
 
     /* v3 public key */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/4/rsav3-p.asc");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/4/rsav3-p.asc");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_int_equal(rnp_key_store_get_key_count(pubring), 1);
@@ -1181,7 +1181,7 @@ TEST_F(rnp_tests, test_stream_key_signature_validate)
     rnp_key_store_free(pubring);
 
     /* keyring */
-    pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_true(rnp_key_store_get_key_count(pubring) > 0);
@@ -1441,7 +1441,7 @@ TEST_F(rnp_tests, test_stream_825_dearmor_blank_line)
     rnp_key_store_t *keystore = NULL;
     pgp_source_t     src = {};
 
-    keystore = rnp_key_store_new("GPG", "");
+    keystore = rnp_key_store_new(PGP_KEY_STORE_GPG, "");
     assert_non_null(keystore);
     assert_rnp_success(
       init_file_src(&src, "data/test_stream_armor/extra_line_before_trailer.asc"));

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -58,7 +58,7 @@ TEST_F(rnp_tests, test_load_user_prefs)
 {
     rnp_key_store_t *pubring = NULL;
 
-    pubring = rnp_key_store_new("GPG", "data/keyrings/1/pubring.gpg");
+    pubring = rnp_key_store_new(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_non_null(pubring);
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_int_equal(rnp_key_store_get_key_count(pubring), 7);


### PR DESCRIPTION
This PR fixes #1025, and also refactors lower layer to use pgp_key_store_format_t instead of `char *`.