### PR TITLE
Use single ERR_MSG() call to report errors and warning in CLI.

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -816,7 +816,7 @@ cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username)
 {
     /* set key generation parameters to rnp_cfg_t */
     if (!cli_rnp_set_generate_params(cfg)) {
-        (void) fprintf(stderr, "Key generation setup failed.\n");
+        ERR_MSG("Key generation setup failed.");
         return false;
     }
     /* generate the primary key */
@@ -826,32 +826,32 @@ cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username)
     bool              res = false;
 
     if (rnp_op_generate_create(&genkey, rnp->ffi, rnp_cfg_getstr(cfg, CFG_KG_PRIMARY_ALG))) {
-        (void) fprintf(stderr, "Failed to initialize key generation.\n");
+        ERR_MSG("Failed to initialize key generation.");
         return false;
     }
     if (username && rnp_op_generate_set_userid(genkey, username)) {
-        (void) fprintf(stderr, "Failed to set userid.\n");
+        ERR_MSG("Failed to set userid.");
         goto done;
     }
     if (rnp_cfg_hasval(cfg, CFG_KG_PRIMARY_BITS) &&
         rnp_op_generate_set_bits(genkey, rnp_cfg_getint(cfg, CFG_KG_PRIMARY_BITS))) {
-        (void) fprintf(stderr, "Failed to set key bits.\n");
+        ERR_MSG("Failed to set key bits.");
         goto done;
     }
     if (rnp_cfg_hasval(cfg, CFG_KG_PRIMARY_CURVE) &&
         rnp_op_generate_set_curve(genkey, rnp_cfg_getstr(cfg, CFG_KG_PRIMARY_CURVE))) {
-        (void) fprintf(stderr, "Failed to set key curve.\n");
+        ERR_MSG("Failed to set key curve.");
         goto done;
     }
     // TODO : set DSA qbits
     if (rnp_op_generate_set_hash(genkey, rnp_cfg_getstr(cfg, CFG_KG_HASH))) {
-        (void) fprintf(stderr, "Failed to set hash algorithm.\n");
+        ERR_MSG("Failed to set hash algorithm.");
         goto done;
     }
 
     fprintf(stdout, "Generating a new key...\n");
     if (rnp_op_generate_execute(genkey) || rnp_op_generate_get_key(genkey, &primary)) {
-        (void) fprintf(stderr, "Primary key generation failed.\n");
+        ERR_MSG("Primary key generation failed.");
         goto done;
     }
 
@@ -864,26 +864,26 @@ cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username)
     genkey = NULL;
     if (rnp_op_generate_subkey_create(
           &genkey, rnp->ffi, primary, rnp_cfg_getstr(cfg, CFG_KG_SUBKEY_ALG))) {
-        (void) fprintf(stderr, "Failed to initialize subkey generation.\n");
+        ERR_MSG("Failed to initialize subkey generation.");
         goto done;
     }
     if (rnp_cfg_hasval(cfg, CFG_KG_SUBKEY_BITS) &&
         rnp_op_generate_set_bits(genkey, rnp_cfg_getint(cfg, CFG_KG_SUBKEY_BITS))) {
-        (void) fprintf(stderr, "Failed to set subkey bits.\n");
+        ERR_MSG("Failed to set subkey bits.");
         goto done;
     }
     if (rnp_cfg_hasval(cfg, CFG_KG_SUBKEY_CURVE) &&
         rnp_op_generate_set_curve(genkey, rnp_cfg_getstr(cfg, CFG_KG_SUBKEY_CURVE))) {
-        (void) fprintf(stderr, "Failed to set subkey curve.\n");
+        ERR_MSG("Failed to set subkey curve.");
         goto done;
     }
     // TODO : set DSA qbits
     if (rnp_op_generate_set_hash(genkey, rnp_cfg_getstr(cfg, CFG_KG_HASH))) {
-        (void) fprintf(stderr, "Failed to set hash algorithm.\n");
+        ERR_MSG("Failed to set hash algorithm.");
         goto done;
     }
     if (rnp_op_generate_execute(genkey) || rnp_op_generate_get_key(genkey, &subkey)) {
-        (void) fprintf(stderr, "Subkey generation failed.\n");
+        ERR_MSG("Subkey generation failed.");
         goto done;
     }
 
@@ -908,7 +908,7 @@ cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username)
                             NULL,
                             rnp_cfg_getstr(cfg, CFG_KG_PROT_HASH),
                             rnp_cfg_getint(cfg, CFG_KG_PROT_ITERATIONS))) {
-            (void) fprintf(stderr, "Failed to protect key.\n");
+            ERR_MSG("Failed to protect key.");
             goto done;
         }
     }
@@ -1424,10 +1424,9 @@ conffile(const char *homedir, char *userid, size_t length)
                           &buf[(int) matchv[1].rm_so],
                           MIN((unsigned) (matchv[1].rm_eo - matchv[1].rm_so), length));
 
