### PR TITLE
Add FFI function and CLI command to revoke key and subkey.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -171,6 +171,10 @@ pgp_key_t *rnp_key_store_import_key(rnp_key_store_t *,
  */
 pgp_key_t *rnp_key_store_get_signer_key(rnp_key_store_t *store, const pgp_signature_t *sig);
 
+pgp_sig_import_status_t rnp_key_store_import_key_signature(rnp_key_store_t *      keyring,
+                                                           pgp_key_t *            key,
+                                                           const pgp_signature_t *sig);
+
 /**
  * @brief Import revocation or direct-key signature to the keyring.
  *

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -823,6 +823,27 @@ rnp_result_t rnp_key_export_revocation(rnp_key_handle_t key,
                                        const char *     code,
                                        const char *     reason);
 
+/**
+ * @brief revoke a key or subkey by generating and adding revocation signature.
+ * @param key key or subkey to be revoked. For primary key must have secret key, otherwise
+ *            keyrings will be searched for the authorized to issue revocation signatures
+ *            secret key. For subkey keyrings must have primary secret key.
+ *            If secret key is locked then password will be asked via password provider.
+ * @param flags currently must be 0.
+ * @param hash hash algorithm used to calculate signature. Pass NULL for default algorithm
+ *             selection.
+ * @param code reason for revocation code. Possible values: 'no', 'superseded', 'compromised',
+ *             'retired'. May be NULL - then 'no' value will be used.
+ * @param reason textual representation of the reason for revocation. May be NULL or empty
+ *               string.
+ * @return RNP_SUCCESS on success, or any other value on error
+ */
+rnp_result_t rnp_key_revoke(rnp_key_handle_t key,
+                            uint32_t         flags,
+                            const char *     hash,
+                            const char *     code,
+                            const char *     reason);
+
 /** remove a key from keyring(s)
  *  Note: you need to call rnp_save_keys() to write updated keyring(s) out.
  *        Other handles of the same key should not be used after this call.

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -588,43 +588,97 @@ rnp_key_store_get_signer_key(rnp_key_store_t *store, const pgp_signature_t *sig)
     return NULL;
 }
 
+static pgp_sig_import_status_t
+rnp_key_store_import_subkey_signature(rnp_key_store_t *      keyring,
+                                      pgp_key_t *            key,
+                                      const pgp_signature_t *sig)
+{
+    pgp_sig_type_t sigtype = signature_get_type(sig);
+    if ((sigtype != PGP_SIG_SUBKEY) && (sigtype != PGP_SIG_REV_SUBKEY)) {
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+    const uint8_t *prim_grip = pgp_key_get_primary_grip(key);
+    pgp_key_t *    primary = rnp_key_store_get_signer_key(keyring, sig);
+    if (!prim_grip || !primary) {
+        RNP_LOG("No primary grip or primary key");
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN_KEY;
+    }
+    if (memcmp(pgp_key_get_grip(primary), prim_grip, PGP_KEY_GRIP_SIZE)) {
+        RNP_LOG("Wrong subkey signature's signer.");
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+
+    pgp_key_t tmpkey = {};
+    if (!pgp_key_from_pkt(&tmpkey, &key->pkt) || !rnp_key_add_signature(&tmpkey, sig)) {
+        RNP_LOG("Failed to add signature to the key.");
+        pgp_key_free_data(&tmpkey);
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+
+    size_t expackets = pgp_key_get_rawpacket_count(key);
+    if (!(key = rnp_key_store_add_key(keyring, &tmpkey))) {
+        RNP_LOG("Failed to add key with imported sig to the keyring");
+        pgp_key_free_data(&tmpkey);
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+    return (pgp_key_get_rawpacket_count(key) > expackets) ? PGP_SIG_IMPORT_STATUS_NEW :
+                                                            PGP_SIG_IMPORT_STATUS_UNCHANGED;
+}
+
+pgp_sig_import_status_t
+rnp_key_store_import_key_signature(rnp_key_store_t *      keyring,
+                                   pgp_key_t *            key,
+                                   const pgp_signature_t *sig)
+{
+    if (pgp_key_is_subkey(key)) {
+        return rnp_key_store_import_subkey_signature(keyring, key, sig);
+    }
+    pgp_sig_type_t sigtype = signature_get_type(sig);
+    if ((sigtype != PGP_SIG_DIRECT) && (sigtype != PGP_SIG_REV_KEY)) {
+        RNP_LOG("Wrong signature type: %d", (int) sigtype);
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+
+    pgp_key_t tmpkey = {};
+    if (!pgp_key_from_pkt(&tmpkey, &key->pkt) || !rnp_key_add_signature(&tmpkey, sig)) {
+        RNP_LOG("Failed to add signature to the key.");
+        pgp_key_free_data(&tmpkey);
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+
+    size_t expackets = pgp_key_get_rawpacket_count(key);
+    if (!(key = rnp_key_store_add_key(keyring, &tmpkey))) {
+        RNP_LOG("Failed to add key with imported sig to the keyring");
+        pgp_key_free_data(&tmpkey);
+        return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    }
+    return (pgp_key_get_rawpacket_count(key) > expackets) ? PGP_SIG_IMPORT_STATUS_NEW :
+                                                            PGP_SIG_IMPORT_STATUS_UNCHANGED;
+}
+
 pgp_key_t *
 rnp_key_store_import_signature(rnp_key_store_t *        keyring,
                                const pgp_signature_t *  sig,
                                pgp_sig_import_status_t *status)
 {
-    pgp_key_t *             res_key = NULL;
-    pgp_key_t               tmpkey = {};
-    pgp_sig_import_status_t res_status = PGP_SIG_IMPORT_STATUS_UNKNOWN;
-    pgp_sig_type_t          sigtype = signature_get_type(sig);
-    size_t                  expackets = 0;
+    pgp_sig_import_status_t tmp_status = PGP_SIG_IMPORT_STATUS_UNKNOWN;
+    if (!status) {
+        status = &tmp_status;
+    }
+    *status = PGP_SIG_IMPORT_STATUS_UNKNOWN;
 
+    pgp_sig_type_t sigtype = signature_get_type(sig);
     /* we support only direct-key and key revocation signatures here */
     if ((sigtype != PGP_SIG_DIRECT) && (sigtype != PGP_SIG_REV_KEY)) {
-        goto done;
-    }
-    res_key = rnp_key_store_get_signer_key(keyring, sig);
-    if (!res_key) {
-        res_status = PGP_SIG_IMPORT_STATUS_UNKNOWN_KEY;
-        goto done;
-    }
-    if (!pgp_key_from_pkt(&tmpkey, &res_key->pkt) || !rnp_key_add_signature(&tmpkey, sig)) {
-        goto done;
+        return NULL;
     }
 
-    expackets = pgp_key_get_rawpacket_count(res_key);
-    if (!(res_key = rnp_key_store_add_key(keyring, &tmpkey))) {
-        RNP_LOG("failed to add key with imported sig to the keyring");
-        goto done;
+    pgp_key_t *res_key = rnp_key_store_get_signer_key(keyring, sig);
+    if (!res_key || !pgp_key_is_primary_key(res_key)) {
+        *status = PGP_SIG_IMPORT_STATUS_UNKNOWN_KEY;
+        return NULL;
     }
-    res_status = (pgp_key_get_rawpacket_count(res_key) > expackets) ?
-                   PGP_SIG_IMPORT_STATUS_NEW :
-                   PGP_SIG_IMPORT_STATUS_UNCHANGED;
-done:
-    pgp_key_free_data(&tmpkey);
-    if (status) {
-        *status = res_status;
-    }
+    *status = rnp_key_store_import_key_signature(keyring, res_key, sig);
     return res_key;
 }
 

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -697,6 +697,7 @@ cli_rnp_print_key_info(FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecr
     const char * header = NULL;
     bool         secret = false;
     bool         primary = false;
+    bool         revoked = false;
     uint32_t     bits = 0;
     int64_t      create = 0;
     uint32_t     expiry = 0;
@@ -712,11 +713,11 @@ cli_rnp_print_key_info(FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecr
         return;
     }
     if (!(pkts = json_tokener_parse(json))) {
-        fprintf(fp, "Key JSON error");
+        fprintf(fp, "Key JSON error.\n");
         goto done;
     }
     if (!(keypkt = json_object_array_get_idx(pkts, 0))) {
-        fprintf(fp, "Key JSON error");
+        fprintf(fp, "Key JSON error.\n");
         goto done;
     }
 
@@ -749,6 +750,11 @@ cli_rnp_print_key_info(FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecr
         time_t expire_time = create + expiry;
         ptimestr(buf, sizeof(buf), expire_time);
         fprintf(fp, " [%s %s]", expire_time <= now ? "EXPIRED" : "EXPIRES", buf);
+    }
+    /* key is revoked */
+    (void) rnp_key_is_revoked(key, &revoked);
+    if (revoked) {
+        fprintf(fp, " [REVOKED]");
     }
     /* fingerprint */
     fprintf(fp, "\n      %s\n", json_obj_get_str(keypkt, "fingerprint"));

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1729,6 +1729,74 @@ done:
 }
 
 bool
+cli_rnp_revoke_key(cli_rnp_t *rnp, const char *key)
+{
+    std::vector<rnp_key_handle_t> keys;
+    if (!cli_rnp_keys_matching_string(rnp, keys, key, CLI_SEARCH_SUBKEYS)) {
+        ERR_MSG("Key matching '%s' not found.", key);
+        return false;
+    }
+    rnp_cfg_t *  cfg = cli_rnp_cfg(rnp);
+    bool         res = false;
+    bool         revoked = false;
+    rnp_result_t ret = 0;
+
+    if (keys.size() > 1) {
+        ERR_MSG("Ambiguous input: too many keys found for '%s'.", key);
+        goto done;
+    }
+    if (rnp_key_is_revoked(keys[0], &revoked)) {
+        ERR_MSG("Error getting key revocation status.");
+        goto done;
+    }
+    if (revoked && !rnp_cfg_getbool(cfg, CFG_FORCE)) {
+        ERR_MSG("Error: key '%s' is revoked already. Use --force to generate another "
+                "revocation signature.",
+                key);
+        goto done;
+    }
+
+    ret = rnp_key_revoke(keys[0],
+                         0,
+                         rnp_cfg_getstr(cfg, CFG_HASH),
+                         rnp_cfg_getstr(cfg, CFG_REV_TYPE),
+                         rnp_cfg_getstr(cfg, CFG_REV_REASON));
+    if (ret) {
+        ERR_MSG("Failed to revoke a key: error %d", (int) ret);
+        goto done;
+    }
+    res = cli_rnp_save_keyrings(rnp);
+    /* print info about the revoked key */
+    if (res) {
+        bool  subkey = false;
+        char *grip = NULL;
+        if (rnp_key_is_sub(keys[0], &subkey)) {
+            ERR_MSG("Failed to get key info");
+            goto done;
+        }
+        ret =
+          subkey ? rnp_key_get_primary_grip(keys[0], &grip) : rnp_key_get_grip(keys[0], &grip);
+        if (ret || !grip) {
+            ERR_MSG("Failed to get primary key grip.");
+            goto done;
+        }
+        clear_key_handles(keys);
+        if (!cli_rnp_keys_matching_string(rnp, keys, grip, CLI_SEARCH_SUBKEYS_AFTER)) {
+            ERR_MSG("Failed to search for revoked key.");
+            rnp_buffer_destroy(grip);
+            goto done;
+        }
+        rnp_buffer_destroy(grip);
+        for (auto handle : keys) {
+            cli_rnp_print_key_info(rnp->userio_out, rnp->ffi, handle, false, false);
+        }
+    }
+done:
+    clear_key_handles(keys);
+    return res;
+}
+
+bool
 cli_rnp_add_key(cli_rnp_t *rnp)
 {
     std::string path = rnp_cfg_getstring(cli_rnp_cfg(rnp), CFG_KEYFILE);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -118,6 +118,7 @@ bool        cli_rnp_keys_matching_strings(cli_rnp_t *                     rnp,
                                           int                             flags);
 bool        cli_rnp_export_keys(cli_rnp_t *rnp, const char *filter);
 bool        cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key);
+bool        cli_rnp_revoke_key(cli_rnp_t *rnp, const char *key);
 bool        cli_rnp_add_key(cli_rnp_t *rnp);
 bool        cli_rnp_dump_file(cli_rnp_t *rnp);
 bool        cli_rnp_armor_file(cli_rnp_t *rnp);

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -50,6 +50,7 @@ extern const char *rnp_keys_progname;
 const char *usage = "--help OR\n"
                     "\t--export-key [options] OR\n"
                     "\t--export-rev [options] OR\n"
+                    "\t--revoke-key [options] OR\n"
                     "\t--generate-key [options] OR\n"
                     "\t--import, --import-keys, --import-sigs [options] OR\n"
                     "\t--list-keys [options] OR\n"
@@ -84,6 +85,7 @@ struct option options[] = {
   {"generate-key", optional_argument, NULL, CMD_GENERATE_KEY},
   {"export-rev", no_argument, NULL, CMD_EXPORT_REV},
   {"export-revocation", no_argument, NULL, CMD_EXPORT_REV},
+  {"revoke-key", no_argument, NULL, CMD_REVOKE_KEY},
   /* debugging commands */
   {"help", no_argument, NULL, CMD_HELP},
   {"version", no_argument, NULL, CMD_VERSION},
@@ -385,6 +387,13 @@ rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f)
         }
         return cli_rnp_export_revocation(rnp, f);
     }
