### PR TITLE
Refactor rnp_cfg_t usage within cli_rnp_t

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -856,9 +856,10 @@ cli_rnp_save_keyrings(cli_rnp_t *rnp)
 }
 
 bool
-cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username)
+cli_rnp_generate_key(cli_rnp_t *rnp, const char *username)
 {
     /* set key generation parameters to rnp_cfg_t */
+    rnp_cfg_t *cfg = cli_rnp_cfg(rnp);
     if (!cli_rnp_set_generate_params(cfg)) {
         ERR_MSG("Key generation setup failed.");
         return false;
@@ -1559,9 +1560,9 @@ stdout_writer(void *app_ctx, const void *buf, size_t len)
 }
 
 bool
-cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter)
+cli_rnp_export_keys(cli_rnp_t *rnp, const char *filter)
 {
-    bool secret = rnp_cfg_getbool(cfg, CFG_SECRET);
+    bool secret = rnp_cfg_getbool(cli_rnp_cfg(rnp), CFG_SECRET);
     list keys = cli_rnp_get_keylist(rnp, filter, secret, true);
     if (!keys) {
         fprintf(rnp->userio_out, "Key(s) matching '%s' not found.\n", filter);
@@ -1570,13 +1571,14 @@ cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter)
 
     rnp_output_t output = NULL;
     rnp_output_t armor = NULL;
-    const char * file = rnp_cfg_getstr(cfg, CFG_OUTFILE);
+    const char * file = rnp_cfg_getstr(cli_rnp_cfg(rnp), CFG_OUTFILE);
     rnp_result_t ret;
     uint32_t     base_flags = secret ? RNP_KEY_EXPORT_SECRET : RNP_KEY_EXPORT_PUBLIC;
     bool         result = false;
 
     if (file) {
-        uint32_t flags = rnp_cfg_getbool(cfg, CFG_FORCE) ? RNP_OUTPUT_FILE_OVERWRITE : 0;
+        uint32_t flags =
+          rnp_cfg_getbool(cli_rnp_cfg(rnp), CFG_FORCE) ? RNP_OUTPUT_FILE_OVERWRITE : 0;
         ret = rnp_output_to_file(&output, file, flags);
     } else {
         ret = rnp_output_to_callback(&output, stdout_writer, NULL, NULL);
@@ -1624,7 +1626,7 @@ done:
 }
 
 bool
-cli_rnp_export_revocation(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *key)
+cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key)
 {
     list keys = cli_rnp_get_keylist(rnp, key, false, false);
     if (!keys) {
@@ -1637,13 +1639,15 @@ cli_rnp_export_revocation(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *key)
         return false;
     }
     rnp_key_handle_t key_handle = *((rnp_key_handle_t *) list_front(keys));
+    rnp_cfg_t *      cfg = cli_rnp_cfg(rnp);
     const char *     file = rnp_cfg_getstr(cfg, CFG_OUTFILE);
     rnp_result_t     ret = RNP_ERROR_GENERIC;
     rnp_output_t     output = NULL;
     rnp_output_t     armored = NULL;
     bool             result = false;
     if (file) {
-        uint32_t flags = rnp_cfg_getbool(cfg, CFG_FORCE) ? RNP_OUTPUT_FILE_OVERWRITE : 0;
+        uint32_t flags =
+          rnp_cfg_getbool(cli_rnp_cfg(rnp), CFG_FORCE) ? RNP_OUTPUT_FILE_OVERWRITE : 0;
         ret = rnp_output_to_file(&output, file, flags);
     } else {
         ret = rnp_output_to_callback(&output, stdout_writer, NULL, NULL);

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -339,6 +339,12 @@ ffi_pass_callback_string(rnp_ffi_t        ffi,
     return true;
 }
 
+rnp_cfg_t *
+cli_rnp_cfg(cli_rnp_t *rnp)
+{
+    return &rnp->cfg;
+}
+
 bool
 cli_rnp_init(cli_rnp_t *rnp, rnp_cfg_t *cfg)
 {
@@ -347,6 +353,11 @@ cli_rnp_init(cli_rnp_t *rnp, rnp_cfg_t *cfg)
     if (!cli_rnp_baseinit(rnp)) {
         return false;
     }
+    if (!rnp_cfg_copy(&rnp->cfg, cfg)) {
+        cli_rnp_end(rnp);
+        return false;
+    }
+    cfg = cli_rnp_cfg(rnp);
 
     /* If system resource constraints are in effect then attempt to
      * disable core dumps.
@@ -430,15 +441,7 @@ done:
 bool
 cli_rnp_baseinit(cli_rnp_t *rnp)
 {
-    rnp->ffi = NULL;
-    rnp->resfp = NULL;
-    rnp->passfp = NULL;
-    rnp->pswdtries = 0;
-    rnp->pubpath = NULL;
-    rnp->pubformat = NULL;
-    rnp->secpath = NULL;
-    rnp->secformat = NULL;
-    rnp->defkey = NULL;
+    memset(rnp, 0, sizeof(*rnp));
 
     /* Configure user's io streams. */
     rnp->userio_in = (isatty(fileno(stdin)) ? stdin : fopen("/dev/tty", "r"));
@@ -476,6 +479,7 @@ cli_rnp_end(cli_rnp_t *rnp)
         fclose(rnp->userio_out);
     }
     rnp->userio_out = NULL;
+    rnp_cfg_free(&rnp->cfg);
     rnp_ffi_destroy(rnp->ffi);
     memset(rnp, 0, sizeof(*rnp));
 }

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -40,6 +40,7 @@ extern "C" {
 
 typedef struct cli_rnp_t {
     rnp_ffi_t ffi;
+    rnp_cfg_t cfg;
     FILE *    resfp;      /* where to put result messages, defaults to stdout */
     FILE *    passfp;     /* file pointer for password input */
     FILE *    userio_in;  /* file pointer for user's inputs */
@@ -61,6 +62,8 @@ typedef struct cli_rnp_t {
  * @return false
  */
 bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
+
+rnp_cfg_t *cli_rnp_cfg(cli_rnp_t *);
 
 bool cli_rnp_init(cli_rnp_t *, rnp_cfg_t *);
 bool cli_rnp_baseinit(cli_rnp_t *);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -74,11 +74,11 @@ void cli_rnp_set_default_key(cli_rnp_t *rnp);
 void cli_rnp_print_key_info(
   FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);
 bool cli_rnp_set_generate_params(rnp_cfg_t *cfg);
-bool cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username);
+bool cli_rnp_generate_key(cli_rnp_t *rnp, const char *username);
 list cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret, bool subkeys);
 void cli_rnp_keylist_destroy(list *keys);
-bool cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter);
-bool cli_rnp_export_revocation(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *key);
+bool cli_rnp_export_keys(cli_rnp_t *rnp, const char *filter);
+bool cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key);
 bool cli_rnp_add_key(const rnp_cfg_t *cfg, cli_rnp_t *rnp);
 bool cli_rnp_dump_file(const rnp_cfg_t *cfg);
 bool cli_rnp_armor_file(const rnp_cfg_t *cfg);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -79,13 +79,13 @@ list cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret, bool s
 void cli_rnp_keylist_destroy(list *keys);
 bool cli_rnp_export_keys(cli_rnp_t *rnp, const char *filter);
 bool cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key);