-            (void) fprintf(stderr,
-                           "rnp: default key set to \"%.*s\"\n",
-                           (int) (matchv[1].rm_eo - matchv[1].rm_so),
-                           &buf[(int) matchv[1].rm_so]);
+            ERR_MSG("rnp: default key set to \"%.*s\"",
+                    (int) (matchv[1].rm_eo - matchv[1].rm_so),
+                    &buf[(int) matchv[1].rm_so]);
         }
 #else
         std::smatch result;
@@ -1436,7 +1435,7 @@ conffile(const char *homedir, char *userid, size_t length)
             (void) strncpy(userid, result[1].str().c_str(), length);
             userid[length - 1] = '\0';
 
-            (void) fprintf(stderr, "rnp: default key set to \"%s\"\n", userid);
+            ERR_MSG("rnp: default key set to \"%s\"", userid);
         }
 #endif
     }

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -216,8 +216,7 @@ static struct option options[] = {
 static void
 print_praise(void)
 {
-    fprintf(stderr,
-            "%s\nAll bug reports, praise and chocolate, please, to:\n%s\n",
+    ERR_MSG("%s\nAll bug reports, praise and chocolate, please, to:\n%s",
             PACKAGE_STRING,
             PACKAGE_BUGREPORT);
 }
@@ -227,7 +226,7 @@ static void
 print_usage(const char *usagemsg)
 {
     print_praise();
-    fprintf(stderr, "Usage: %s %s", rnp_prog_name, usagemsg);
+    ERR_MSG("Usage: %s %s", rnp_prog_name, usagemsg);
 }
 
 /* do a command once for a specified config */
@@ -323,7 +322,7 @@ setcmd(rnp_cfg_t *cfg, int cmd, const char *arg)
             } else if (msgt == "sign") {
                 msgt = "signature";
             } else {
-                fprintf(stderr, "Wrong enarmor argument: %s\n", arg);
+                ERR_MSG("Wrong enarmor argument: %s", arg);
                 return false;
             }
         }
@@ -370,19 +369,19 @@ setoption(rnp_cfg_t *cfg, int val, const char *arg)
         return rnp_cfg_setbool(cfg, CFG_COREDUMPS, true);
     case OPT_KEY_STORE_FORMAT:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No keyring format argument provided\n");