+    case CMD_REVOKE_KEY: {
+        if (!f) {
+            ERR_MSG("You need to specify key or subkey to revoke.");
+            return false;
+        }
+        return cli_rnp_revoke_key(rnp, f);
+    }
     case CMD_VERSION:
         print_praise();
         return true;
@@ -415,6 +424,7 @@ setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, const char *arg)
     case CMD_LIST_KEYS:
     case CMD_EXPORT_KEY:
     case CMD_EXPORT_REV:
+    case CMD_REVOKE_KEY:
     case CMD_IMPORT:
     case CMD_IMPORT_KEYS:
     case CMD_IMPORT_SIGS:

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -16,6 +16,7 @@ typedef enum {
     CMD_IMPORT_SIGS,
     CMD_GENERATE_KEY,
     CMD_EXPORT_REV,
+    CMD_REVOKE_KEY,
     CMD_VERSION,
     CMD_HELP,
 

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -279,6 +279,8 @@ void test_ffi_secret_sig_import(void **state);
 
 void test_ffi_rnp_request_password(void **state);
 
+void test_ffi_key_revoke(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
This PR adds the following functionality:
- rnp_key_revoke() FFI function, which allows to revoke key and subkey and all underlying code
- `rnpkeys --revoke-key` command, which uses this function.

Currently we have feature to export key revocation signature, this PR extends functionality to allow to revoke key and subkey directly (without the signature import).