### PR TITLE
Fix secret key locking during signature import.

### DIFF
--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -330,6 +330,15 @@ rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *prim
         goto done;
     }
 
+    /* check whether key was unlocked and assign secret key data */
+    if (pgp_key_is_secret(dst) && !pgp_key_is_locked(dst)) {
+        /* we may do thing below only because key material is opaque structure without
+         * pointers! */
+        tmpkey.pkt.material = dst->pkt.material;
+    } else if (pgp_key_is_secret(src) && !pgp_key_is_locked(src)) {
+        tmpkey.pkt.material = src->pkt.material;
+    }
+
     pgp_key_free_data(dst);
     *dst = tmpkey;
     res = true;
@@ -388,6 +397,14 @@ rnp_key_store_merge_key(pgp_key_t *dst, const pgp_key_t *src)
         if (!pgp_key_add_subkey_grip(&tmpkey, (uint8_t *) li)) {
             RNP_LOG("failed to add subkey grip");
         }
+    }
+    /* check whether key was unlocked and assign secret key data */
+    if (pgp_key_is_secret(dst) && !pgp_key_is_locked(dst)) {
+        /* we may do thing below only because key material is opaque structure without
+         * pointers! */
+        tmpkey.pkt.material = dst->pkt.material;
+    } else if (pgp_key_is_secret(src) && !pgp_key_is_locked(src)) {
+        tmpkey.pkt.material = src->pkt.material;
     }
 
     pgp_key_free_data(dst);

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -273,6 +273,8 @@ void test_ffi_import_signatures(void **state);
 
 void test_ffi_export_revocation(void **state);
 
+void test_ffi_secret_sig_import(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
Hit this while was working on subkey revocation: unlocked secret key is locked when some signatures/userids/subkeys are attached to it.
This PR fixes this issue.