### PR TITLE
Remove unused pgp_signatures_info_t structure and functions.

### DIFF
--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1273,22 +1273,3 @@ signature_check_subkey_revocation(pgp_signature_info_t *sinfo,
 
     return signature_check(sinfo, &hash);
 }
-
-bool
-check_signatures_info(const pgp_signatures_info_t *info)
-{
-    return list_length(info->sigs) && !info->unknownc && !info->invalidc && !info->expiredc &&
-           (info->validc == list_length(info->sigs));
-}
-
-void
-free_signatures_info(pgp_signatures_info_t *info)
-{
-    for (list_item *si = list_front(info->sigs); si; si = list_next(si)) {
-        pgp_signature_info_t *sinfo = (pgp_signature_info_t *) si;
-        free_signature(sinfo->sig);
-        free(sinfo->sig);
-    }
-    list_destroy(&info->sigs);
-    memset(info, 0, sizeof(*info));
-}

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -44,14 +44,6 @@ typedef struct pgp_signature_info_t {
     bool             signer_valid; /* assume that signing key is valid */
 } pgp_signature_info_t;
 
-typedef struct pgp_signatures_info_t {
-    list     sigs; /* list of pgp_signature_info_t structures, struct owns them */
-    unsigned validc;
-    unsigned expiredc;
-    unsigned invalidc;
-    unsigned unknownc;
-} pgp_signatures_info_t;
-
 /**
  * @brief Check whether signature packet matches one-pass signature packet.
  * @param sig pointer to the read signature packet
@@ -367,16 +359,5 @@ rnp_result_t signature_check_direct(pgp_signature_info_t *sinfo, const pgp_key_p
 rnp_result_t signature_check_subkey_revocation(pgp_signature_info_t *sinfo,
                                                const pgp_key_pkt_t * key,
                                                const pgp_key_pkt_t * subkey);
-
-/**
- * @brief Check whether signatures info structure has all correct signatures.
- *
- * @param info populated signatures info
- * @return true if all signatures are valid and there is at least one signature
- * @return false if there are invalid, unknown or expired signature(s)
- */
-bool check_signatures_info(const pgp_signatures_info_t *info);
-
-void free_signatures_info(pgp_signatures_info_t *info);
 
 #endif


### PR DESCRIPTION
This should be done in PR #1017 but somehow I missed it.