### PR TITLE
Add FFI function rnp_request_password().

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1621,6 +1621,14 @@ rnp_result_t rnp_op_verify_signature_get_times(rnp_op_verify_signature_t sig,
 void rnp_buffer_destroy(void *ptr);
 
 /**
+ * @brief Securely clear buffer contents.
+ *
+ * @param ptr pointer to the buffer contents, may be NULL.
+ * @param size number of bytes in buffer.
+ */
+void rnp_buffer_clear(void *ptr, size_t size);
+
+/**
  * @brief Initialize input struct to read from a path
  *
  * @param input pointer to the input opaque structure

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -332,10 +332,28 @@ rnp_result_t rnp_supports_feature(const char *type, const char *name, bool *supp
  *
  * @param type type of the feature. See rnp_supports_feature() function for possible values.
  * @param result after successfull execution will contain the JSON with supported feature
- * values. You must destroy it using the rnp_destroy_buffer() function.
+ * values. You must destroy it using the rnp_buffer_destroy() function.
  * @return RNP_SUCCESS on success or any other value on error.
  */
 rnp_result_t rnp_supported_features(const char *type, char **result);
+
+/**
+ * @brief Request password via configured FFI's callback
+ *
+ * @param ffi initialized FFI structure
+ * @param key key handle for which password is requested. May be NULL.
+ * @param context string describing the purpose of password request. See description of
+ *                rnp_password_cb for the list of possible values. Also you may use any
+ *                custom one as far as your password callback handles it.
+ * @param password password will be put here on success. Must be destroyed via
+ *                 rnp_buffer_destroy(), also it is good idea to securely clear it via
+ *                 rnp_buffer_clear().
+ * @return RNP_SUCCESS or other value on error.
+ */
+rnp_result_t rnp_request_password(rnp_ffi_t        ffi,
+                                  rnp_key_handle_t key,
+                                  const char *     context,
+                                  char **          password);
 
 /** load keys
  *

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -4697,6 +4697,14 @@ rnp_buffer_destroy(void *ptr)
     free(ptr);
 }
 
+void
+rnp_buffer_clear(void *ptr, size_t size)
+{
+    if (ptr) {
+        pgp_forget(ptr, size);
+    }
+}
+
 static pgp_key_t *
 get_key_require_public(rnp_key_handle_t handle)
 {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -963,6 +963,29 @@ done:
     return ret;
 }
 
+rnp_result_t
+rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
+{
+    if (!ffi || !password || !ffi->getpasscb) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+
+    Botan::secure_vector<char> pass(MAX_PASSWORD_LENGTH, '\0');
+    bool                       req_res =
+      ffi->getpasscb(ffi, ffi->getpasscb_ctx, key, context, pass.data(), pass.size());
+    size_t pass_len = strlen(pass.data());
+    if (!req_res || !pass_len) {
+        return RNP_ERROR_GENERIC;
+    }
+
+    *password = (char *) malloc(pass_len + 1);
+    if (!*password) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    strcpy(*password, pass.data());
+    return RNP_SUCCESS;
+}
+
 static rnp_result_t
 load_keys_from_input(rnp_ffi_t ffi, rnp_input_t input, rnp_key_store_t *store)
 {

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -294,7 +294,7 @@ start:
     ok = true;
 done:
     fputs("", rnp->userio_out);
-    pgp_forget(buffer, sizeof(buffer));
+    rnp_buffer_clear(buffer, sizeof(buffer));
     return ok;
 }
 
@@ -960,7 +960,7 @@ done:
             cli_rnp_print_key_info(stdout, rnp->ffi, subkey, true, false);
         }
     }
-    pgp_forget(password, sizeof(password));
+    rnp_buffer_clear(password, sizeof(password));
     rnp_op_generate_destroy(genkey);
     rnp_key_handle_destroy(primary);
     rnp_key_handle_destroy(subkey);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -107,7 +107,6 @@ bool        rnp_casecmp(const std::string &str1, const std::string &str2);
 #define EXT_GPG (".gpg")
 
 char *rnp_strip_eol(char *s);
-void  pgp_forget(void *vp, size_t size);
 
 #if defined(__cplusplus)
 }

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -6885,3 +6885,85 @@ TEST_F(rnp_tests, test_ffi_secret_sig_import)
     assert_rnp_success(rnp_key_handle_destroy(key_handle));
     assert_rnp_success(rnp_ffi_destroy(ffi));
 }
+
+static bool
+getpasscb_fail(rnp_ffi_t        ffi,
+               void *           app_ctx,
+               rnp_key_handle_t key,
+               const char *     pgp_context,
+               char *           buf,
+               size_t           buf_len)
+{
+    return false;
+}
+
+static bool
+getpasscb_context(rnp_ffi_t        ffi,
+                  void *           app_ctx,
+                  rnp_key_handle_t key,
+                  const char *     pgp_context,
+                  char *           buf,
+                  size_t           buf_len)
+{
+    strncpy(buf, pgp_context, buf_len - 1);
+    return true;
+}
+
+static bool
+getpasscb_keyid(rnp_ffi_t        ffi,
+                void *           app_ctx,
+                rnp_key_handle_t key,
+                const char *     pgp_context,
+                char *           buf,
+                size_t           buf_len)
+{
+    if (!key) {
+        return false;
+    }
+    char *keyid = NULL;
+    if (rnp_key_get_keyid(key, &keyid)) {
+        return false;
+    }
+    strncpy(buf, keyid, buf_len - 1);
+    rnp_buffer_destroy(keyid);
+    return true;
+}
+
+TEST_F(rnp_tests, test_ffi_rnp_request_password)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    /* check wrong parameters cases */
+    char *password = NULL;
+    assert_rnp_failure(rnp_request_password(ffi, NULL, "sign", &password));
+    assert_null(password);
+    assert_rnp_success(rnp_ffi_set_pass_provider(ffi, getpasscb, (void *) "password"));
+    assert_rnp_failure(rnp_request_password(NULL, NULL, "sign", &password));
+    assert_rnp_failure(rnp_request_password(ffi, NULL, "sign", NULL));
+    /* now it should succeed */
+    assert_rnp_success(rnp_request_password(ffi, NULL, "sign", &password));
+    assert_int_equal(strcmp(password, "password"), 0);
+    rnp_buffer_destroy(password);
+    /* let's try failing password provider */
+    assert_rnp_success(rnp_ffi_set_pass_provider(ffi, getpasscb_fail, NULL));
+    assert_rnp_failure(rnp_request_password(ffi, NULL, "sign", &password));
+    /* let's try to return request context */
+    assert_rnp_success(rnp_ffi_set_pass_provider(ffi, getpasscb_context, NULL));
+    assert_rnp_success(rnp_request_password(ffi, NULL, "custom context", &password));
+    assert_int_equal(strcmp(password, "custom context"), 0);
+    rnp_buffer_destroy(password);
+    /* let's check whether key is correctly passed to handler */
+    rnp_input_t input = NULL;
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_key_validity/alice-sec.asc"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_SECRET_KEYS, NULL));
+    assert_rnp_success(rnp_input_destroy(input));
+    rnp_key_handle_t key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "userid", "Alice <alice@rnp>", &key));
+    assert_non_null(key);
+    assert_rnp_success(rnp_ffi_set_pass_provider(ffi, getpasscb_keyid, NULL));
+    assert_rnp_success(rnp_request_password(ffi, key, NULL, &password));
+    assert_int_equal(strcmp(password, "0451409669FFDE3C"), 0);
+    rnp_buffer_destroy(password);
+    assert_rnp_success(rnp_key_handle_destroy(key));
+    assert_rnp_success(rnp_ffi_destroy(ffi));
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -275,6 +275,8 @@ void test_ffi_export_revocation(void **state);
 
 void test_ffi_secret_sig_import(void **state);
 
+void test_ffi_rnp_request_password(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
This PR implements function `rnp_request_password()` which requests password via configured FFI callback in case user needs it. Fixes #1036.
Also it adds function `rnp_buffer_clear()` to securely clear buffer (instead of pgp_forget() which belongs to lower layer).
Fixes #1035.