### PR TITLE
Add feature to export key revocation.

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -137,13 +137,13 @@ typedef enum {
 #define MDC_PKT_TAG 0xd3
 #define MDC_V1_SIZE 22
 
-enum {
+typedef enum {
     PGP_REVOCATION_NO_REASON = 0,
     PGP_REVOCATION_SUPERSEDED = 1,
     PGP_REVOCATION_COMPROMISED = 2,
     PGP_REVOCATION_RETIRED = 3,
     PGP_REVOCATION_NO_LONGER_VALID = 0x20
-};
+} pgp_revocation_type_t;
 
 /**
  * @brief OpenPGP packet tags. See section 4.3 of RFC4880 for the detailed description.

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -781,6 +781,30 @@ rnp_result_t rnp_op_generate_destroy(rnp_op_generate_t op);
  **/
 rnp_result_t rnp_key_export(rnp_key_handle_t key, rnp_output_t output, uint32_t flags);
 
+/**
+ * @brief Generate and export primary key revocation signature.
+ *        Note: to revoke a key you'll need to import this signature into the keystore or use
+ *        rnp_key_revoke() function.
+ * @param key primary key to be revoked. Must have secret key, otherwise keyrings will be
+ *            searched for the authorized to issue revocation signature secret key. If secret
+ *            key is locked then password will be asked via password provider.
+ * @param output signature contents will be saved here.
+ * @param flags currently must be 0.
+ * @param hash hash algorithm used to calculate signature. Pass NULL for default algorithm
+ *             selection.
+ * @param code reason for revocation code. Possible values: 'no', 'superseded', 'compromised',
+ *             'retired'. May be NULL - then 'no' value will be used.
+ * @param reason textual representation of the reason for revocation. May be NULL or empty
+ *               string.
+ * @return RNP_SUCCESS on success, or any other value on error
+ */
+rnp_result_t rnp_key_export_revocation(rnp_key_handle_t key,
+                                       rnp_output_t     output,
+                                       uint32_t         flags,
+                                       const char *     hash,
+                                       const char *     code,
+                                       const char *     reason);
+
 /** remove a key from keyring(s)
  *  Note: you need to call rnp_save_keys() to write updated keyring(s) out.
  *        Other handles of the same key should not be used after this call.

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -178,7 +178,7 @@ pgp_subsig_free(pgp_subsig_t *subsig)
     free_signature(&subsig->sig);
 }
 
-static void
+void
 revoke_free(pgp_revoke_t *revoke)
 {
     if (!revoke) {

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -265,6 +265,8 @@ size_t pgp_key_get_revoke_count(const pgp_key_t *);
 
 pgp_revoke_t *pgp_key_get_revoke(const pgp_key_t *, size_t);
 
+void revoke_free(pgp_revoke_t *revoke);
+
 pgp_subsig_t *pgp_key_add_subsig(pgp_key_t *);
 
 size_t pgp_key_get_subsig_count(const pgp_key_t *);

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -253,9 +253,9 @@ typedef struct pgp_sig_subpkt_t {
             unsigned    len;
         } signer; /* 5.2.3.22.  Signer's User ID */
         struct {
-            uint8_t     code;
-            const char *str;
-            unsigned    len;
+            pgp_revocation_type_t code;
+            const char *          str;
+            unsigned              len;
         } revocation_reason; /* 5.2.3.23.  Reason for Revocation */
         struct {
             bool mdc;
@@ -348,9 +348,9 @@ typedef struct {
 
 /* user revocation info */
 typedef struct pgp_revoke_t {
-    uint32_t uid;    /* index in uid array */
-    uint8_t  code;   /* revocation code */
-    char *   reason; /* c'mon, spill the beans */
+    uint32_t              uid;    /* index in uid array */
+    pgp_revocation_type_t code;   /* revocation code */
+    char *                reason; /* c'mon, spill the beans */
 } pgp_revoke_t;
 
 typedef struct pgp_user_prefs_t {

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -68,11 +68,11 @@ __RCSID("$NetBSD: keyring.c,v 1.50 2011/06/25 00:37:44 agc Exp $");
 #include "pgp-key.h"
 
 static pgp_map_t ss_rr_code_map[] = {
-  {0x00, "No reason specified"},
-  {0x01, "Key is superseded"},
-  {0x02, "Key material has been compromised"},
-  {0x03, "Key is retired and no longer used"},
-  {0x20, "User ID information is no longer valid"},
+  {PGP_REVOCATION_NO_REASON, "No reason specified"},
+  {PGP_REVOCATION_SUPERSEDED, "Key is superseded"},
+  {PGP_REVOCATION_COMPROMISED, "Key material has been compromised"},
+  {PGP_REVOCATION_RETIRED, "Key is retired and no longer used"},
+  {PGP_REVOCATION_NO_LONGER_VALID, "User ID information is no longer valid"},
   {0x00, NULL}, /* this is the end-of-array marker */
 };
 

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -145,6 +145,7 @@ rnp_key_add_signature(pgp_key_t *key, const pgp_signature_t *sig)
             /* revoke whole key */
             key->revoked = 1;
             revocation = &key->revocation;
+            revoke_free(revocation);
         } else {
             /* revoke the user id */
             if (!(revocation = pgp_key_add_revoke(key))) {

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -98,6 +98,11 @@ pgp_signature_t *transferable_subkey_bind(const pgp_key_pkt_t *             prim
                                           pgp_hash_alg_t                    hash_alg,
                                           const rnp_selfsig_binding_info_t *binding);
 
+pgp_signature_t *transferable_key_revoke(const pgp_key_pkt_t *key,
+                                         const pgp_key_pkt_t *signer,
+                                         pgp_hash_alg_t       hash_alg,
+                                         const pgp_revoke_t * revoke);
+
 void key_sequence_destroy(pgp_key_sequence_t *keys);
 
 rnp_result_t process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t *keys);

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -1382,7 +1382,7 @@ signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
         break;
     case PGP_SIG_SUBPKT_REVOCATION_REASON:
         if ((oklen = subpkt->len >= 1)) {
-            subpkt->fields.revocation_reason.code = subpkt->data[0];
+            subpkt->fields.revocation_reason.code = (pgp_revocation_type_t) subpkt->data[0];
             subpkt->fields.revocation_reason.str = (const char *) &subpkt->data[1];
             subpkt->fields.revocation_reason.len = subpkt->len - 1;
         }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -819,6 +819,26 @@ signature_get_revocation_reason(const pgp_signature_t *sig,
 }
 
 bool
+signature_set_revocation_reason(pgp_signature_t *     sig,
+                                pgp_revocation_type_t code,
+                                const char *          reason)
+{
+    size_t            datalen = 1 + (reason ? strlen(reason) : 0);
+    pgp_sig_subpkt_t *subpkt =
+      signature_add_subpkt(sig, PGP_SIG_SUBPKT_REVOCATION_REASON, datalen, true);
+    if (!subpkt) {
+        return false;
+    }
+
+    subpkt->hashed = 1;
+    subpkt->data[0] = code;
+    if (reason) {
+        memcpy(subpkt->data + 1, reason, strlen(reason));
+    }
+    return signature_parse_subpacket(subpkt);
+}
+
+bool
 signature_fill_hashed_data(pgp_signature_t *sig)
 {
     pgp_packet_body_t hbody;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -792,7 +792,9 @@ signature_has_revocation_reason(const pgp_signature_t *sig)
 }
 
 bool
-signature_get_revocation_reason(const pgp_signature_t *sig, uint8_t *code, char **reason)
+signature_get_revocation_reason(const pgp_signature_t *sig,
+                                pgp_revocation_type_t *code,
+                                char **                reason)
 {
     pgp_sig_subpkt_t *subpkt;
 

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -287,6 +287,10 @@ bool signature_get_revocation_reason(const pgp_signature_t *sig,
                                      pgp_revocation_type_t *code,
                                      char **                reason);
 
+bool signature_set_revocation_reason(pgp_signature_t *     sig,
+                                     pgp_revocation_type_t code,
+                                     const char *          reason);
+
 /**
  * @brief Fill signature's hashed data. This includes all the fields from signature which are
  *        hashed after the previous document or key fields.

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -283,7 +283,9 @@ char *signature_get_key_server(const pgp_signature_t *sig);
 
 bool signature_has_revocation_reason(const pgp_signature_t *sig);
 
-bool signature_get_revocation_reason(const pgp_signature_t *sig, uint8_t *code, char **reason);
+bool signature_get_revocation_reason(const pgp_signature_t *sig,
+                                     pgp_revocation_type_t *code,
+                                     char **                reason);
 
 /**
  * @brief Fill signature's hashed data. This includes all the fields from signature which are

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -72,7 +72,7 @@ void cli_rnp_print_key_info(
   FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);
 bool cli_rnp_set_generate_params(rnp_cfg_t *cfg);
 bool cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username);
-list cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret);
+list cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret, bool subkeys);
 void cli_rnp_keylist_destroy(list *keys);
 bool cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter);
 bool cli_rnp_add_key(const rnp_cfg_t *cfg, cli_rnp_t *rnp);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2019-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -75,6 +75,7 @@ bool cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username);
 list cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret, bool subkeys);
 void cli_rnp_keylist_destroy(list *keys);
 bool cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter);
+bool cli_rnp_export_revocation(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *key);
 bool cli_rnp_add_key(const rnp_cfg_t *cfg, cli_rnp_t *rnp);
 bool cli_rnp_dump_file(const rnp_cfg_t *cfg);
 bool cli_rnp_armor_file(const rnp_cfg_t *cfg);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -77,14 +77,16 @@
 #define CFG_AEAD "aead"                 /* if nonzero then AEAD enryption mode, int */
 #define CFG_AEAD_CHUNK "aead_chunk"     /* AEAD chunk size bits, int from 0 to 56 */
 #define CFG_KEYSTORE_DISABLED \
-    "disable_keystore"            /* indicates wether keystore must be initialized */
-#define CFG_FORCE "force"         /* force command to succeed operation */
-#define CFG_SECRET "secret"       /* indicates operation on secret key */
-#define CFG_WITH_SIGS "with-sigs" /* list keys with signatures */
-#define CFG_JSON "json"           /* list packets with JSON output */
-#define CFG_GRIPS "grips"         /* dump grips when dumping key packets */
-#define CFG_MPIS "mpis"           /* dump MPI values when dumping packets */
-#define CFG_RAW "raw"             /* dump raw packet contents */
+    "disable_keystore"              /* indicates wether keystore must be initialized */
+#define CFG_FORCE "force"           /* force command to succeed operation */
+#define CFG_SECRET "secret"         /* indicates operation on secret key */
+#define CFG_WITH_SIGS "with-sigs"   /* list keys with signatures */
+#define CFG_JSON "json"             /* list packets with JSON output */
+#define CFG_GRIPS "grips"           /* dump grips when dumping key packets */
+#define CFG_MPIS "mpis"             /* dump MPI values when dumping packets */
+#define CFG_RAW "raw"               /* dump raw packet contents */
+#define CFG_REV_TYPE "rev-type"     /* revocation reason code */
+#define CFG_REV_REASON "rev-reason" /* revocation reason human-readable string */
 
 /* rnp keyring setup variables */
 #define CFG_KR_PUB_FORMAT "kr-pub-format"

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -117,7 +117,7 @@ print_keys_info(rnp_cfg_t *cfg, cli_rnp_t *rnp, FILE *fp, const char *filter)
     int  keyc;
     bool psecret = rnp_cfg_getbool(cfg, CFG_SECRET);
 
-    keys = cli_rnp_get_keylist(rnp, filter, psecret);
+    keys = cli_rnp_get_keylist(rnp, filter, psecret, true);
     if (!keys) {
         fprintf(fp, "Key(s) not found.\n");
         return false;

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -15,6 +15,7 @@ typedef enum {
     CMD_IMPORT_KEYS,
     CMD_IMPORT_SIGS,
     CMD_GENERATE_KEY,
+    CMD_EXPORT_REV,
     CMD_VERSION,
     CMD_HELP,
 
@@ -37,6 +38,8 @@ typedef enum {
     OPT_S2K_ITER,
     OPT_S2K_MSEC,
     OPT_WITH_SIGS,
+    OPT_REV_TYPE,
+    OPT_REV_REASON,
 
     /* debug */
     OPT_DEBUG

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -99,8 +99,8 @@ def run_proc_windows(proc, params, stdin=None):
     logging.debug('Working directory: ' + os.getcwd())
 
     exe = os.path.basename(proc)
-    # Not sure why but empty string is not passed to underlying spawnv call
-    params = map(lambda st: st if st else '""', [exe] + params)
+    # We need to escape empty parameters/ones with spaces with quotes
+    params = map(lambda st: st if (st and not ' ' in st) else '"%s"' % st, [exe] + params)
     sys.stdout.flush()
 
     stdin_path = os.path.join(WORKDIR, 'stdin.txt')

--- a/src/tests/exportkey.cpp
+++ b/src/tests/exportkey.cpp
@@ -54,7 +54,7 @@ TEST_F(rnp_tests, rnpkeys_exportkey_verifyUserId)
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
 
-    list keys = cli_rnp_get_keylist(&rnp, getenv_logname(), false);
+    list keys = cli_rnp_get_keylist(&rnp, getenv_logname(), false, true);
     assert_int_equal(list_length(keys), 2);
     cli_rnp_keylist_destroy(&keys);
 

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -74,7 +74,7 @@ generate_test_key(const char *keystore, const char *userid, const char *hash, co
         goto done;
     }
 
-    keys = cli_rnp_get_keylist(&rnp, userid, false);
+    keys = cli_rnp_get_keylist(&rnp, userid, false, true);
     if (list_length(keys) != 2) {
         goto done;
     }

--- a/src/tests/issues/1030.cpp
+++ b/src/tests/issues/1030.cpp
@@ -50,11 +50,11 @@ test_issue_1030(const char *keystore)
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
 
-    keys = cli_rnp_get_keylist(&rnp, userid, false);
+    keys = cli_rnp_get_keylist(&rnp, userid, false, true);
     assert_int_equal(list_length(keys), 2);
     cli_rnp_keylist_destroy(&keys);
 
-    keys = cli_rnp_get_keylist(&rnp, userid, true);
+    keys = cli_rnp_get_keylist(&rnp, userid, true, true);
     assert_int_equal(list_length(keys), 2);
     for (list_item *item = list_front(keys); item; item = list_next(item)) {
         rnp_key_handle_t key = *((rnp_key_handle_t *) item);

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -271,6 +271,8 @@ void test_ffi_op_verify_sig_count(void **state);
 
 void test_ffi_import_signatures(void **state);
 
+void test_ffi_export_revocation(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -429,12 +429,12 @@ TEST_F(rnp_tests, test_stream_signatures_revoked_key)
     assert_rnp_success(stream_parse_signature(&sigsrc, &sig));
     src_close(&sigsrc);
     /* get revocation */
-    uint8_t code = 0;
-    char *  reason = NULL;
+    pgp_revocation_type_t code = PGP_REVOCATION_NO_REASON;
+    char *                reason = NULL;
     assert_true(signature_get_revocation_reason(&sig, &code, &reason));
     assert_non_null(reason);
     /* check revocation */
-    assert_int_equal(code, 3);
+    assert_int_equal(code, PGP_REVOCATION_RETIRED);
     assert_string_equal(reason, "For testing!");
     /* cleanup */
     free(reason);


### PR DESCRIPTION
This PR is part of work on key revocation(s) (issue #1005), and fixes #1007 
It implements low-level functionality to generate key revocation certificate, FFI function to export such certificate and rnpkeys CLI command `--export-rev` and options `--rev-type, --rev-reason`  to work with this.