-bool cli_rnp_add_key(const rnp_cfg_t *cfg, cli_rnp_t *rnp);
-bool cli_rnp_dump_file(const rnp_cfg_t *cfg);
-bool cli_rnp_armor_file(const rnp_cfg_t *cfg);
-bool cli_rnp_dearmor_file(const rnp_cfg_t *cfg);
-bool cli_rnp_setup(const rnp_cfg_t *cfg, cli_rnp_t *rnp);
-bool cli_rnp_protect_file(const rnp_cfg_t *cfg, cli_rnp_t *rnp);
-bool cli_rnp_process_file(const rnp_cfg_t *cfg, cli_rnp_t *rnp);
+bool cli_rnp_add_key(cli_rnp_t *rnp);
+bool cli_rnp_dump_file(cli_rnp_t *rnp);
+bool cli_rnp_armor_file(cli_rnp_t *rnp);
+bool cli_rnp_dearmor_file(cli_rnp_t *rnp);
+bool cli_rnp_setup(cli_rnp_t *rnp);
+bool cli_rnp_protect_file(cli_rnp_t *rnp);
+bool cli_rnp_process_file(cli_rnp_t *rnp);
 
 const char *json_obj_get_str(json_object *obj, const char *key);
 int64_t     json_obj_get_int64(json_object *obj, const char *key);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -34,10 +34,6 @@
 #include "rnpcfg.h"
 #include "json.h"
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 typedef struct cli_rnp_t {
     rnp_ffi_t ffi;
     rnp_cfg_t cfg;
@@ -50,7 +46,6 @@ typedef struct cli_rnp_t {
     char *    pubformat;  /* format of the public keyring */
     char *    secpath;    /* path to the secret keyring */
     char *    secformat;  /* format of the secret keyring */
-    char *    defkey;     /* default key id */
 } cli_rnp_t;
 
 /**
@@ -63,7 +58,8 @@ typedef struct cli_rnp_t {
  */
 bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
 
-rnp_cfg_t *cli_rnp_cfg(cli_rnp_t *);
+rnp_cfg_t *       cli_rnp_cfg(cli_rnp_t *rnp);
+const std::string cli_rnp_defkey(cli_rnp_t *rnp);
 
 bool cli_rnp_init(cli_rnp_t *, rnp_cfg_t *);
 bool cli_rnp_baseinit(cli_rnp_t *);
@@ -111,9 +107,5 @@ bool        rnp_casecmp(const std::string &str1, const std::string &str2);
 
 char *rnp_strip_eol(char *s);
 void  pgp_forget(void *vp, size_t size);
-
-#if defined(__cplusplus)
-}
-#endif
 
 #endif

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -42,10 +42,6 @@ typedef struct cli_rnp_t {
     FILE *    userio_in;  /* file pointer for user's inputs */
     FILE *    userio_out; /* file pointer for user's outputs */
     int       pswdtries;  /* number of password tries, -1 for unlimited */
-    char *    pubpath;    /* path to the public keyring */
-    char *    pubformat;  /* format of the public keyring */
-    char *    secpath;    /* path to the secret keyring */
-    char *    secformat;  /* format of the secret keyring */
 } cli_rnp_t;
 
 /**
@@ -60,6 +56,10 @@ bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
 
 rnp_cfg_t *       cli_rnp_cfg(cli_rnp_t *rnp);
 const std::string cli_rnp_defkey(cli_rnp_t *rnp);
+const std::string cli_rnp_pubpath(cli_rnp_t *rnp);
+const std::string cli_rnp_secpath(cli_rnp_t *rnp);
+const std::string cli_rnp_pubformat(cli_rnp_t *rnp);
+const std::string cli_rnp_secformat(cli_rnp_t *rnp);
 
 bool cli_rnp_init(cli_rnp_t *, rnp_cfg_t *);
 bool cli_rnp_baseinit(cli_rnp_t *);

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -599,7 +599,7 @@ rnp_main(int argc, char **argv)
 #endif
 {
     cli_rnp_t clirnp = {};
-    rnp_cfg_t cfg;
+    rnp_cfg_t cfg = {};
     int       optindex;
     int       ret = EXIT_ERROR;
     int       ch;
@@ -733,12 +733,12 @@ rnp_main(int argc, char **argv)
     /* now do the required action for each of the command line args */
     ret = EXIT_SUCCESS;
     if (optind == argc) {
-        if (!rnp_cmd(&cfg, &clirnp))
+        if (!rnp_cmd(cli_rnp_cfg(&clirnp), &clirnp))
             ret = EXIT_FAILURE;
     } else {
         for (i = optind; i < argc; i++) {
             rnp_cfg_setstr(&cfg, CFG_INFILE, argv[i]);
-            if (!rnp_cmd(&cfg, &clirnp)) {
+            if (!rnp_cmd(cli_rnp_cfg(&clirnp), &clirnp)) {
                 ret = EXIT_FAILURE;
             }
         }

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -231,29 +231,25 @@ print_usage(const char *usagemsg)
 
 /* do a command once for a specified config */
 static bool
-rnp_cmd(rnp_cfg_t *cfg, cli_rnp_t *clirnp)
+rnp_cmd(cli_rnp_t *rnp)
 {
     bool ret = false;
 
-    if (!cli_rnp_setup(cfg, clirnp)) {
-        return false;
-    }
-
-    switch (rnp_cfg_getint(cfg, CFG_COMMAND)) {
+    switch (rnp_cfg_getint(cli_rnp_cfg(rnp), CFG_COMMAND)) {
     case CMD_PROTECT:
-        ret = cli_rnp_protect_file(cfg, clirnp);
+        ret = cli_rnp_protect_file(rnp);
         break;
     case CMD_PROCESS:
-        ret = cli_rnp_process_file(cfg, clirnp);
+        ret = cli_rnp_process_file(rnp);
         break;
     case CMD_LIST_PACKETS:
-        ret = cli_rnp_dump_file(cfg);
+        ret = cli_rnp_dump_file(rnp);
         break;
     case CMD_DEARMOR:
-        ret = cli_rnp_dearmor_file(cfg);
+        ret = cli_rnp_dearmor_file(rnp);
         break;
     case CMD_ENARMOR:
-        ret = cli_rnp_armor_file(cfg);
+        ret = cli_rnp_armor_file(rnp);
         break;
     case CMD_VERSION:
         print_praise();
@@ -598,12 +594,12 @@ int
 rnp_main(int argc, char **argv)
 #endif
 {
-    cli_rnp_t clirnp = {};
+    cli_rnp_t rnp = {};
     rnp_cfg_t cfg = {};
     int       optindex;
     int       ret = EXIT_ERROR;
     int       ch;
-    int       i;
+    bool      disable_ks = false;
 
     rnp_prog_name = argv[0];
 
@@ -697,8 +693,12 @@ rnp_main(int argc, char **argv)
 
     switch (rnp_cfg_getint(&cfg, CFG_COMMAND)) {
     case CMD_HELP:
+        print_usage(usage);
+        ret = EXIT_SUCCESS;
+        goto finish;
     case CMD_VERSION:
-        ret = rnp_cmd(&cfg, &clirnp) ? EXIT_SUCCESS : EXIT_FAILURE;
+        print_praise();
+        ret = EXIT_SUCCESS;
         goto finish;
     default:;
     }
@@ -709,23 +709,29 @@ rnp_main(int argc, char **argv)
         goto finish;
     }
 
-    if (!cli_rnp_init(&clirnp, &cfg)) {
+    if (!cli_rnp_init(&rnp, &cfg)) {
         ERR_MSG("fatal: cannot initialise");
         ret = EXIT_ERROR;
         goto finish;
     }
 
-    if (!rnp_cfg_getbool(&cfg, CFG_KEYSTORE_DISABLED) &&
-        !cli_rnp_load_keyrings(&clirnp, rnp_cfg_getbool(&cfg, CFG_NEEDSSECKEY))) {
+    disable_ks = rnp_cfg_getbool(cli_rnp_cfg(&rnp), CFG_KEYSTORE_DISABLED);
+    if (!disable_ks &&
+        !cli_rnp_load_keyrings(&rnp, rnp_cfg_getbool(cli_rnp_cfg(&rnp), CFG_NEEDSSECKEY))) {
         ERR_MSG("fatal: failed to load keys");
         ret = EXIT_ERROR;
         goto finish;
     }
 
     /* load the keyfile if any */
-    if (rnp_cfg_getbool(&cfg, CFG_KEYSTORE_DISABLED) && rnp_cfg_getstr(&cfg, CFG_KEYFILE) &&
-        !cli_rnp_add_key(&cfg, &clirnp)) {
+    if (disable_ks && rnp_cfg_getstr(cli_rnp_cfg(&rnp), CFG_KEYFILE) &&
+        !cli_rnp_add_key(&rnp)) {
         ERR_MSG("fatal: failed to load key(s) from the file");
+        ret = EXIT_ERROR;
+        goto finish;
+    }
+
+    if (!cli_rnp_setup(&rnp)) {
         ret = EXIT_ERROR;
         goto finish;
     }
@@ -733,12 +739,12 @@ rnp_main(int argc, char **argv)
     /* now do the required action for each of the command line args */
     ret = EXIT_SUCCESS;
     if (optind == argc) {
-        if (!rnp_cmd(cli_rnp_cfg(&clirnp), &clirnp))
+        if (!rnp_cmd(&rnp))
             ret = EXIT_FAILURE;
     } else {
-        for (i = optind; i < argc; i++) {
-            rnp_cfg_setstr(&cfg, CFG_INFILE, argv[i]);
-            if (!rnp_cmd(cli_rnp_cfg(&clirnp), &clirnp)) {
+        for (int i = optind; i < argc; i++) {
+            rnp_cfg_setstr(cli_rnp_cfg(&rnp), CFG_INFILE, argv[i]);
+            if (!rnp_cmd(&rnp)) {
                 ret = EXIT_FAILURE;
             }
         }
@@ -746,7 +752,6 @@ rnp_main(int argc, char **argv)
 
 finish:
     rnp_cfg_free(&cfg);
-    cli_rnp_end(&clirnp);
-
+    cli_rnp_end(&rnp);
     return ret;
 }

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -617,7 +617,6 @@ rnp_main(int argc, char **argv)
         if (ch >= CMD_ENCRYPT) {
             /* getopt_long returns 0 for long options */
             if (!setoption(&cfg, options[optindex].val, optarg)) {
-                ret = EXIT_ERROR;
                 goto finish;
             }
         } else {
@@ -644,7 +643,6 @@ rnp_main(int argc, char **argv)
             case 'o':
                 if (!parse_option(&cfg, optarg)) {
                     ERR_MSG("Bad option");
-                    ret = EXIT_ERROR;
                     goto finish;
                 }
                 break;
@@ -658,7 +656,6 @@ rnp_main(int argc, char **argv)
             case 'u':
                 if (!optarg) {
                     ERR_MSG("No userid argument provided");
-                    ret = EXIT_ERROR;
                     goto finish;
                 }
                 rnp_cfg_addstr(&cfg, CFG_SIGNERS, optarg);
@@ -673,7 +670,6 @@ rnp_main(int argc, char **argv)
             case 'f':
                 if (!optarg) {
                     ERR_MSG("No keyfile argument provided");
-                    ret = EXIT_ERROR;
                     goto finish;
                 }
                 rnp_cfg_setstr(&cfg, CFG_KEYFILE, optarg);
@@ -685,7 +681,6 @@ rnp_main(int argc, char **argv)
             }
 
             if (cmd && !setcmd(&cfg, cmd, optarg)) {
-                ret = EXIT_ERROR;
                 goto finish;
             }
         }
@@ -705,13 +700,11 @@ rnp_main(int argc, char **argv)
 
     if (!cli_cfg_set_keystore_info(&cfg)) {
         ERR_MSG("fatal: cannot set keystore info");
-        ret = EXIT_ERROR;
         goto finish;
     }
 
     if (!cli_rnp_init(&rnp, &cfg)) {
         ERR_MSG("fatal: cannot initialise");
-        ret = EXIT_ERROR;
         goto finish;
     }
 
@@ -719,7 +712,6 @@ rnp_main(int argc, char **argv)
     if (!disable_ks &&
         !cli_rnp_load_keyrings(&rnp, rnp_cfg_getbool(cli_rnp_cfg(&rnp), CFG_NEEDSSECKEY))) {
         ERR_MSG("fatal: failed to load keys");
-        ret = EXIT_ERROR;
         goto finish;
     }
 
@@ -727,12 +719,10 @@ rnp_main(int argc, char **argv)
     if (disable_ks && rnp_cfg_getstr(cli_rnp_cfg(&rnp), CFG_KEYFILE) &&
         !cli_rnp_add_key(&rnp)) {
         ERR_MSG("fatal: failed to load key(s) from the file");
-        ret = EXIT_ERROR;
         goto finish;
     }
 
     if (!cli_rnp_setup(&rnp)) {
-        ret = EXIT_ERROR;
         goto finish;
     }
 
@@ -749,7 +739,6 @@ rnp_main(int argc, char **argv)
             }
         }
     }
-
 finish:
     rnp_cfg_free(&cfg);
     cli_rnp_end(&rnp);

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -594,14 +594,14 @@ get_creation(const char *s)
     return (uint64_t) strtoll(s, NULL, 10);
 }
 
-void
+bool
 rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src)
 {
     bool          res = true;
     rnp_cfg_val_t val;
 
     if (!src || !dst) {
-        return;
+        return false;
     }
 
     for (list_item *li = list_front(src->vals); li; li = list_next(li)) {
@@ -615,4 +615,5 @@ rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src)
     if (!res) {
         rnp_cfg_free(dst);
     }
+    return res;
 }

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -274,9 +274,10 @@ int rnp_cfg_getint_default(const rnp_cfg_t *cfg, const char *key, int def);
  *         from this object
  *
  *  @pre   dst is correctly initialized and not NULL
+ *  @return true on success or false otherwise
  *
  **/
-void rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
+bool rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
 
 /** @brief Return the desired hash algorithm.
  *  @param cfg [in] rnp config, must be allocated and initialized

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -99,7 +99,7 @@ rnpkeys_main(int argc, char **argv)
         }
     }
 
-    if (!rnpkeys_init(&cfg, &rnp, &opt_cfg, true)) {
+    if (!rnpkeys_init(&cfg, &rnp, &opt_cfg)) {
         ret = EXIT_FAILURE;
         goto end;
     }

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -106,12 +106,12 @@ rnpkeys_main(int argc, char **argv)
     /* now do the required action for each of the command line args */
     ret = EXIT_SUCCESS;
     if (optind == argc) {
-        if (!rnp_cmd(cli_rnp_cfg(&rnp), &rnp, cmd, NULL)) {
+        if (!rnp_cmd(&rnp, cmd, NULL)) {
             ret = EXIT_FAILURE;
         }
     } else {
         for (int i = optind; i < argc; i++) {
-            if (!rnp_cmd(cli_rnp_cfg(&rnp), &rnp, cmd, argv[i])) {
+            if (!rnp_cmd(&rnp, cmd, argv[i])) {
                 ret = EXIT_FAILURE;
             }
         }

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -51,7 +51,6 @@ rnpkeys_main(int argc, char **argv)
 #endif
 {
     cli_rnp_t rnp = {};
-    rnp_cfg_t opt_cfg = {};
     rnp_cfg_t cfg = {};
     optdefs_t cmd = (optdefs_t) 0;
     int       optindex = 0;
@@ -65,12 +64,12 @@ rnpkeys_main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    rnp_cfg_init(&opt_cfg);
+    rnp_cfg_init(&cfg);
 
     while ((ch = getopt_long(argc, argv, "Vglo:", options, &optindex)) != -1) {
         if (ch >= CMD_LIST_KEYS) {
             /* getopt_long returns 0 for long options */
-            if (!setoption(&opt_cfg, &cmd, options[optindex].val, optarg)) {
+            if (!setoption(&cfg, &cmd, options[optindex].val, optarg)) {
                 ERR_MSG("Bad setoption result %d", ch);
                 goto end;
             }
@@ -87,7 +86,7 @@ rnpkeys_main(int argc, char **argv)
                 cmd = CMD_LIST_KEYS;
                 break;
             case 'o':
-                if (!parse_option(&opt_cfg, &cmd, optarg)) {
+                if (!parse_option(&cfg, &cmd, optarg)) {
                     ERR_MSG("Bad parse_option");
                     goto end;
                 }
@@ -99,7 +98,7 @@ rnpkeys_main(int argc, char **argv)
         }
     }
 
-    if (!rnpkeys_init(&cfg, &rnp, &opt_cfg)) {
+    if (!rnpkeys_init(&rnp, &cfg)) {
         ret = EXIT_FAILURE;
         goto end;
     }
@@ -107,12 +106,12 @@ rnpkeys_main(int argc, char **argv)
     /* now do the required action for each of the command line args */
     ret = EXIT_SUCCESS;
     if (optind == argc) {
-        if (!rnp_cmd(&cfg, &rnp, cmd, NULL)) {
+        if (!rnp_cmd(cli_rnp_cfg(&rnp), &rnp, cmd, NULL)) {
             ret = EXIT_FAILURE;
         }
     } else {
         for (int i = optind; i < argc; i++) {
-            if (!rnp_cmd(&cfg, &rnp, cmd, argv[i])) {
+            if (!rnp_cmd(cli_rnp_cfg(&rnp), &rnp, cmd, argv[i])) {
                 ret = EXIT_FAILURE;
             }
         }
@@ -120,7 +119,6 @@ rnpkeys_main(int argc, char **argv)
 
 end:
     rnp_cfg_free(&cfg);
-    rnp_cfg_free(&opt_cfg);
     cli_rnp_end(&rnp);
     return ret;
 }

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -199,7 +199,7 @@ import_keys(cli_rnp_t *rnp, const char *file)
     }
 
     // set default key if we didn't have one
-    if (!rnp->defkey) {
+    if (cli_rnp_defkey(rnp).empty()) {
         cli_rnp_set_default_key(rnp);
     }
 

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -638,10 +638,7 @@ parse_option(rnp_cfg_t *cfg, optdefs_t *cmd, const char *s)
 }
 
 bool
-rnpkeys_init(rnp_cfg_t *      cfg,
-             cli_rnp_t *      rnp,
-             const rnp_cfg_t *override_cfg,
-             bool             is_generate_key)
+rnpkeys_init(rnp_cfg_t *cfg, cli_rnp_t *rnp, const rnp_cfg_t *override_cfg)
 {
     bool ret = false;
     rnp_cfg_init(cfg);
@@ -662,11 +659,8 @@ rnpkeys_init(rnp_cfg_t *      cfg,
         ERR_MSG("fatal: failed to initialize rnpkeys");
         goto end;
     }
-    if (!cli_rnp_load_keyrings(rnp, true) && !is_generate_key) {
-        /* Keys mightn't loaded if this is a key generation step. */
-        ERR_MSG("fatal: failed to load keys");
-        goto end;
-    }
+    /* TODO: at some point we should check for error here */
+    (void) cli_rnp_load_keyrings(rnp, true);
     ret = true;
 end:
     if (!ret) {

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -643,37 +643,31 @@ rnpkeys_init(rnp_cfg_t *      cfg,
              const rnp_cfg_t *override_cfg,
              bool             is_generate_key)
 {
-    bool ret = true;
-
+    bool ret = false;
     rnp_cfg_init(cfg);
-
     rnp_cfg_load_defaults(cfg);
     rnp_cfg_setint(cfg, CFG_NUMBITS, DEFAULT_RSA_NUMBITS);
     rnp_cfg_setstr(cfg, CFG_IO_RESS, "<stdout>");
     rnp_cfg_setstr(cfg, CFG_KEYFORMAT, "human");
-    rnp_cfg_copy(cfg, override_cfg);
-
+    if (!rnp_cfg_copy(cfg, override_cfg)) {
+        ERR_MSG("fatal: out of memory");
+        goto end;
+    }
     memset(rnp, '\0', sizeof(*rnp));
-
     if (!cli_cfg_set_keystore_info(cfg)) {
         ERR_MSG("fatal: cannot set keystore info");
-        ret = false;
         goto end;
     }
-
     if (!cli_rnp_init(rnp, cfg)) {
         ERR_MSG("fatal: failed to initialize rnpkeys");
-        ret = false;
         goto end;
     }
-
     if (!cli_rnp_load_keyrings(rnp, true) && !is_generate_key) {
         /* Keys mightn't loaded if this is a key generation step. */
         ERR_MSG("fatal: failed to load keys");
-        ret = false;
         goto end;
     }
-
+    ret = true;
 end:
     if (!ret) {
         rnp_cfg_free(cfg);

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -638,24 +638,24 @@ parse_option(rnp_cfg_t *cfg, optdefs_t *cmd, const char *s)
 }
 
 bool
-rnpkeys_init(rnp_cfg_t *cfg, cli_rnp_t *rnp, const rnp_cfg_t *override_cfg)
+rnpkeys_init(cli_rnp_t *rnp, const rnp_cfg_t *cfg)
 {
-    bool ret = false;
-    rnp_cfg_init(cfg);
-    rnp_cfg_load_defaults(cfg);
-    rnp_cfg_setint(cfg, CFG_NUMBITS, DEFAULT_RSA_NUMBITS);
-    rnp_cfg_setstr(cfg, CFG_IO_RESS, "<stdout>");
-    rnp_cfg_setstr(cfg, CFG_KEYFORMAT, "human");
-    if (!rnp_cfg_copy(cfg, override_cfg)) {
+    rnp_cfg_t rnpcfg = {};
+    bool      ret = false;
+    rnp_cfg_init(&rnpcfg);
+    rnp_cfg_load_defaults(&rnpcfg);
+    rnp_cfg_setint(&rnpcfg, CFG_NUMBITS, DEFAULT_RSA_NUMBITS);
+    rnp_cfg_setstr(&rnpcfg, CFG_IO_RESS, "<stdout>");
+    rnp_cfg_setstr(&rnpcfg, CFG_KEYFORMAT, "human");
+    if (!rnp_cfg_copy(&rnpcfg, cfg)) {
         ERR_MSG("fatal: out of memory");
         goto end;
     }
-    memset(rnp, '\0', sizeof(*rnp));
-    if (!cli_cfg_set_keystore_info(cfg)) {
+    if (!cli_cfg_set_keystore_info(&rnpcfg)) {
         ERR_MSG("fatal: cannot set keystore info");
         goto end;
     }
-    if (!cli_rnp_init(rnp, cfg)) {
+    if (!cli_rnp_init(rnp, &rnpcfg)) {
         ERR_MSG("fatal: failed to initialize rnpkeys");
         goto end;
     }
@@ -663,8 +663,8 @@ rnpkeys_init(rnp_cfg_t *cfg, cli_rnp_t *rnp, const rnp_cfg_t *override_cfg)
     (void) cli_rnp_load_keyrings(rnp, true);
     ret = true;
 end:
+    rnp_cfg_free(&rnpcfg);
     if (!ret) {
-        rnp_cfg_free(cfg);
         cli_rnp_end(rnp);
     }
     return ret;

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -45,7 +45,7 @@ typedef enum {
     OPT_DEBUG
 } optdefs_t;
 
-bool rnp_cmd(rnp_cfg_t *cfg, cli_rnp_t *rnp, optdefs_t cmd, const char *f);
+bool rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f);
 bool setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, const char *arg);
 void print_praise(void);
 void print_usage(const char *usagemsg);

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -58,12 +58,8 @@ bool parse_option(rnp_cfg_t *cfg, optdefs_t *cmd, const char *s);
  * @param cfg configuration to be used by rnd_cmd
  * @param rnp initialized rnp context
  * @param opt_cfg configuration with settings from command line
- * @param is_generate_key wether rnpkeys should be configured to run key generation
  * @return true on success, or false otherwise.
  */
-bool rnpkeys_init(rnp_cfg_t *      cfg,
-                  cli_rnp_t *      rnp,
-                  const rnp_cfg_t *opt_cfg,
-                  bool             is_generate_key);
+bool rnpkeys_init(rnp_cfg_t *cfg, cli_rnp_t *rnp, const rnp_cfg_t *opt_cfg);
 
 #endif /* _rnpkeys_ */

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -53,13 +53,12 @@ bool parse_option(rnp_cfg_t *cfg, optdefs_t *cmd, const char *s);
 
 /**
  * @brief Initializes rnpkeys. Function allocates memory dynamically for
- *        cfg and rnp arguments, which must be freed by the caller.
+ *        rnp argument, which must be freed by the caller.
  *
- * @param cfg configuration to be used by rnd_cmd
  * @param rnp initialized rnp context
- * @param opt_cfg configuration with settings from command line
+ * @param cfg configuration with settings from command line
  * @return true on success, or false otherwise.
  */
-bool rnpkeys_init(rnp_cfg_t *cfg, cli_rnp_t *rnp, const rnp_cfg_t *opt_cfg);
+bool rnpkeys_init(cli_rnp_t *rnp, const rnp_cfg_t *cfg);
 
 #endif /* _rnpkeys_ */

--- a/src/tests/exportkey.cpp
+++ b/src/tests/exportkey.cpp
@@ -34,17 +34,13 @@ TEST_F(rnp_tests, rnpkeys_exportkey_verifyUserId)
 {
     /* Generate the key and export it */
     cli_rnp_t rnp = {};
-    rnp_cfg_t cfg = {};
     int       pipefd[2];
 
     /* Initialize the rnp structure. */
     assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
-    rnp_cfg_init(&cfg);
-
     /* Generate the key */
-    cli_set_default_rsa_key_desc(&cfg, "SHA256");
-
-    assert_true(cli_rnp_generate_key(&cfg, &rnp, NULL));
+    cli_set_default_rsa_key_desc(cli_rnp_cfg(&rnp), "SHA256");
+    assert_true(cli_rnp_generate_key(&rnp, NULL));
 
     /* Loading keyrings and checking whether they have correct key */
     assert_true(cli_rnp_load_keyrings(&rnp, true));
@@ -59,12 +55,11 @@ TEST_F(rnp_tests, rnpkeys_exportkey_verifyUserId)
     cli_rnp_keylist_destroy(&keys);
 
     /* Try to export the key with specified userid parameter from the env */
-    assert_true(cli_rnp_export_keys(&cfg, &rnp, getenv_logname()));
+    assert_true(cli_rnp_export_keys(&rnp, getenv_logname()));
 
     /* try to export the key with specified userid parameter (which is wrong) */
-    assert_false(cli_rnp_export_keys(&cfg, &rnp, "LOGNAME"));
+    assert_false(cli_rnp_export_keys(&rnp, "LOGNAME"));
 
     close(pipefd[0]);
     cli_rnp_end(&rnp); // Free memory and other allocated resources.
-    rnp_cfg_free(&cfg);
 }

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -555,8 +555,7 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg_t *ops, const char *rsp)
         goto end;
     }
 
-    rnp_cfg_copy(ops, &cfg);
-
+    ret = rnp_cfg_copy(ops, &cfg);
 end:
     /* Close & clean fd*/
     if (user_input_pipefd[0]) {

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -46,7 +46,6 @@ static bool
 generate_test_key(const char *keystore, const char *userid, const char *hash, const char *home)
 {
     cli_rnp_t rnp = {};
-    rnp_cfg_t cfg = {};
     int       pipefd[2] = {0};
     bool      res = false;
     size_t    keycount = 0;
@@ -56,11 +55,10 @@ generate_test_key(const char *keystore, const char *userid, const char *hash, co
     if (!setup_cli_rnp_common(&rnp, keystore, home, pipefd)) {
         return false;
     }
-    rnp_cfg_init(&cfg);
 
     /* Generate the key */
-    cli_set_default_rsa_key_desc(&cfg, hash);
-    if (!cli_rnp_generate_key(&cfg, &rnp, userid)) {
+    cli_set_default_rsa_key_desc(cli_rnp_cfg(&rnp), hash);
+    if (!cli_rnp_generate_key(&rnp, userid)) {
         goto done;
     }
 
@@ -84,7 +82,6 @@ done:
     close(pipefd[0]);
     cli_rnp_keylist_destroy(&keys);
     cli_rnp_end(&rnp);
-    rnp_cfg_free(&cfg);
     return res;
 }
 
@@ -547,7 +544,7 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg_t *ops, const char *rsp)
     /* Mock user-input*/
     rnp_cfg_setint(cli_rnp_cfg(ctx), CFG_USERINPUTFD, user_input_pipefd[0]);
 
-    if (!rnp_cmd(cli_rnp_cfg(ctx), ctx, CMD_GENERATE_KEY, NULL)) {
+    if (!rnp_cmd(ctx, CMD_GENERATE_KEY, NULL)) {
         ret = false;
         goto end;
     }

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -533,7 +533,7 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg_t *ops, const char *rsp)
     }
     rnp_cfg_setint(ops, CFG_PASSFD, pipefd[0]);
     write_pass_to_pipe(pipefd[1], 2);
-    if (!rnpkeys_init(&cfg, ctx, ops, true)) {
+    if (!rnpkeys_init(&cfg, ctx, ops)) {
         return false;
     }
 

--- a/src/tests/issues/1030.cpp
+++ b/src/tests/issues/1030.cpp
@@ -32,17 +32,14 @@ test_issue_1030(const char *keystore)
 {
     int         pipefd[2] = {0};
     cli_rnp_t   rnp = {};
-    rnp_cfg_t   cfg = {};
     const char *userid = "user";
     size_t      keycount = 0;
     list        keys = NULL;
 
     char *home = make_temp_dir();
     assert_true(setup_cli_rnp_common(&rnp, keystore, home, pipefd));
-    rnp_cfg_init(&cfg);
-
-    cli_set_default_rsa_key_desc(&cfg, "SHA256");
-    assert_true(cli_rnp_generate_key(&cfg, &rnp, userid));
+    cli_set_default_rsa_key_desc(cli_rnp_cfg(&rnp), "SHA256");
+    assert_true(cli_rnp_generate_key(&rnp, userid));
 
     assert_true(cli_rnp_load_keyrings(&rnp, true));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
@@ -68,7 +65,6 @@ test_issue_1030(const char *keystore)
     close(pipefd[0]);
     cli_rnp_keylist_destroy(&keys);
     cli_rnp_end(&rnp);
-    rnp_cfg_free(&cfg);
     free(home);
 }
 

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -147,7 +147,7 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
                       std::ios_base::binary | std::ios_base::out | std::ios_base::in);
     off_t        versize = file_size("dummyfile.dat.pgp");
     verf.seekg(versize - 3, std::ios::beg);
-    verf.write("0x0C", 1);
+    verf.write("\x0C", 1);
     verf.close();
     assert_false(cli_rnp_process_file(&rnp));
 

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -67,17 +67,15 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     // try signing with a failing password provider (should fail)
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_failing_password_provider, NULL));
-    rnp_cfg_t cfg = {};
-    rnp_cfg_init(&cfg);
-    rnp_cfg_load_defaults(&cfg);
-    rnp_cfg_setbool(&cfg, CFG_SIGN_NEEDED, true);
-    rnp_cfg_setstr(&cfg, CFG_HASH, "SHA1");
-    rnp_cfg_setint(&cfg, CFG_ZLEVEL, 0);
-    rnp_cfg_setstr(&cfg, CFG_INFILE, "dummyfile.dat");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
-    rnp_cfg_addstr(&cfg, CFG_SIGNERS, keyids[0]);
-    assert_false(cli_rnp_protect_file(&cfg, &rnp));
-    rnp_cfg_free(&cfg);
+    rnp_cfg_t *cfg = cli_rnp_cfg(&rnp);
+    rnp_cfg_load_defaults(cfg);
+    rnp_cfg_setbool(cfg, CFG_SIGN_NEEDED, true);
+    rnp_cfg_setstr(cfg, CFG_HASH, "SHA1");
+    rnp_cfg_setint(cfg, CFG_ZLEVEL, 0);
+    rnp_cfg_setstr(cfg, CFG_INFILE, "dummyfile.dat");
+    rnp_cfg_setstr(cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
+    rnp_cfg_addstr(cfg, CFG_SIGNERS, keyids[0]);
+    assert_false(cli_rnp_protect_file(&rnp));
 
     // grab the signing key to unlock
     rnp_key_handle_t key = NULL;
@@ -126,24 +124,23 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     // now the signing key is unlocked, confirm that no password is required for signing
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_asserting_password_provider, NULL));
-    rnp_cfg_init(&cfg);
-    rnp_cfg_load_defaults(&cfg);
-    rnp_cfg_setbool(&cfg, CFG_SIGN_NEEDED, true);
-    rnp_cfg_setstr(&cfg, CFG_HASH, "SHA1");
-    rnp_cfg_setint(&cfg, CFG_ZLEVEL, 0);
-    rnp_cfg_setstr(&cfg, CFG_INFILE, "dummyfile.dat");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
-    rnp_cfg_addstr(&cfg, CFG_SIGNERS, keyids[0]);
-    assert_true(cli_rnp_protect_file(&cfg, &rnp));
-    rnp_cfg_free(&cfg);
+    rnp_cfg_free(cfg);
+    rnp_cfg_load_defaults(cfg);
+    rnp_cfg_setbool(cfg, CFG_SIGN_NEEDED, true);
+    rnp_cfg_setstr(cfg, CFG_HASH, "SHA1");
+    rnp_cfg_setint(cfg, CFG_ZLEVEL, 0);
+    rnp_cfg_setstr(cfg, CFG_INFILE, "dummyfile.dat");
+    rnp_cfg_setstr(cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
+    rnp_cfg_addstr(cfg, CFG_SIGNERS, keyids[0]);
+    assert_true(cli_rnp_protect_file(&rnp));
+    rnp_cfg_free(cfg);
 
     // verify
-    rnp_cfg_init(&cfg);
-    rnp_cfg_load_defaults(&cfg);
-    rnp_cfg_setbool(&cfg, CFG_OVERWRITE, true);
-    rnp_cfg_setstr(&cfg, CFG_INFILE, "dummyfile.dat.pgp");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "dummyfile.verify");
-    assert_true(cli_rnp_process_file(&cfg, &rnp));
+    rnp_cfg_load_defaults(cfg);
+    rnp_cfg_setbool(cfg, CFG_OVERWRITE, true);
+    rnp_cfg_setstr(cfg, CFG_INFILE, "dummyfile.dat.pgp");
+    rnp_cfg_setstr(cfg, CFG_OUTFILE, "dummyfile.verify");
+    assert_true(cli_rnp_process_file(&rnp));
 
     // verify (negative)
     std::fstream verf("dummyfile.dat.pgp",
@@ -152,8 +149,7 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     verf.seekg(versize - 3, std::ios::beg);
     verf.write("0x0C", 1);
     verf.close();
-    assert_false(cli_rnp_process_file(&cfg, &rnp));
-    rnp_cfg_free(&cfg);
+    assert_false(cli_rnp_process_file(&rnp));
 
     // lock the signing key
     assert_rnp_success(rnp_key_lock(key));
@@ -163,38 +159,36 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     // sign, with no password (should now fail)
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_failing_password_provider, NULL));
-    rnp_cfg_init(&cfg);
-    rnp_cfg_load_defaults(&cfg);
-    rnp_cfg_setbool(&cfg, CFG_SIGN_NEEDED, true);
-    rnp_cfg_setbool(&cfg, CFG_OVERWRITE, true);
-    rnp_cfg_setstr(&cfg, CFG_HASH, "SHA1");
-    rnp_cfg_setint(&cfg, CFG_ZLEVEL, 0);
-    rnp_cfg_setstr(&cfg, CFG_INFILE, "dummyfile.dat");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
-    rnp_cfg_addstr(&cfg, CFG_SIGNERS, keyids[0]);
-    assert_false(cli_rnp_protect_file(&cfg, &rnp));
-    rnp_cfg_free(&cfg);
+    rnp_cfg_free(cfg);
+    rnp_cfg_load_defaults(cfg);
+    rnp_cfg_setbool(cfg, CFG_SIGN_NEEDED, true);
+    rnp_cfg_setbool(cfg, CFG_OVERWRITE, true);
+    rnp_cfg_setstr(cfg, CFG_HASH, "SHA1");
+    rnp_cfg_setint(cfg, CFG_ZLEVEL, 0);
+    rnp_cfg_setstr(cfg, CFG_INFILE, "dummyfile.dat");
+    rnp_cfg_setstr(cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
+    rnp_cfg_addstr(cfg, CFG_SIGNERS, keyids[0]);
+    assert_false(cli_rnp_protect_file(&rnp));
+    rnp_cfg_free(cfg);
 
     // encrypt
-    rnp_cfg_init(&cfg);
-    rnp_cfg_load_defaults(&cfg);
-    rnp_cfg_setbool(&cfg, CFG_ENCRYPT_PK, true);
-    rnp_cfg_setint(&cfg, CFG_ZLEVEL, 0);
-    rnp_cfg_setstr(&cfg, CFG_INFILE, "dummyfile.dat");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
-    rnp_cfg_setbool(&cfg, CFG_OVERWRITE, true);
-    rnp_cfg_setstr(&cfg, CFG_CIPHER, "AES256");
-    rnp_cfg_addstr(&cfg, CFG_RECIPIENTS, keyids[1]);
-    assert_true(cli_rnp_protect_file(&cfg, &rnp));
-    rnp_cfg_free(&cfg);
+    rnp_cfg_load_defaults(cfg);
+    rnp_cfg_setbool(cfg, CFG_ENCRYPT_PK, true);
+    rnp_cfg_setint(cfg, CFG_ZLEVEL, 0);
+    rnp_cfg_setstr(cfg, CFG_INFILE, "dummyfile.dat");
+    rnp_cfg_setstr(cfg, CFG_OUTFILE, "dummyfile.dat.pgp");
+    rnp_cfg_setbool(cfg, CFG_OVERWRITE, true);
+    rnp_cfg_setstr(cfg, CFG_CIPHER, "AES256");
+    rnp_cfg_addstr(cfg, CFG_RECIPIENTS, keyids[1]);
+    assert_true(cli_rnp_protect_file(&rnp));
+    rnp_cfg_free(cfg);
 
     // try decrypting with a failing password provider (should fail)
-    rnp_cfg_init(&cfg);
-    rnp_cfg_load_defaults(&cfg);
-    rnp_cfg_setbool(&cfg, CFG_OVERWRITE, true);
-    rnp_cfg_setstr(&cfg, CFG_INFILE, "dummyfile.dat.pgp");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "dummyfile.decrypt");
-    assert_false(cli_rnp_process_file(&cfg, &rnp));
+    rnp_cfg_load_defaults(cfg);
+    rnp_cfg_setbool(cfg, CFG_OVERWRITE, true);
+    rnp_cfg_setstr(cfg, CFG_INFILE, "dummyfile.dat.pgp");
+    rnp_cfg_setstr(cfg, CFG_OUTFILE, "dummyfile.decrypt");
+    assert_false(cli_rnp_process_file(&rnp));
 
     // grab the encrypting key to unlock
     rnp_key_handle_t subkey = NULL;
@@ -207,7 +201,7 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     assert_false(locked);
 
     // decrypt, with no password
-    assert_true(cli_rnp_process_file(&cfg, &rnp));
+    assert_true(cli_rnp_process_file(&rnp));
 
     std::string decrypt = file_to_str("dummyfile.decrypt");
     assert_true(decrypt == data);
@@ -218,8 +212,7 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     assert_true(locked);
 
     // decrypt, with no password (should now fail)
-    assert_false(cli_rnp_process_file(&cfg, &rnp));
-    rnp_cfg_free(&cfg);
+    assert_false(cli_rnp_process_file(&rnp));
     // cleanup
     assert_rnp_success(rnp_key_handle_destroy(key));
     assert_rnp_success(rnp_key_handle_destroy(subkey));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -804,10 +804,9 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, ".rnp", NULL));
 
     /* import just the public key */
-    rnp_cfg_t cfg = {};
-    rnp_cfg_init(&cfg);
-    rnp_cfg_setstr(&cfg, CFG_KEYFILE, MERGE_PATH "key-pub-just-key.pgp");
-    assert_true(cli_rnp_add_key(&cfg, &rnp));
+    rnp_cfg_t *cfg = cli_rnp_cfg(&rnp);
+    rnp_cfg_setstr(cfg, CFG_KEYFILE, MERGE_PATH "key-pub-just-key.pgp");
+    assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
     size_t keycount = 0;
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
@@ -823,8 +822,8 @@ TEST_F(rnp_tests, test_key_import)
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 userid */
-    rnp_cfg_setstr(&cfg, CFG_KEYFILE, MERGE_PATH "key-pub-uid-1-no-sigs.pgp");
-    assert_true(cli_rnp_add_key(&cfg, &rnp));
+    rnp_cfg_setstr(cfg, CFG_KEYFILE, MERGE_PATH "key-pub-uid-1-no-sigs.pgp");
+    assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 1);
@@ -843,8 +842,8 @@ TEST_F(rnp_tests, test_key_import)
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 userid + signature */
-    rnp_cfg_setstr(&cfg, CFG_KEYFILE, MERGE_PATH "key-pub-uid-1.pgp");
-    assert_true(cli_rnp_add_key(&cfg, &rnp));
+    rnp_cfg_setstr(cfg, CFG_KEYFILE, MERGE_PATH "key-pub-uid-1.pgp");
+    assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 1);
@@ -863,8 +862,8 @@ TEST_F(rnp_tests, test_key_import)
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 subkey */
-    rnp_cfg_setstr(&cfg, CFG_KEYFILE, MERGE_PATH "key-pub-subkey-1.pgp");
-    assert_true(cli_rnp_add_key(&cfg, &rnp));
+    rnp_cfg_setstr(cfg, CFG_KEYFILE, MERGE_PATH "key-pub-subkey-1.pgp");
+    assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
@@ -886,8 +885,8 @@ TEST_F(rnp_tests, test_key_import)
     transferable_key_destroy(&tkey);
 
     /* import secret key with 1 uid and 1 subkey */
-    rnp_cfg_setstr(&cfg, CFG_KEYFILE, MERGE_PATH "key-sec-uid-1-subkey-1.pgp");
-    assert_true(cli_rnp_add_key(&cfg, &rnp));
+    rnp_cfg_setstr(cfg, CFG_KEYFILE, MERGE_PATH "key-sec-uid-1-subkey-1.pgp");
+    assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
@@ -925,8 +924,8 @@ TEST_F(rnp_tests, test_key_import)
     transferable_key_destroy(&tkey);
 
     /* import secret key with 2 uids and 2 subkeys */
-    rnp_cfg_setstr(&cfg, CFG_KEYFILE, MERGE_PATH "key-sec.pgp");
-    assert_true(cli_rnp_add_key(&cfg, &rnp));
+    rnp_cfg_setstr(cfg, CFG_KEYFILE, MERGE_PATH "key-sec.pgp");
+    assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 3);
@@ -978,7 +977,6 @@ TEST_F(rnp_tests, test_key_import)
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
     transferable_key_destroy(&tkey);
 
-    rnp_cfg_free(&cfg);
     cli_rnp_end(&rnp);
 }
 

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1236,41 +1236,42 @@ TEST_F(rnp_tests, test_stream_verify_no_key)
     rnp_cfg_setstr(&cfg, CFG_KR_PUB_FORMAT, RNP_KEYSTORE_GPG);
     rnp_cfg_setstr(&cfg, CFG_KR_SEC_FORMAT, RNP_KEYSTORE_GPG);
     assert_true(cli_rnp_init(&rnp, &cfg));
+    rnp_cfg_free(&cfg);
 
+    rnp_cfg_t *rnpcfg = cli_rnp_cfg(&rnp);
     /* setup cfg for verification */
     rnp_cfg_setstr(
-      &cfg, CFG_INFILE, "data/test_stream_verification/verify_encrypted_no_key.pgp");
-    rnp_cfg_setstr(&cfg, CFG_OUTFILE, "output.dat");
-    rnp_cfg_setbool(&cfg, CFG_OVERWRITE, true);
+      rnpcfg, CFG_INFILE, "data/test_stream_verification/verify_encrypted_no_key.pgp");
+    rnp_cfg_setstr(rnpcfg, CFG_OUTFILE, "output.dat");
+    rnp_cfg_setbool(rnpcfg, CFG_OVERWRITE, true);
     /* setup operation context */
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_string_password_provider, (void *) "pass1"));
     /* operation should success if output is not discarded, i.e. operation = decrypt */
-    rnp_cfg_setbool(&cfg, CFG_NO_OUTPUT, false);
-    assert_true(cli_rnp_process_file(&cfg, &rnp));
+    rnp_cfg_setbool(rnpcfg, CFG_NO_OUTPUT, false);
+    assert_true(cli_rnp_process_file(&rnp));
     assert_int_equal(file_size("output.dat"), 4);
     /* try second password */
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_string_password_provider, (void *) "pass2"));
-    assert_true(cli_rnp_process_file(&cfg, &rnp));
+    assert_true(cli_rnp_process_file(&rnp));
     assert_int_equal(file_size("output.dat"), 4);
     /* decryption/verification fails without password */
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_failing_password_provider, NULL));
-    assert_false(cli_rnp_process_file(&cfg, &rnp));
+    assert_false(cli_rnp_process_file(&rnp));
     assert_int_equal(file_size("output.dat"), -1);
     /* decryption/verification fails with wrong password */
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_string_password_provider, (void *) "pass_wrong"));
-    assert_false(cli_rnp_process_file(&cfg, &rnp));
+    assert_false(cli_rnp_process_file(&rnp));
     assert_int_equal(file_size("output.dat"), -1);
     /* verification fails if output is discarded, i.e. operation = verify */
