### PR TITLE
Rename pgp_content_enum to pgp_pkt_type_t

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * This code is originally derived from software contributed to
@@ -145,44 +145,33 @@ enum {
     PGP_REVOCATION_NO_LONGER_VALID = 0x20
 };
 
-/* PTag Content Tags */
-/***************************/
-
-/** Package Tags (aka Content Tags) and signature subpacket types.
- * This enumerates all rfc-defined packet tag values and the
- * signature subpacket type values that we understand.
+/**
+ * @brief OpenPGP packet tags. See section 4.3 of RFC4880 for the detailed description.
  *
- * \see RFC4880 4.3
- * \see RFC4880 5.2.3.1
  */
 typedef enum {
-    PGP_PTAG_CT_RESERVED = 0,       /* Reserved - a packet tag must
-                                     * not have this value */
-    PGP_PTAG_CT_PK_SESSION_KEY = 1, /* Public-Key Encrypted Session
-                                     * Key Packet */
-    PGP_PTAG_CT_SIGNATURE = 2,      /* Signature Packet */
-    PGP_PTAG_CT_SK_SESSION_KEY = 3, /* Symmetric-Key Encrypted Session
-                                     * Key Packet */
-    PGP_PTAG_CT_1_PASS_SIG = 4,     /* One-Pass Signature
-                                     * Packet */
-    PGP_PTAG_CT_SECRET_KEY = 5,     /* Secret Key Packet */
-    PGP_PTAG_CT_PUBLIC_KEY = 6,     /* Public Key Packet */
-    PGP_PTAG_CT_SECRET_SUBKEY = 7,  /* Secret Subkey Packet */
-    PGP_PTAG_CT_COMPRESSED = 8,     /* Compressed Data Packet */
-    PGP_PTAG_CT_SE_DATA = 9,        /* Symmetrically Encrypted Data Packet */
-    PGP_PTAG_CT_MARKER = 10,        /* Marker Packet */
-    PGP_PTAG_CT_LITDATA = 11,       /* Literal Data Packet */
-    PGP_PTAG_CT_TRUST = 12,         /* Trust Packet */
-    PGP_PTAG_CT_USER_ID = 13,       /* User ID Packet */
-    PGP_PTAG_CT_PUBLIC_SUBKEY = 14, /* Public Subkey Packet */
-    PGP_PTAG_CT_RESERVED2 = 15,     /* reserved */
-    PGP_PTAG_CT_RESERVED3 = 16,     /* reserved */
-    PGP_PTAG_CT_USER_ATTR = 17,     /* User Attribute Packet */
-    PGP_PTAG_CT_SE_IP_DATA = 18,    /* Sym. Encrypted and Integrity
-                                     * Protected Data Packet */
-    PGP_PTAG_CT_MDC = 19,           /* Modification Detection Code Packet */
-    PGP_PTAG_CT_AEAD_ENCRYPTED = 20 /* AEAD Encrypted Data Packet, RFC 4880bis */
-} pgp_content_enum;
+    PGP_PKT_RESERVED = 0,       /* Reserved - a packet tag must not have this value */
+    PGP_PKT_PK_SESSION_KEY = 1, /* Public-Key Encrypted Session Key Packet */
+    PGP_PKT_SIGNATURE = 2,      /* Signature Packet */
+    PGP_PKT_SK_SESSION_KEY = 3, /* Symmetric-Key Encrypted Session Key Packet */
+    PGP_PKT_ONE_PASS_SIG = 4,   /* One-Pass Signature Packet */
+    PGP_PKT_SECRET_KEY = 5,     /* Secret Key Packet */
+    PGP_PKT_PUBLIC_KEY = 6,     /* Public Key Packet */
+    PGP_PKT_SECRET_SUBKEY = 7,  /* Secret Subkey Packet */
+    PGP_PKT_COMPRESSED = 8,     /* Compressed Data Packet */
+    PGP_PKT_SE_DATA = 9,        /* Symmetrically Encrypted Data Packet */
+    PGP_PKT_MARKER = 10,        /* Marker Packet */
+    PGP_PKT_LITDATA = 11,       /* Literal Data Packet */
+    PGP_PKT_TRUST = 12,         /* Trust Packet */
+    PGP_PKT_USER_ID = 13,       /* User ID Packet */
+    PGP_PKT_PUBLIC_SUBKEY = 14, /* Public Subkey Packet */
+    PGP_PKT_RESERVED2 = 15,     /* Reserved */
+    PGP_PKT_RESERVED3 = 16,     /* Reserved */
+    PGP_PKT_USER_ATTR = 17,     /* User Attribute Packet */
+    PGP_PKT_SE_IP_DATA = 18,    /* Sym. Encrypted and Integrity Protected Data Packet */
+    PGP_PKT_MDC = 19,           /* Modification Detection Code Packet */
+    PGP_PKT_AEAD_ENCRYPTED = 20 /* AEAD Encrypted Data Packet, RFC 4880bis */
+} pgp_pkt_type_t;
 
 /** Public Key Algorithm Numbers.
  * OpenPGP assigns a unique Algorithm Number to each algorithm that is part of OpenPGP.

--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
@@ -99,7 +99,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto,
     seckey->creation_time = time(NULL);
     seckey->alg = crypto->key_alg;
     seckey->material.alg = crypto->key_alg;
-    seckey->tag = primary ? PGP_PTAG_CT_SECRET_KEY : PGP_PTAG_CT_SECRET_SUBKEY;
+    seckey->tag = primary ? PGP_PKT_SECRET_KEY : PGP_PKT_SECRET_SUBKEY;
     rng = crypto->rng;
 
     switch (seckey->alg) {

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -659,7 +659,7 @@ pgp_key_get_version(const pgp_key_t *key)
     return key->pkt.version;
 }
 
-int
+pgp_pkt_type_t
 pgp_key_get_type(const pgp_key_t *key)
 {
     return key->pkt.tag;
@@ -1192,7 +1192,7 @@ pgp_write_seckey(pgp_dest_t *   dst,
                  const char *   password)
 {
     bool           res = false;
-    pgp_pkt_type_t oldtag = (pgp_pkt_type_t) seckey->tag;
+    pgp_pkt_type_t oldtag = seckey->tag;
 
     seckey->tag = tag;
     if (encrypt_secret_key(seckey, password, NULL)) {
@@ -1335,7 +1335,7 @@ pgp_key_protect(pgp_key_t *                  key,
     // write the protected key to packets[0]
     if (!write_key_to_rawpacket(decrypted_seckey,
                                 pgp_key_get_rawpacket(key, 0),
-                                (pgp_pkt_type_t) pgp_key_get_type(key),
+                                pgp_key_get_type(key),
                                 format,
                                 new_password)) {
         goto done;
@@ -1380,11 +1380,8 @@ pgp_key_unprotect(pgp_key_t *key, const pgp_password_provider_t *password_provid
         seckey = decrypted_seckey;
     }
     seckey->sec_protection.s2k.usage = PGP_S2KU_NONE;
-    if (!write_key_to_rawpacket(seckey,
-                                pgp_key_get_rawpacket(key, 0),
-                                (pgp_pkt_type_t) pgp_key_get_type(key),
-                                key->format,
-                                NULL)) {
+    if (!write_key_to_rawpacket(
+          seckey, pgp_key_get_rawpacket(key, 0), pgp_key_get_type(key), key->format, NULL)) {
         goto done;
     }
     if (decrypted_seckey) {
@@ -1519,7 +1516,7 @@ write_xfer_packets(pgp_dest_t *           dst,
     for (size_t i = 0; i < pgp_key_get_rawpacket_count(key); i++) {
         pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
 
-        if (!packet_matches((pgp_pkt_type_t) pkt->tag, secret)) {
+        if (!packet_matches(pkt->tag, secret)) {
             RNP_LOG("skipping packet with tag: %d", pkt->tag);
             continue;
         }

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -962,7 +962,7 @@ pgp_key_get_subsig(const pgp_key_t *key, size_t idx)
 }
 
 pgp_rawpacket_t *
-pgp_key_add_rawpacket(pgp_key_t *key, void *data, size_t len, pgp_content_enum tag)
+pgp_key_add_rawpacket(pgp_key_t *key, void *data, size_t len, pgp_pkt_type_t tag)
 {
     pgp_rawpacket_t *packet;
     if (!(packet = (pgp_rawpacket_t *) list_append(&key->packets, NULL, sizeof(*packet)))) {
@@ -981,7 +981,7 @@ pgp_key_add_rawpacket(pgp_key_t *key, void *data, size_t len, pgp_content_enum t
 }
 
 pgp_rawpacket_t *
-pgp_key_add_stream_rawpacket(pgp_key_t *key, pgp_content_enum tag, pgp_dest_t *memdst)
+pgp_key_add_stream_rawpacket(pgp_key_t *key, pgp_pkt_type_t tag, pgp_dest_t *memdst)
 {
     pgp_rawpacket_t *res =
       pgp_key_add_rawpacket(key, mem_dest_get_memory(memdst), memdst->writeb, tag);
@@ -1004,7 +1004,7 @@ pgp_key_add_key_rawpacket(pgp_key_t *key, pgp_key_pkt_t *pkt)
         dst_close(&dst, true);
         return NULL;
     }
-    return pgp_key_add_stream_rawpacket(key, (pgp_content_enum) pkt->tag, &dst);
+    return pgp_key_add_stream_rawpacket(key, (pgp_pkt_type_t) pkt->tag, &dst);
 }
 
 pgp_rawpacket_t *
@@ -1019,7 +1019,7 @@ pgp_key_add_sig_rawpacket(pgp_key_t *key, const pgp_signature_t *pkt)
         dst_close(&dst, true);
         return NULL;
     }
-    return pgp_key_add_stream_rawpacket(key, PGP_PTAG_CT_SIGNATURE, &dst);
+    return pgp_key_add_stream_rawpacket(key, PGP_PKT_SIGNATURE, &dst);
 }
 
 pgp_rawpacket_t *
@@ -1034,7 +1034,7 @@ pgp_key_add_uid_rawpacket(pgp_key_t *key, const pgp_userid_pkt_t *pkt)
         dst_close(&dst, true);
         return NULL;
     }
-    return pgp_key_add_stream_rawpacket(key, (pgp_content_enum) pkt->tag, &dst);
+    return pgp_key_add_stream_rawpacket(key, (pgp_pkt_type_t) pkt->tag, &dst);
 }
 
 size_t
@@ -1186,13 +1186,13 @@ pgp_key_lock(pgp_key_t *key)
 }
 
 static bool
-pgp_write_seckey(pgp_dest_t *     dst,
-                 pgp_content_enum tag,
-                 pgp_key_pkt_t *  seckey,
-                 const char *     password)
+pgp_write_seckey(pgp_dest_t *   dst,
+                 pgp_pkt_type_t tag,
+                 pgp_key_pkt_t *seckey,
+                 const char *   password)
 {
-    bool res = false;
-    int  oldtag = seckey->tag;
+    bool           res = false;
+    pgp_pkt_type_t oldtag = (pgp_pkt_type_t) seckey->tag;
 
     seckey->tag = tag;
     if (encrypt_secret_key(seckey, password, NULL)) {
@@ -1207,7 +1207,7 @@ done:
 static bool
 write_key_to_rawpacket(pgp_key_pkt_t *        seckey,
                        pgp_rawpacket_t *      packet,
-                       pgp_content_enum       type,
+                       pgp_pkt_type_t         type,
                        pgp_key_store_format_t format,
                        const char *           password)
 {
@@ -1335,7 +1335,7 @@ pgp_key_protect(pgp_key_t *                  key,
     // write the protected key to packets[0]
     if (!write_key_to_rawpacket(decrypted_seckey,
                                 pgp_key_get_rawpacket(key, 0),
-                                (pgp_content_enum) pgp_key_get_type(key),
+                                (pgp_pkt_type_t) pgp_key_get_type(key),
                                 format,
                                 new_password)) {
         goto done;
@@ -1382,7 +1382,7 @@ pgp_key_unprotect(pgp_key_t *key, const pgp_password_provider_t *password_provid
     seckey->sec_protection.s2k.usage = PGP_S2KU_NONE;
     if (!write_key_to_rawpacket(seckey,
                                 pgp_key_get_rawpacket(key, 0),
-                                (pgp_content_enum) pgp_key_get_type(key),
+                                (pgp_pkt_type_t) pgp_key_get_type(key),
                                 key->format,
                                 NULL)) {
         goto done;
@@ -1452,7 +1452,7 @@ pgp_key_add_userid_certified(pgp_key_t *              key,
     }
 
     /* Fill the transferable userid */