+            ERR_MSG("No keyring format argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_KEYSTOREFMT, arg);
     case OPT_USERID:
         if (arg == NULL) {
-            fputs("No userid argument provided\n", stderr);
+            ERR_MSG("No userid argument provided");
             return false;
         }
         return rnp_cfg_addstr(cfg, CFG_SIGNERS, arg);
     case OPT_RECIPIENT:
         if (arg == NULL) {
-            fputs("No recipient argument provided\n", stderr);
+            ERR_MSG("No recipient argument provided");
             return false;
         }
         return rnp_cfg_addstr(cfg, CFG_RECIPIENTS, arg);
@@ -394,13 +393,13 @@ setoption(rnp_cfg_t *cfg, int val, const char *arg)
         return rnp_cfg_setint(cfg, CFG_VERBOSE, rnp_cfg_getint(cfg, CFG_VERBOSE) + 1);
     case OPT_HOMEDIR:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No home directory argument provided\n");
+            ERR_MSG("No home directory argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_HOMEDIR, arg);
     case OPT_KEYFILE:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No keyfile argument provided\n");
+            ERR_MSG("No keyfile argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_KEYFILE, arg) &&
@@ -419,26 +418,26 @@ setoption(rnp_cfg_t *cfg, int val, const char *arg)
     }
     case OPT_PASSWDFD:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No pass-fd argument provided\n");
+            ERR_MSG("No pass-fd argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_PASSFD, arg);
     case OPT_PASSWD:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No password argument provided\n");
+            ERR_MSG("No password argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_PASSWD, arg);
     case OPT_PASSWORDS: {
         int count;
         if (arg == NULL) {
-            (void) fprintf(stderr, "You must provide a number with --passwords option\n");
+            ERR_MSG("You must provide a number with --passwords option");
             return false;
         }
 
         count = atoi(arg);
         if (count <= 0) {
-            (void) fprintf(stderr, "Incorrect value for --passwords option: %s\n", arg);
+            ERR_MSG("Incorrect value for --passwords option: %s", arg);
             return false;
         }
 
@@ -450,13 +449,13 @@ setoption(rnp_cfg_t *cfg, int val, const char *arg)
     }
     case OPT_OUTPUT:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No output filename argument provided\n");
+            ERR_MSG("No output filename argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_OUTFILE, arg);
     case OPT_RESULTS:
         if (arg == NULL) {
-            (void) fprintf(stderr, "No output filename argument provided\n");
+            ERR_MSG("No output filename argument provided");
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_RESULTS, arg);
@@ -492,21 +491,21 @@ setoption(rnp_cfg_t *cfg, int val, const char *arg)
         } else if ((argstr == "2") || rnp_casecmp(argstr, "ocb")) {
             alg = "OCB";
         } else {
-            (void) fprintf(stderr, "Wrong AEAD algorithm: %s\n", arg);
+            ERR_MSG("Wrong AEAD algorithm: %s", arg);
             return false;
         }
         return rnp_cfg_setstr(cfg, CFG_AEAD, alg);
     }
     case OPT_AEAD_CHUNK: {
         if (!arg) {
-            (void) fprintf(stderr, "Option aead-chunk-bits requires parameter\n");
+            ERR_MSG("Option aead-chunk-bits requires parameter");
             return false;
         }
 
         int bits = atoi(arg);
 
         if ((bits < 0) || (bits > 56)) {
-            (void) fprintf(stderr, "Wrong argument value %s for aead-chunk-bits\n", arg);
+            ERR_MSG("Wrong argument value %s for aead-chunk-bits", arg);
             return false;
         }
 
@@ -546,7 +545,7 @@ parse_option(rnp_cfg_t *cfg, const char *s)
     if (!compiled) {
         compiled = 1;
         if (regcomp(&opt, "([^=]{1,128})(=(.*))?", REG_EXTENDED) != 0) {
-            fprintf(stderr, "Can't compile regex\n");
+            ERR_MSG("Can't compile regex");
             return 0;
         }
     }
@@ -648,21 +647,21 @@ rnp_main(int argc, char **argv)
                 break;
             case 'o':
                 if (!parse_option(&cfg, optarg)) {
-                    (void) fprintf(stderr, "Bad option\n");
+                    ERR_MSG("Bad option");
                     ret = EXIT_ERROR;
                     goto finish;
                 }
                 break;
             case 'r':
                 if (strlen(optarg) < 1) {
-                    fprintf(stderr, "Recipient should not be empty\n");
+                    ERR_MSG("Recipient should not be empty");
                 } else {
                     rnp_cfg_addstr(&cfg, CFG_RECIPIENTS, optarg);
                 }
                 break;
             case 'u':
                 if (!optarg) {
-                    fputs("No userid argument provided\n", stderr);
+                    ERR_MSG("No userid argument provided");
                     ret = EXIT_ERROR;
                     goto finish;
                 }
@@ -670,14 +669,14 @@ rnp_main(int argc, char **argv)
                 break;
             case 'z':
                 if ((strlen(optarg) != 1) || (optarg[0] < '0') || (optarg[0] > '9')) {
-                    fprintf(stderr, "Bad compression level: %s. Should be 0..9\n", optarg);
+                    ERR_MSG("Bad compression level: %s. Should be 0..9", optarg);
                 } else {
                     rnp_cfg_setint(&cfg, CFG_ZLEVEL, (int) (optarg[0] - '0'));
                 }
                 break;
             case 'f':
                 if (!optarg) {
-                    (void) fprintf(stderr, "No keyfile argument provided\n");
+                    ERR_MSG("No keyfile argument provided");
                     ret = EXIT_ERROR;
                     goto finish;
                 }
@@ -705,7 +704,7 @@ rnp_main(int argc, char **argv)
     }
 
     if (!cli_cfg_set_keystore_info(&cfg)) {
-        fputs("fatal: cannot set keystore info\n", stderr);
+        ERR_MSG("fatal: cannot set keystore info");
         ret = EXIT_ERROR;
         goto finish;
     }

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -495,34 +495,6 @@ rnp_cfg_get_pswdtries(const rnp_cfg_t *cfg)
     }
 }
 
-#if 0
-bool
-rnp_cfg_check_homedir(rnp_cfg_t *cfg, char *homedir)
-{
-    struct stat st;
-    int         ret;
-
-    if (homedir == NULL) {
-        fputs("rnp: homedir option and HOME environment variable are not set \n", stderr);
-        return false;
-    } else if ((ret = stat(homedir, &st)) == 0 && !S_ISDIR(st.st_mode)) {
-        /* file exists in place of homedir */
-        RNP_LOG("homedir \"%s\" is not a dir", homedir);
-        return false;
-    } else if (ret != 0 && errno == ENOENT) {
-        /* If the path doesn't exist then fail. */
-        RNP_LOG("warning homedir \"%s\" not found", homedir);
-        return false;
-    } else if (ret != 0) {
-        /* If any other occurred then fail. */
-        RNP_LOG("an unspecified error occurred");
-        return false;
-    }
-
-    return true;
-}
-#endif
-
 /**
  * @brief Grabs date from the string in %Y-%m-%d format
  *

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -71,7 +71,7 @@ rnpkeys_main(int argc, char **argv)
         if (ch >= CMD_LIST_KEYS) {
             /* getopt_long returns 0 for long options */
             if (!setoption(&opt_cfg, &cmd, options[optindex].val, optarg)) {
-                fprintf(stderr, "Bad setoption result %d\n", ch);
+                ERR_MSG("Bad setoption result %d", ch);
                 goto end;
             }
         } else {
@@ -88,7 +88,7 @@ rnpkeys_main(int argc, char **argv)
                 break;
             case 'o':
                 if (!parse_option(&opt_cfg, &cmd, optarg)) {
-                    (void) fprintf(stderr, "Bad parse_option\n");
+                    ERR_MSG("Bad parse_option");
                     goto end;
                 }
                 break;


### PR DESCRIPTION
Probably later on we should use some function instead of define, but at least now it will be more consistent, and later on easily replaceable.