-    rnp_cfg_setbool(&cfg, CFG_NO_OUTPUT, true);
-    assert_false(cli_rnp_process_file(&cfg, &rnp));
+    rnp_cfg_setbool(rnpcfg, CFG_NO_OUTPUT, true);
+    assert_false(cli_rnp_process_file(&rnp));
     assert_int_equal(file_size("output.dat"), -1);
 
     /* cleanup */
-    rnp_cfg_free(&cfg);
     cli_rnp_end(&rnp);
 }
 

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -572,7 +572,6 @@ setup_cli_rnp_common(cli_rnp_t *rnp, const char *ks_format, const char *homedir,
     }
 
     /*initialize the basic RNP structure. */
-    memset(rnp, '\0', sizeof(*rnp));
     bool res = cli_rnp_init(rnp, &cfg);
     rnp_cfg_free(&cfg);
     return res;

--- a/src/tests/utils-rnpcfg.cpp
+++ b/src/tests/utils-rnpcfg.cpp
@@ -53,13 +53,13 @@ TEST_F(rnp_tests, test_rnpcfg)
     }
 
     /* copy empty cfg2 to cfg1 to make sure values are not deleted */
-    rnp_cfg_copy(&cfg1, &cfg2);
+    assert_true(rnp_cfg_copy(&cfg1, &cfg2));
 
     /* copy to the cfg2 */
-    rnp_cfg_copy(&cfg2, &cfg1);
+    assert_true(rnp_cfg_copy(&cfg2, &cfg1));
 
     /* copy second time to make sure there are no leaks */
-    rnp_cfg_copy(&cfg2, &cfg1);
+    assert_true(rnp_cfg_copy(&cfg2, &cfg1));
 
     /* get values back, including transformations */
     for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
This PR improves usage of rnp_cfg_t for cli_rnp_t structure, which would make implementation of future CLI features easier.
Also fixes #1075 