-    uid.uid.tag = PGP_PTAG_CT_USER_ID;
+    uid.uid.tag = PGP_PKT_USER_ID;
     uid.uid.uid_len = strlen((char *) cert->userid);
     if (!(uid.uid.uid = (uint8_t *) malloc(uid.uid.uid_len))) {
         RNP_LOG("allocation failed");
@@ -1492,18 +1492,18 @@ pgp_key_write_packets(const pgp_key_t *key, pgp_dest_t *dst)
 }
 
 static bool
-packet_matches(pgp_content_enum tag, bool secret)
+packet_matches(pgp_pkt_type_t tag, bool secret)
 {
     switch (tag) {
-    case PGP_PTAG_CT_SIGNATURE:
-    case PGP_PTAG_CT_USER_ID:
-    case PGP_PTAG_CT_USER_ATTR:
+    case PGP_PKT_SIGNATURE:
+    case PGP_PKT_USER_ID:
+    case PGP_PKT_USER_ATTR:
         return true;
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
+    case PGP_PKT_PUBLIC_KEY:
+    case PGP_PKT_PUBLIC_SUBKEY:
         return !secret;
-    case PGP_PTAG_CT_SECRET_KEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
+    case PGP_PKT_SECRET_KEY:
+    case PGP_PKT_SECRET_SUBKEY:
         return secret;
     default:
         return false;
@@ -1519,7 +1519,7 @@ write_xfer_packets(pgp_dest_t *           dst,
     for (size_t i = 0; i < pgp_key_get_rawpacket_count(key); i++) {
         pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
 
-        if (!packet_matches(pkt->tag, secret)) {
+        if (!packet_matches((pgp_pkt_type_t) pkt->tag, secret)) {
             RNP_LOG("skipping packet with tag: %d", pkt->tag);
             continue;
         }

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -160,7 +160,7 @@ pgp_curve_t pgp_key_get_curve(const pgp_key_t *key);
 
 pgp_version_t pgp_key_get_version(const pgp_key_t *key);
 
-int pgp_key_get_type(const pgp_key_t *key);
+pgp_pkt_type_t pgp_key_get_type(const pgp_key_t *key);
 
 bool pgp_key_is_encrypted(const pgp_key_t *);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -273,7 +273,7 @@ pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
 
 void pgp_subsig_free(pgp_subsig_t *subsig);
 
-pgp_rawpacket_t *pgp_key_add_rawpacket(pgp_key_t *, void *, size_t, pgp_content_enum);
+pgp_rawpacket_t *pgp_key_add_rawpacket(pgp_key_t *, void *, size_t, pgp_pkt_type_t);
 
 pgp_rawpacket_t *pgp_key_add_key_rawpacket(pgp_key_t *key, pgp_key_pkt_t *pkt);
 

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
@@ -279,9 +279,9 @@ typedef struct pgp_sig_subpkt_t {
 
 /** pgp_rawpacket_t */
 typedef struct pgp_rawpacket_t {
-    pgp_content_enum tag;
-    size_t           length;
-    uint8_t *        raw;
+    pgp_pkt_type_t tag;
+    size_t         length;
+    uint8_t *      raw;
 } pgp_rawpacket_t;
 
 typedef enum {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -146,7 +146,7 @@ typedef struct pgp_key_protection_t {
 
 /** Struct to hold a key packet. May contain public or private key/subkey */
 typedef struct pgp_key_pkt_t {
-    int              tag;           /* packet tag: public key/subkey or private key/subkey */
+    pgp_pkt_type_t   tag;           /* packet tag: public key/subkey or private key/subkey */
     pgp_version_t    version;       /* Key packet version */
     uint32_t         creation_time; /* Key creation time */
     pgp_pubkey_alg_t alg;
@@ -169,9 +169,9 @@ typedef struct pgp_key_t pgp_key_t;
  *  binary blob as it is. It may be distinguished by tag field.
  */
 typedef struct pgp_userid_pkt_t {
-    int      tag;
-    uint8_t *uid;
-    size_t   uid_len;
+    pgp_pkt_type_t tag;
+    uint8_t *      uid;
+    size_t         uid_len;
 } pgp_userid_pkt_t;
 
 typedef struct pgp_signature_t {

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1093,7 +1093,7 @@ copy_secret_fields(pgp_key_pkt_t *dst, const pgp_key_pkt_t *src)
 
     dst->material.secret = src->material.secret;
     dst->sec_protection = src->sec_protection;
-    dst->tag = is_subkey_pkt(dst->tag) ? PGP_PTAG_CT_SECRET_SUBKEY : PGP_PTAG_CT_SECRET_KEY;
+    dst->tag = is_subkey_pkt(dst->tag) ? PGP_PKT_SECRET_SUBKEY : PGP_PKT_SECRET_KEY;
 
     return true;
 }
@@ -1155,7 +1155,7 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
     }
 
     if (!pgp_key_add_rawpacket(
-          &key, (uint8_t *) mem_src_get_memory(&memsrc), memsrc.size, PGP_PTAG_CT_RESERVED)) {
+          &key, (uint8_t *) mem_src_get_memory(&memsrc), memsrc.size, PGP_PKT_RESERVED)) {
         RNP_LOG("failed to add packet");
         goto done;
     }

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1105,7 +1105,7 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
 {
     const pgp_key_t *pubkey = NULL;
     pgp_key_t        key = {0};
-    pgp_key_pkt_t    seckey = {0};
+    pgp_key_pkt_t    seckey = {};
     pgp_source_t     memsrc = {};
     bool             ret = false;
 

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -211,7 +211,7 @@ rnp_key_add_transferable_userid(pgp_key_t *key, pgp_transferable_userid_t *uid)
         RNP_LOG("Failed to add userid");
         return false;
     }
-    if (uid->uid.tag == PGP_PTAG_CT_USER_ID) {
+    if (uid->uid.tag == PGP_PKT_USER_ID) {
         userid->str = (char *) calloc(1, uid->uid.uid_len + 1);
         if (!userid->str) {
             RNP_LOG("uid alloc failed");

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -493,21 +493,21 @@ rnp_armor_guess_type(pgp_source_t *src)
     ptype = get_packet_type(ptag);
 
     switch (ptype) {
-    case PGP_PTAG_CT_PK_SESSION_KEY:
-    case PGP_PTAG_CT_SK_SESSION_KEY:
-    case PGP_PTAG_CT_1_PASS_SIG:
-    case PGP_PTAG_CT_SE_DATA:
-    case PGP_PTAG_CT_SE_IP_DATA:
-    case PGP_PTAG_CT_COMPRESSED:
-    case PGP_PTAG_CT_LITDATA:
+    case PGP_PKT_PK_SESSION_KEY:
+    case PGP_PKT_SK_SESSION_KEY:
+    case PGP_PKT_ONE_PASS_SIG:
+    case PGP_PKT_SE_DATA:
+    case PGP_PKT_SE_IP_DATA:
+    case PGP_PKT_COMPRESSED:
+    case PGP_PKT_LITDATA:
         return PGP_ARMORED_MESSAGE;
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
+    case PGP_PKT_PUBLIC_KEY:
+    case PGP_PKT_PUBLIC_SUBKEY:
         return PGP_ARMORED_PUBLIC_KEY;
-    case PGP_PTAG_CT_SECRET_KEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
+    case PGP_PKT_SECRET_KEY:
+    case PGP_PKT_SECRET_SUBKEY:
         return PGP_ARMORED_SECRET_KEY;
-    case PGP_PTAG_CT_SIGNATURE:
+    case PGP_PKT_SIGNATURE:
         return PGP_ARMORED_SIGNATURE;
     default:
         return PGP_ARMORED_UNKNOWN;

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2018-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -48,27 +48,27 @@
 #include <algorithm>
 
 static pgp_map_t packet_tag_map[] = {
-  {PGP_PTAG_CT_RESERVED, "Reserved"},
-  {PGP_PTAG_CT_PK_SESSION_KEY, "Public-Key Encrypted Session Key"},
-  {PGP_PTAG_CT_SIGNATURE, "Signature"},
-  {PGP_PTAG_CT_SK_SESSION_KEY, "Symmetric-Key Encrypted Session Key"},
-  {PGP_PTAG_CT_1_PASS_SIG, "One-Pass Signature"},
-  {PGP_PTAG_CT_SECRET_KEY, "Secret Key"},
-  {PGP_PTAG_CT_PUBLIC_KEY, "Public Key"},
-  {PGP_PTAG_CT_SECRET_SUBKEY, "Secret Subkey"},
-  {PGP_PTAG_CT_COMPRESSED, "Compressed Data"},
-  {PGP_PTAG_CT_SE_DATA, "Symmetrically Encrypted Data"},
-  {PGP_PTAG_CT_MARKER, "Marker"},
-  {PGP_PTAG_CT_LITDATA, "Literal Data"},
-  {PGP_PTAG_CT_TRUST, "Trust"},
-  {PGP_PTAG_CT_USER_ID, "User ID"},
-  {PGP_PTAG_CT_PUBLIC_SUBKEY, "Public Subkey"},
-  {PGP_PTAG_CT_RESERVED2, "reserved2"},
-  {PGP_PTAG_CT_RESERVED3, "reserved3"},
-  {PGP_PTAG_CT_USER_ATTR, "User Attribute"},
-  {PGP_PTAG_CT_SE_IP_DATA, "Symmetric Encrypted and Integrity Protected Data"},
-  {PGP_PTAG_CT_MDC, "Modification Detection Code"},
-  {PGP_PTAG_CT_AEAD_ENCRYPTED, "AEAD Encrypted Data Packet"},
+  {PGP_PKT_RESERVED, "Reserved"},
+  {PGP_PKT_PK_SESSION_KEY, "Public-Key Encrypted Session Key"},
+  {PGP_PKT_SIGNATURE, "Signature"},
+  {PGP_PKT_SK_SESSION_KEY, "Symmetric-Key Encrypted Session Key"},
+  {PGP_PKT_ONE_PASS_SIG, "One-Pass Signature"},
+  {PGP_PKT_SECRET_KEY, "Secret Key"},
+  {PGP_PKT_PUBLIC_KEY, "Public Key"},
+  {PGP_PKT_SECRET_SUBKEY, "Secret Subkey"},
+  {PGP_PKT_COMPRESSED, "Compressed Data"},
+  {PGP_PKT_SE_DATA, "Symmetrically Encrypted Data"},
+  {PGP_PKT_MARKER, "Marker"},
+  {PGP_PKT_LITDATA, "Literal Data"},
+  {PGP_PKT_TRUST, "Trust"},
+  {PGP_PKT_USER_ID, "User ID"},
+  {PGP_PKT_PUBLIC_SUBKEY, "Public Subkey"},
+  {PGP_PKT_RESERVED2, "reserved2"},
+  {PGP_PKT_RESERVED3, "reserved3"},
+  {PGP_PKT_USER_ATTR, "User Attribute"},
+  {PGP_PKT_SE_IP_DATA, "Symmetric Encrypted and Integrity Protected Data"},
+  {PGP_PKT_MDC, "Modification Detection Code"},
+  {PGP_PKT_AEAD_ENCRYPTED, "AEAD Encrypted Data Packet"},
 
   {0x00, NULL}, /* this is the end-of-array marker */
 };
@@ -122,10 +122,10 @@ static pgp_map_t sig_subpkt_type_map[] = {
 };
 
 static pgp_map_t key_type_map[] = {
-  {PGP_PTAG_CT_SECRET_KEY, "Secret key"},
-  {PGP_PTAG_CT_PUBLIC_KEY, "Public key"},
-  {PGP_PTAG_CT_SECRET_SUBKEY, "Secret subkey"},
-  {PGP_PTAG_CT_PUBLIC_SUBKEY, "Public subkey"},
+  {PGP_PKT_SECRET_KEY, "Secret key"},
+  {PGP_PKT_PUBLIC_KEY, "Public key"},
+  {PGP_PKT_SECRET_SUBKEY, "Secret subkey"},
+  {PGP_PKT_PUBLIC_SUBKEY, "Public subkey"},
   {0x00, NULL},
 };
 
@@ -875,10 +875,10 @@ stream_dump_userid(pgp_source_t *src, pgp_dest_t *dst)
     }
 
     switch (uid.tag) {
-    case PGP_PTAG_CT_USER_ID:
+    case PGP_PKT_USER_ID:
         utype = "UserID";
         break;
-    case PGP_PTAG_CT_USER_ATTR:
+    case PGP_PKT_USER_ATTR:
         utype = "UserAttr";
         break;
     default:
@@ -889,12 +889,12 @@ stream_dump_userid(pgp_source_t *src, pgp_dest_t *dst)
     indent_dest_increase(dst);
 
     switch (uid.tag) {
-    case PGP_PTAG_CT_USER_ID:
+    case PGP_PKT_USER_ID:
         dst_printf(dst, "id: ");
         dst_write(dst, uid.uid, uid.uid_len);
         dst_printf(dst, "\n");
         break;
-    case PGP_PTAG_CT_USER_ATTR:
+    case PGP_PKT_USER_ATTR:
         dst_printf(dst, "id: (%d bytes of data)\n", (int) uid.uid_len);
         break;
     default:;
@@ -1033,13 +1033,13 @@ static rnp_result_t
 stream_dump_encrypted(pgp_source_t *src, pgp_dest_t *dst, int tag)
 {
     switch (tag) {
-    case PGP_PTAG_CT_SE_DATA:
+    case PGP_PKT_SE_DATA:
         dst_printf(dst, "Symmetrically-encrypted data packet\n\n");
         break;
-    case PGP_PTAG_CT_SE_IP_DATA:
+    case PGP_PKT_SE_IP_DATA:
         dst_printf(dst, "Symmetrically-encrypted integrity protected data packet\n\n");
         break;
-    case PGP_PTAG_CT_AEAD_ENCRYPTED:
+    case PGP_PKT_AEAD_ENCRYPTED:
         return stream_dump_aead_encrypted(src, dst);
     default:
         dst_printf(dst, "Unknown encrypted data packet\n\n");
@@ -1191,42 +1191,42 @@ stream_dump_packets_raw(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
         }
 
         switch (hdr.tag) {
-        case PGP_PTAG_CT_SIGNATURE:
+        case PGP_PKT_SIGNATURE:
             ret = stream_dump_signature(ctx, src, dst);
             break;
-        case PGP_PTAG_CT_SECRET_KEY:
-        case PGP_PTAG_CT_PUBLIC_KEY:
-        case PGP_PTAG_CT_SECRET_SUBKEY:
-        case PGP_PTAG_CT_PUBLIC_SUBKEY:
+        case PGP_PKT_SECRET_KEY:
+        case PGP_PKT_PUBLIC_KEY:
+        case PGP_PKT_SECRET_SUBKEY:
+        case PGP_PKT_PUBLIC_SUBKEY:
             ret = stream_dump_key(ctx, src, dst);
             break;
-        case PGP_PTAG_CT_USER_ID:
-        case PGP_PTAG_CT_USER_ATTR:
+        case PGP_PKT_USER_ID:
+        case PGP_PKT_USER_ATTR:
             ret = stream_dump_userid(src, dst);
             break;
-        case PGP_PTAG_CT_PK_SESSION_KEY:
+        case PGP_PKT_PK_SESSION_KEY:
             ret = stream_dump_pk_session_key(ctx, src, dst);
             break;
-        case PGP_PTAG_CT_SK_SESSION_KEY:
+        case PGP_PKT_SK_SESSION_KEY:
             ret = stream_dump_sk_session_key(src, dst);
             break;
-        case PGP_PTAG_CT_SE_DATA:
-        case PGP_PTAG_CT_SE_IP_DATA:
-        case PGP_PTAG_CT_AEAD_ENCRYPTED:
+        case PGP_PKT_SE_DATA:
+        case PGP_PKT_SE_IP_DATA:
+        case PGP_PKT_AEAD_ENCRYPTED:
             ret = stream_dump_encrypted(src, dst, hdr.tag);
             break;
-        case PGP_PTAG_CT_1_PASS_SIG:
+        case PGP_PKT_ONE_PASS_SIG:
             ret = stream_dump_one_pass(src, dst);
             break;
-        case PGP_PTAG_CT_COMPRESSED:
+        case PGP_PKT_COMPRESSED:
             ret = stream_dump_compressed(ctx, src, dst);
             break;
-        case PGP_PTAG_CT_LITDATA:
+        case PGP_PKT_LITDATA:
             ret = stream_dump_literal(src, dst);
             break;
-        case PGP_PTAG_CT_MARKER:
-        case PGP_PTAG_CT_TRUST:
-        case PGP_PTAG_CT_MDC:
+        case PGP_PKT_MARKER:
+        case PGP_PKT_TRUST:
+        case PGP_PKT_MDC:
             dst_printf(dst, "Skipping unhandled pkt: %d\n\n", (int) hdr.tag);
             ret = stream_skip_packet(src);
             break;
@@ -1873,14 +1873,14 @@ stream_dump_userid_json(pgp_source_t *src, json_object *pkt)
     }
 
     switch (uid.tag) {
-    case PGP_PTAG_CT_USER_ID:
+    case PGP_PKT_USER_ID:
         if (!obj_add_field_json(
               pkt, "userid", json_object_new_string_len((char *) uid.uid, uid.uid_len))) {
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto done;
         }
         break;
-    case PGP_PTAG_CT_USER_ATTR:
+    case PGP_PKT_USER_ATTR:
         if (!obj_add_hex_json(pkt, "userattr", uid.uid, uid.uid_len)) {
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto done;
@@ -1981,9 +1981,9 @@ stream_dump_sk_session_key_json(pgp_source_t *src, json_object *pkt)
 }
 
 static rnp_result_t
-stream_dump_encrypted_json(pgp_source_t *src, json_object *pkt, pgp_content_enum tag)
+stream_dump_encrypted_json(pgp_source_t *src, json_object *pkt, pgp_pkt_type_t tag)
 {
-    if (tag != PGP_PTAG_CT_AEAD_ENCRYPTED) {
+    if (tag != PGP_PKT_AEAD_ENCRYPTED) {
         /* packet header with tag is already in pkt */
         return stream_skip_packet(src);
     }
@@ -2199,42 +2199,42 @@ stream_dump_raw_packets_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object
         }
 
         switch (hdr.tag) {
-        case PGP_PTAG_CT_SIGNATURE:
+        case PGP_PKT_SIGNATURE:
             ret = stream_dump_signature_json(ctx, src, pkt);
             break;
-        case PGP_PTAG_CT_SECRET_KEY:
-        case PGP_PTAG_CT_PUBLIC_KEY:
-        case PGP_PTAG_CT_SECRET_SUBKEY:
-        case PGP_PTAG_CT_PUBLIC_SUBKEY:
+        case PGP_PKT_SECRET_KEY:
+        case PGP_PKT_PUBLIC_KEY:
+        case PGP_PKT_SECRET_SUBKEY:
+        case PGP_PKT_PUBLIC_SUBKEY:
             ret = stream_dump_key_json(ctx, src, pkt);
             break;
-        case PGP_PTAG_CT_USER_ID:
-        case PGP_PTAG_CT_USER_ATTR:
+        case PGP_PKT_USER_ID:
+        case PGP_PKT_USER_ATTR:
             ret = stream_dump_userid_json(src, pkt);
             break;
-        case PGP_PTAG_CT_PK_SESSION_KEY:
+        case PGP_PKT_PK_SESSION_KEY:
             ret = stream_dump_pk_session_key_json(ctx, src, pkt);
             break;
-        case PGP_PTAG_CT_SK_SESSION_KEY:
+        case PGP_PKT_SK_SESSION_KEY:
             ret = stream_dump_sk_session_key_json(src, pkt);
             break;
-        case PGP_PTAG_CT_SE_DATA:
-        case PGP_PTAG_CT_SE_IP_DATA:
-        case PGP_PTAG_CT_AEAD_ENCRYPTED:
+        case PGP_PKT_SE_DATA:
+        case PGP_PKT_SE_IP_DATA:
+        case PGP_PKT_AEAD_ENCRYPTED:
             ret = stream_dump_encrypted_json(src, pkt, hdr.tag);
             break;
-        case PGP_PTAG_CT_1_PASS_SIG:
+        case PGP_PKT_ONE_PASS_SIG:
             ret = stream_dump_one_pass_json(src, pkt);
             break;
-        case PGP_PTAG_CT_COMPRESSED:
+        case PGP_PKT_COMPRESSED:
             ret = stream_dump_compressed_json(ctx, src, pkt);
             break;
-        case PGP_PTAG_CT_LITDATA:
+        case PGP_PKT_LITDATA:
             ret = stream_dump_literal_json(src, pkt);
             break;
-        case PGP_PTAG_CT_MARKER:
-        case PGP_PTAG_CT_TRUST:
-        case PGP_PTAG_CT_MDC:
+        case PGP_PKT_MARKER:
+        case PGP_PKT_TRUST:
+        case PGP_PKT_MDC:
             ret = stream_skip_packet(src);
             break;
         default:

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1304,7 +1304,7 @@ encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t *rng)
     }
 
     /* build secret key data */
-    if (!init_packet_body(&body, 0)) {
+    if (!init_packet_body(&body, PGP_PKT_RESERVED)) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     if (!write_secret_key_mpis(&body, key)) {

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2018-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -336,7 +336,7 @@ transferable_key_add_userid(pgp_transferable_key_t *key, const char *userid)
     pgp_userid_pkt_t           uid = {};
     pgp_transferable_userid_t *tuid = NULL;
 
-    uid.tag = PGP_PTAG_CT_USER_ID;
+    uid.tag = PGP_PKT_USER_ID;
     uid.uid_len = strlen(userid);
     if (!(uid.uid = (uint8_t *) malloc(uid.uid_len))) {
         return NULL;
@@ -653,7 +653,7 @@ static rnp_result_t
 process_pgp_key_trusts(pgp_source_t *src)
 {
     rnp_result_t ret;
-    while (stream_pkt_type(src) == PGP_PTAG_CT_TRUST) {
+    while (stream_pkt_type(src) == PGP_PKT_TRUST) {
         if ((ret = stream_skip_packet(src))) {
             RNP_LOG("failed to skip trust packet");
             return ret;
@@ -668,7 +668,7 @@ process_pgp_key_signatures(pgp_source_t *src, list *sigs)
     int          ptag;
     rnp_result_t ret = RNP_ERROR_BAD_FORMAT;
 
-    while ((ptag = stream_pkt_type(src)) == PGP_PTAG_CT_SIGNATURE) {
+    while ((ptag = stream_pkt_type(src)) == PGP_PKT_SIGNATURE) {
         pgp_signature_t *sig = (pgp_signature_t *) list_append(sigs, NULL, sizeof(*sig));
         if (!sig) {
             RNP_LOG("sig alloc failed");
@@ -697,7 +697,7 @@ process_pgp_userid(pgp_source_t *src, pgp_transferable_userid_t *uid)
     memset(uid, 0, sizeof(*uid));
     ptag = stream_pkt_type(src);
 
-    if ((ptag != PGP_PTAG_CT_USER_ID) && (ptag != PGP_PTAG_CT_USER_ATTR)) {
+    if ((ptag != PGP_PKT_USER_ID) && (ptag != PGP_PKT_USER_ATTR)) {
         RNP_LOG("wrong uid ptag: %d", ptag);
         return RNP_ERROR_BAD_FORMAT;
     }
@@ -795,8 +795,8 @@ armoredpass:
             goto finish;
         }
 
-        has_secret |= (ptag == PGP_PTAG_CT_SECRET_KEY);
-        has_public |= (ptag == PGP_PTAG_CT_PUBLIC_KEY);
+        has_secret |= (ptag == PGP_PKT_SECRET_KEY);
+        has_public |= (ptag == PGP_PKT_PUBLIC_KEY);
     }
 
     /* file may have multiple armored keys */
@@ -867,7 +867,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key)
 
     /* user ids/attrs with signatures */
     while ((ptag = stream_pkt_type(src))) {
-        if ((ptag != PGP_PTAG_CT_USER_ID) && (ptag != PGP_PTAG_CT_USER_ATTR)) {
+        if ((ptag != PGP_PKT_USER_ID) && (ptag != PGP_PKT_USER_ATTR)) {
             break;
         }
 

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -268,7 +268,7 @@ get_pkt_len(uint8_t *hdr)
 }
 
 bool
-init_packet_body(pgp_packet_body_t *body, int tag)
+init_packet_body(pgp_packet_body_t *body, pgp_pkt_type_t tag)
 {
     body->data = (uint8_t *) malloc(16);
     if (!body->data) {
@@ -406,7 +406,7 @@ add_packet_body_subpackets(pgp_packet_body_t *body, const pgp_signature_t *sig, 
     uint8_t           splen[6];
     bool              res;
 
-    if (!init_packet_body(&spbody, 0)) {
+    if (!init_packet_body(&spbody, PGP_PKT_RESERVED)) {
         return false;
     }
 
@@ -654,9 +654,11 @@ stream_read_packet_body(pgp_source_t *src, pgp_packet_body_t *body)
 
     body->hdr_len = len;
 
-    if ((body->tag = get_packet_type(body->hdr[0])) < 0) {
+    int ptag = get_packet_type(body->hdr[0]);
+    if (ptag < 0) {
         return RNP_ERROR_BAD_FORMAT;
     }
+    body->tag = (pgp_pkt_type_t) ptag;
 
     len = stream_read_pkt_len(src);
     if (len <= 0) {
@@ -1863,7 +1865,7 @@ key_fill_hashed_data(pgp_key_pkt_t *key)
         return false;
     }
 
-    if (!init_packet_body(&hbody, 0)) {
+    if (!init_packet_body(&hbody, PGP_PKT_RESERVED)) {
         RNP_LOG("allocation failed");
         return false;
     }

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -622,7 +622,7 @@ stream_peek_packet_hdr(pgp_source_t *src, pgp_packet_hdr_t *hdr)
     }
 
     hdr->hdr_len = hlen;
-    hdr->tag = (pgp_content_enum) get_packet_type(hdr->hdr[0]);
+    hdr->tag = (pgp_pkt_type_t) get_packet_type(hdr->hdr[0]);
 
     if (stream_partial_pkt_len(src)) {
         hdr->partial = true;
@@ -796,7 +796,7 @@ stream_write_sk_sesskey(pgp_sk_sesskey_t *skey, pgp_dest_t *dst)
     pgp_packet_body_t pktbody;
     bool              res;
 
-    if (!init_packet_body(&pktbody, PGP_PTAG_CT_SK_SESSION_KEY)) {
+    if (!init_packet_body(&pktbody, PGP_PKT_SK_SESSION_KEY)) {
         return false;
     }
 
@@ -849,7 +849,7 @@ stream_write_pk_sesskey(pgp_pk_sesskey_t *pkey, pgp_dest_t *dst)
     pgp_packet_body_t pktbody;
     bool              res;
 
-    if (!init_packet_body(&pktbody, PGP_PTAG_CT_PK_SESSION_KEY)) {
+    if (!init_packet_body(&pktbody, PGP_PKT_PK_SESSION_KEY)) {
         return false;
     }
 
@@ -896,7 +896,7 @@ stream_write_one_pass(pgp_one_pass_sig_t *onepass, pgp_dest_t *dst)
     pgp_packet_body_t pktbody;
     bool              res;
 
-    if (!init_packet_body(&pktbody, PGP_PTAG_CT_1_PASS_SIG)) {
+    if (!init_packet_body(&pktbody, PGP_PKT_ONE_PASS_SIG)) {
         return false;
     }
 
@@ -927,7 +927,7 @@ stream_write_signature(const pgp_signature_t *sig, pgp_dest_t *dst)
         return false;
     }
 
-    if (!init_packet_body(&pktbody, PGP_PTAG_CT_SIGNATURE)) {
+    if (!init_packet_body(&pktbody, PGP_PKT_SIGNATURE)) {
         RNP_LOG("allocation failed");
         return false;
     }
@@ -986,7 +986,7 @@ stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey)
     pgp_packet_body_t pkt = {};
     rnp_result_t      res = RNP_ERROR_BAD_FORMAT;
 
-    if ((ptag = stream_pkt_type(src)) != PGP_PTAG_CT_SK_SESSION_KEY) {
+    if ((ptag = stream_pkt_type(src)) != PGP_PKT_SK_SESSION_KEY) {
         RNP_LOG("wrong sk ptag: %d", ptag);
         return RNP_ERROR_BAD_FORMAT;
     }
@@ -1091,7 +1091,7 @@ stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_t *pkey)
     rnp_result_t      res = RNP_ERROR_BAD_FORMAT;
     int               ptag;
 
-    if ((ptag = stream_pkt_type(src)) != PGP_PTAG_CT_PK_SESSION_KEY) {
+    if ((ptag = stream_pkt_type(src)) != PGP_PKT_PK_SESSION_KEY) {
         RNP_LOG("wrong pk ptag: %d", ptag);
         return RNP_ERROR_BAD_FORMAT;
     }
@@ -1677,7 +1677,7 @@ stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig)
     pgp_packet_body_t pkt = {};
     rnp_result_t      res = RNP_ERROR_BAD_FORMAT;
 
-    if ((ptag = stream_pkt_type(src)) != PGP_PTAG_CT_SIGNATURE) {
+    if ((ptag = stream_pkt_type(src)) != PGP_PKT_SIGNATURE) {
         RNP_LOG("wrong signature ptag: %d", ptag);
         return RNP_ERROR_BAD_FORMAT;
     }
@@ -1789,10 +1789,10 @@ bool
 is_key_pkt(int tag)
 {
     switch (tag) {
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
-    case PGP_PTAG_CT_SECRET_KEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
+    case PGP_PKT_PUBLIC_KEY:
+    case PGP_PKT_PUBLIC_SUBKEY:
+    case PGP_PKT_SECRET_KEY:
+    case PGP_PKT_SECRET_SUBKEY:
         return true;
     default:
         return false;
@@ -1802,21 +1802,21 @@ is_key_pkt(int tag)
 bool
 is_subkey_pkt(int tag)
 {
-    return (tag == PGP_PTAG_CT_PUBLIC_SUBKEY) || (tag == PGP_PTAG_CT_SECRET_SUBKEY);
+    return (tag == PGP_PKT_PUBLIC_SUBKEY) || (tag == PGP_PKT_SECRET_SUBKEY);
 }
 
 bool
 is_primary_key_pkt(int tag)
 {
-    return (tag == PGP_PTAG_CT_PUBLIC_KEY) || (tag == PGP_PTAG_CT_SECRET_KEY);
+    return (tag == PGP_PKT_PUBLIC_KEY) || (tag == PGP_PKT_SECRET_KEY);
 }
 
 bool
 is_public_key_pkt(int tag)
 {
     switch (tag) {
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
+    case PGP_PKT_PUBLIC_KEY:
+    case PGP_PKT_PUBLIC_SUBKEY:
         return true;
     default:
         return false;
@@ -1827,8 +1827,8 @@ bool
 is_secret_key_pkt(int tag)
 {
     switch (tag) {
-    case PGP_PTAG_CT_SECRET_KEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
+    case PGP_PKT_SECRET_KEY:
+    case PGP_PKT_SECRET_SUBKEY:
         return true;
     default:
         return false;
@@ -2223,10 +2223,10 @@ copy_key_pkt(pgp_key_pkt_t *dst, const pgp_key_pkt_t *src, bool pubonly)
         return true;
     }
 
-    if (src->tag == PGP_PTAG_CT_SECRET_KEY) {
-        dst->tag = PGP_PTAG_CT_PUBLIC_KEY;
+    if (src->tag == PGP_PKT_SECRET_KEY) {
+        dst->tag = PGP_PKT_PUBLIC_KEY;
     } else {
-        dst->tag = PGP_PTAG_CT_PUBLIC_SUBKEY;
+        dst->tag = PGP_PKT_PUBLIC_SUBKEY;
     }
 
     forget_secret_key_fields(&dst->material);
@@ -2285,7 +2285,7 @@ stream_write_userid(const pgp_userid_pkt_t *userid, pgp_dest_t *dst)
     pgp_packet_body_t pktbody;
     bool              res;
 
-    if ((userid->tag != PGP_PTAG_CT_USER_ID) && (userid->tag != PGP_PTAG_CT_USER_ATTR)) {
+    if ((userid->tag != PGP_PKT_USER_ID) && (userid->tag != PGP_PKT_USER_ATTR)) {
         RNP_LOG("wrong userid tag");
         return false;
     }
@@ -2321,7 +2321,7 @@ stream_parse_userid(pgp_source_t *src, pgp_userid_pkt_t *userid)
 
     /* check the tag */
     tag = stream_pkt_type(src);
-    if ((tag != PGP_PTAG_CT_USER_ID) && (tag != PGP_PTAG_CT_USER_ATTR)) {
+    if ((tag != PGP_PKT_USER_ID) && (tag != PGP_PKT_USER_ATTR)) {
         RNP_LOG("wrong userid tag: %d", tag);
         return RNP_ERROR_BAD_FORMAT;
     }

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -37,12 +37,12 @@
 #define PGP_MAX_PKT_SIZE 0x100000
 
 typedef struct pgp_packet_hdr_t {
-    pgp_content_enum tag;
-    uint8_t          hdr[PGP_MAX_HEADER_SIZE];
-    size_t           hdr_len;
-    size_t           pkt_len;
-    bool             partial;
-    bool             indeterminate;
+    pgp_pkt_type_t tag;
+    uint8_t        hdr[PGP_MAX_HEADER_SIZE];
+    size_t         hdr_len;
+    size_t         pkt_len;
+    bool           partial;
+    bool           indeterminate;
 } pgp_packet_hdr_t;
 
 /* structure for convenient writing or parsing of non-stream packets */

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -47,10 +47,10 @@ typedef struct pgp_packet_hdr_t {
 
 /* structure for convenient writing or parsing of non-stream packets */
 typedef struct pgp_packet_body_t {
-    int      tag;       /* packet tag */
-    uint8_t *data;      /* packet body data */
-    size_t   len;       /* length of the data */
-    size_t   allocated; /* allocated bytes in data */
+    pgp_pkt_type_t tag;       /* packet tag */
+    uint8_t *      data;      /* packet body data */
+    size_t         len;       /* length of the data */
+    size_t         allocated; /* allocated bytes in data */
 
     /* fields below are filled only for parsed packet */
     uint8_t hdr[PGP_MAX_HEADER_SIZE]; /* packet header bytes */
@@ -120,7 +120,7 @@ ssize_t stream_read_partial_chunk_len(pgp_source_t *src, bool *last);
  *  @param tag tag of the packet
  *  @return true on success or false otherwise
  **/
-bool init_packet_body(pgp_packet_body_t *body, int tag);
+bool init_packet_body(pgp_packet_body_t *body, pgp_pkt_type_t tag);
 
 /** @brief append chunk of the data to packet body
  *  @param body pointer to the structure, initialized with init_packet_body

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2018-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -899,10 +899,10 @@ signature_hash_userid(const pgp_userid_pkt_t *uid, pgp_hash_t *hash, pgp_version
     }
 
     switch (uid->tag) {
-    case PGP_PTAG_CT_USER_ID:
+    case PGP_PKT_USER_ID:
         hdr[0] = 0xB4;
         break;
-    case PGP_PTAG_CT_USER_ATTR:
+    case PGP_PKT_USER_ATTR:
         hdr[0] = 0xD1;
         break;
     default:
@@ -1309,7 +1309,7 @@ armoredpass:
     while (!src_eof(src) && !src_error(src)) {
         int ptag = stream_pkt_type(src);
 
-        if (ptag != PGP_PTAG_CT_SIGNATURE) {
+        if (ptag != PGP_PKT_SIGNATURE) {
             RNP_LOG("wrong signature tag: %d", ptag);
             ret = RNP_ERROR_BAD_FORMAT;
             goto finish;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -832,7 +832,7 @@ signature_fill_hashed_data(pgp_signature_t *sig)
         return false;
     }
 
-    if (!init_packet_body(&hbody, 0)) {
+    if (!init_packet_body(&hbody, PGP_PKT_RESERVED)) {
         RNP_LOG("allocation failed");
         return false;
     }
@@ -863,7 +863,7 @@ bool
 signature_hash_key(const pgp_key_pkt_t *key, pgp_hash_t *hash)
 {
     uint8_t       hdr[3] = {0x99, 0x00, 0x00};
-    pgp_key_pkt_t keycp = {0};
+    pgp_key_pkt_t keycp = {};
     bool          res = false;
 
     if (!key || !hash) {

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -602,7 +602,7 @@ encrypted_sesk_set_ad(pgp_crypt_t *crypt, pgp_sk_sesskey_t *skey)
 {
     uint8_t ad_data[4];
 
-    ad_data[0] = PGP_PTAG_CT_SK_SESSION_KEY | PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT;
+    ad_data[0] = PGP_PKT_SK_SESSION_KEY | PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT;
     ad_data[1] = skey->version;
     ad_data[2] = skey->alg;
     ad_data[3] = skey->aalg;
@@ -778,7 +778,7 @@ encrypted_start_aead(pgp_dest_encrypted_param_t *param, uint8_t *enckey)
     param->chunkout = 0;
 
     /* fill additional/authenticated data */
-    param->ad[0] = PGP_PTAG_CT_AEAD_ENCRYPTED | PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT;
+    param->ad[0] = PGP_PKT_AEAD_ENCRYPTED | PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT;
     memcpy(param->ad + 1, hdr, 4);
     memset(param->ad + 5, 0, 8);
     param->adlen = 13;
@@ -883,9 +883,9 @@ init_encrypted_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *wr
     param->pkt.partial = true;
     param->pkt.indeterminate = false;
     if (param->aead) {
-        param->pkt.tag = PGP_PTAG_CT_AEAD_ENCRYPTED;
+        param->pkt.tag = PGP_PKT_AEAD_ENCRYPTED;
     } else {
-        param->pkt.tag = param->has_mdc ? PGP_PTAG_CT_SE_IP_DATA : PGP_PTAG_CT_SE_DATA;
+        param->pkt.tag = param->has_mdc ? PGP_PKT_SE_IP_DATA : PGP_PKT_SE_DATA;
     }
 
     /* initializing partial data length writer */
@@ -1532,7 +1532,7 @@ init_compressed_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *w
     param->alg = (pgp_compression_type_t) handler->ctx->zalg;
     param->pkt.partial = true;
     param->pkt.indeterminate = false;
-    param->pkt.tag = PGP_PTAG_CT_COMPRESSED;
+    param->pkt.tag = PGP_PKT_COMPRESSED;
 
     /* initializing partial length or indeterminate packet, writing header */
     if (!init_streamed_packet(&param->pkt, writedst)) {
@@ -1642,7 +1642,7 @@ init_literal_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *writ
     dst->type = PGP_STREAM_LITERAL;
     param->partial = true;
     param->indeterminate = false;
-    param->tag = PGP_PTAG_CT_LITDATA;
+    param->tag = PGP_PKT_LITDATA;
 
     /* initializing partial length or indeterminate packet, writing header */
     if (!init_streamed_packet(param, writedst)) {

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -5471,8 +5471,7 @@ shrink_len_2_to_1(const std::vector<uint8_t> &src)
     std::vector<uint8_t> dst = std::vector<uint8_t>();
     dst.reserve(src.size() - 1);
     dst.insert(dst.end(),
-               PGP_PTAG_ALWAYS_SET |
-                 (PGP_PTAG_CT_PUBLIC_KEY << PGP_PTAG_OF_CONTENT_TAG_SHIFT) |
+               PGP_PTAG_ALWAYS_SET | (PGP_PKT_PUBLIC_KEY << PGP_PTAG_OF_CONTENT_TAG_SHIFT) |
                  PGP_PTAG_OLD_LEN_1);
     // make sure the most significant octet of 2-octet length is actually zero
     assert_int_equal(src[1], 0);
@@ -5544,7 +5543,7 @@ TEST_F(rnp_tests, test_ffi_import_keys_check_pktlen)
     // PGP_PTAG_OLD_LEN_2
     assert_true(keyring.size() >= 5);
     uint8_t expected_tag = PGP_PTAG_ALWAYS_SET |
-                           (PGP_PTAG_CT_PUBLIC_KEY << PGP_PTAG_OF_CONTENT_TAG_SHIFT) |
+                           (PGP_PKT_PUBLIC_KEY << PGP_PTAG_OF_CONTENT_TAG_SHIFT) |
                            PGP_PTAG_OLD_LEN_2;
     assert_int_equal(expected_tag, 0x99);
     assert_int_equal(keyring[0], expected_tag);
@@ -6241,12 +6240,12 @@ TEST_F(rnp_tests, test_ffi_aead_params)
     assert_true(json_object_is_type(jso, json_type_array));
     /* check the symmetric-key encrypted session key packet */
     json_object *pkt = json_object_array_get_idx(jso, 0);
-    assert_true(check_json_pkt_type(pkt, PGP_PTAG_CT_SK_SESSION_KEY));
+    assert_true(check_json_pkt_type(pkt, PGP_PKT_SK_SESSION_KEY));
     assert_true(check_json_field_int(pkt, "version", 5));
     assert_true(check_json_field_str(pkt, "aead algorithm.str", "OCB"));
     /* check the aead-encrypted packet */
     pkt = json_object_array_get_idx(jso, 1);
-    assert_true(check_json_pkt_type(pkt, PGP_PTAG_CT_AEAD_ENCRYPTED));
+    assert_true(check_json_pkt_type(pkt, PGP_PKT_AEAD_ENCRYPTED));
     assert_true(check_json_field_int(pkt, "version", 1));
     assert_true(check_json_field_str(pkt, "aead algorithm.str", "OCB"));
     assert_true(check_json_field_int(pkt, "chunk size", 10));

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -963,8 +963,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_int_not_equal(psig->material.rsa.s.len, 0);
         assert_int_not_equal(ssig->material.rsa.s.len, 0);
         // make sure we're targeting the right packet
-        assert_int_equal(PGP_PTAG_CT_SIGNATURE, pgp_key_get_rawpacket(&pub, 2)->tag);
-        assert_int_equal(PGP_PTAG_CT_SIGNATURE, pgp_key_get_rawpacket(&sec, 2)->tag);
+        assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_rawpacket(&pub, 2)->tag);
+        assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_rawpacket(&sec, 2)->tag);
 
         // validate the userid self-sig
 
@@ -1012,7 +1012,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         ssig->hashed_data[32] ^= 0xff;
         // ensure validation fails with incorrect uid
         pgp_userid_pkt_t uid = {
-          .tag = PGP_PTAG_CT_USER_ID, .uid = (uint8_t *) "fake", .uid_len = 4};
+          .tag = PGP_PKT_USER_ID, .uid = (uint8_t *) "fake", .uid_len = 4};
         assert_rnp_failure(signature_validate_certification(
           psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         assert_rnp_failure(signature_validate_certification(
@@ -1074,8 +1074,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_int_not_equal(psig->material.rsa.s.len, 0);
         assert_int_not_equal(ssig->material.rsa.s.len, 0);
         // make sure we're targeting the right packet
-        assert_int_equal(PGP_PTAG_CT_SIGNATURE, pgp_key_get_rawpacket(&pub, 1)->tag);
-        assert_int_equal(PGP_PTAG_CT_SIGNATURE, pgp_key_get_rawpacket(&sec, 1)->tag);
+        assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_rawpacket(&pub, 1)->tag);
+        assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_rawpacket(&sec, 1)->tag);
         // validate the binding sig
         assert_rnp_success(signature_validate_binding(
           psig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&pub)));

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -54,7 +54,7 @@ TEST_F(rnp_tests, test_key_store_search)
         for (size_t n = 0; n < testdata[i].count; n++) {
             pgp_key_t key = {0};
 
-            key.pkt.tag = PGP_PTAG_CT_PUBLIC_KEY;
+            key.pkt.tag = PGP_PKT_PUBLIC_KEY;
             key.pkt.version = PGP_V4;
 
             // set the keyid

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -416,11 +416,11 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(pgp_key_is_primary_key(key));
     assert_true(pgp_key_is_secret(key));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
 
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", keyid, sizeof(keyid)));
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
@@ -428,8 +428,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(pgp_key_is_subkey(key));
     assert_true(pgp_key_is_secret(key));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_SIGNATURE);
 
     assert_true(rnp_hex_decode("16CD16F267CCDD4F", keyid, sizeof(keyid)));
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
@@ -437,8 +437,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(pgp_key_is_subkey(key));
     assert_true(pgp_key_is_secret(key));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_SIGNATURE);
 
     /* both user ids should be present */
     assert_non_null(rnp_tests_key_search(key_store, "key-merge-uid-1"));
@@ -510,7 +510,7 @@ TEST_F(rnp_tests, test_load_merge)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_false(key->valid);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 1);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
 
     /* load key + user id 1 without sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-1-no-sigs.pgp"));
@@ -521,8 +521,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_false(key->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 1);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
 
     /* load key + user id 1 with sigs */
@@ -534,9 +534,9 @@ TEST_F(rnp_tests, test_load_merge)
     assert_true(key->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 1);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 3);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
 
     /* load key + user id 2 with sigs */
@@ -550,11 +550,11 @@ TEST_F(rnp_tests, test_load_merge)
     assert_true(key->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2"));
 
@@ -571,14 +571,14 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
     assert_true(check_subkey_grip(key, skey1, 0));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 1);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
 
     /* load just subkey 1 but with signature */
     assert_true(load_transferable_subkey(&tskey, MERGE_PATH "key-pub-no-key-subkey-1.pgp"));
@@ -595,15 +595,15 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
     assert_true(check_subkey_grip(key, skey1, 0));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PKT_SIGNATURE);
 
     /* load key + subkey 2 with signature */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-subkey-2.pgp"));
@@ -623,19 +623,19 @@ TEST_F(rnp_tests, test_load_merge)
     assert_true(check_subkey_grip(key, skey1, 0));
     assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PKT_SIGNATURE);
 
     /* load secret key & subkeys */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-sec-no-uid-no-sigs.pgp"));
@@ -655,19 +655,19 @@ TEST_F(rnp_tests, test_load_merge)
     assert_true(check_subkey_grip(key, skey1, 0));
     assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PKT_SIGNATURE);
 
     assert_true(pgp_key_unlock(key, &provider));
     assert_true(pgp_key_unlock(skey1, &provider));
@@ -692,19 +692,19 @@ TEST_F(rnp_tests, test_load_merge)
     assert_true(check_subkey_grip(key, skey1, 0));
     assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PKT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PKT_SIGNATURE);
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2"));
 
@@ -740,7 +740,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(
       memcmp(pgp_key_get_subkey_grip(&keycp, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
-    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PKT_SECRET_KEY);
     pgp_key_free_data(&keycp);
 
     /* copy the public part */
@@ -750,7 +750,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_grip(&keycp, skey1, 0));
     assert_true(check_subkey_grip(&keycp, skey2, 1));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
-    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PKT_PUBLIC_KEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
@@ -762,7 +762,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_grip(key, &keycp, 0));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_keyid(&keycp), sub1id, PGP_KEY_ID_SIZE));
-    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
@@ -774,7 +774,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_grip(key, &keycp, 1));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_keyid(&keycp), sub2id, PGP_KEY_ID_SIZE));
-    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
@@ -819,7 +819,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tkey.subkeys), 0);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 0);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 userid */
@@ -838,8 +838,8 @@ TEST_F(rnp_tests, test_key_import)
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 0);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 userid + signature */
@@ -855,11 +855,11 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tkey.subkeys), 0);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 1);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 subkey */
@@ -875,14 +875,14 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tkey.subkeys), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 1);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
     transferable_key_destroy(&tkey);
 
     /* import secret key with 1 uid and 1 subkey */
@@ -898,29 +898,29 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tkey.subkeys), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 1);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
     transferable_key_destroy(&tkey);
 
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 1);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_SECRET_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
     assert_rnp_success(decrypt_secret_key(&tkey.key, "password"));
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_SECRET_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
     transferable_key_destroy(&tkey);
 
@@ -937,44 +937,44 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tkey.subkeys), 2);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 2);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_PUBLIC_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_next((list_item *) tuid));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_next((list_item *) tskey));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
     transferable_key_destroy(&tkey);
 
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 2);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(list_length(tkey.userids), 2);
-    assert_int_equal(tkey.key.tag, PGP_PTAG_CT_SECRET_KEY);
+    assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
     assert_rnp_success(decrypt_secret_key(&tkey.key, "password"));
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tuid = (pgp_transferable_userid_t *) list_next((list_item *) tuid));
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
-    assert_int_equal(tuid->uid.tag, PGP_PTAG_CT_USER_ID);
+    assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_SECRET_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
     assert_non_null(tskey = (pgp_transferable_subkey_t *) list_next((list_item *) tskey));
     assert_int_equal(list_length(tskey->signatures), 1);
-    assert_int_equal(tskey->subkey.tag, PGP_PTAG_CT_SECRET_SUBKEY);
+    assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
     transferable_key_destroy(&tkey);
 
@@ -1002,8 +1002,8 @@ TEST_F(rnp_tests, test_load_subkey)
     assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_false(skey1->valid);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PKT_SIGNATURE);
     assert_null(pgp_key_get_primary_grip(skey1));
 
     /* load second subkey, without signature */
@@ -1012,7 +1012,7 @@ TEST_F(rnp_tests, test_load_subkey)
     assert_non_null(skey2 = rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_false(skey2->valid);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 1);
-    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
+    assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_primary_grip(skey2));
     assert_false(skey1 == skey2);
 
@@ -1022,9 +1022,9 @@ TEST_F(rnp_tests, test_load_subkey)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 3);
-    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
-    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
+    assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PKT_USER_ID);
+    assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PKT_SIGNATURE);
     assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_non_null(pgp_key_get_primary_grip(skey1));

--- a/src/tests/partial-length.cpp
+++ b/src/tests/partial-length.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -209,12 +209,12 @@ TEST_F(rnp_tests, test_partial_length_first_packet_length)
     // skip first packet (one-pass signature)
     pgp_packet_body_t body;
     assert_rnp_success(stream_read_packet_body(&src, &body));
-    assert_int_equal(body.tag, PGP_PTAG_CT_1_PASS_SIG);
+    assert_int_equal(body.tag, PGP_PKT_ONE_PASS_SIG);
     free_packet_body(&body);
     // checking next packet header (should be partial length literal data)
     uint8_t flags = 0;
     assert_int_equal(src_read(&src, &flags, 1), 1);
-    assert_int_equal(flags, PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT | PGP_PTAG_CT_LITDATA);
+    assert_int_equal(flags, PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT | PGP_PKT_LITDATA);
     // checking length
     bool last = true; // should be reset by stream_read_partial_chunk_len()
     assert_true(stream_read_partial_chunk_len(&src, &last) >=

--- a/src/tests/s2k-iterations.cpp
+++ b/src/tests/s2k-iterations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -66,7 +66,7 @@ test_s2k_iterations_value(rnp_ffi_t ffi,
         assert_true(json_object_is_type(jso, json_type_array));
         // check the symmetric-key encrypted session key packet
         json_object *pkt = json_object_array_get_idx(jso, 0);
-        assert_true(check_json_pkt_type(pkt, PGP_PTAG_CT_SK_SESSION_KEY));
+        assert_true(check_json_pkt_type(pkt, PGP_PKT_SK_SESSION_KEY));
         json_object *s2k = json_object_object_get(pkt, "s2k");
         json_object *fld = NULL;
         assert_true(json_object_object_get_ex(s2k, "iterations", &fld));


### PR DESCRIPTION
This PR fixes #785 by renaming ages old pgp_content_enum to more applicable pgp_pkt_type_t.
Also does some refactoring by using pgp_pkt_type_t instead of int.