### PR TITLE
Remove ssize_t usage.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -171,9 +171,42 @@ typedef struct rnp_uid_handle_st *         rnp_uid_handle_t;
 typedef struct rnp_signature_handle_st *   rnp_signature_handle_t;
 
 /* Callbacks */
+/**
+ * @brief Callback, used to read data from the source.
+ *
+ * @param app_ctx custom parameter, passed back to the function.
+ * @param buf on successfull call data should be put here. Cannot be NULL,
+ *            and must be capable to store at least len bytes.
+ * @param len number of bytes to read.
+ * @param read on successfull call number of read bytes must be put here.
+ * @return true on success (including EOF condition), or false on read error.
+ *         EOF case is indicated by zero bytes read on non-zero read call.
+ */
 typedef bool rnp_input_reader_t(void *app_ctx, void *buf, size_t len, size_t *read);
+/**
+ * @brief Callback, used to close input stream.
+ *
+ * @param app_ctx custom parameter, passed back to the function.
+ * @return void
+ */
 typedef void rnp_input_closer_t(void *app_ctx);
+/**
+ * @brief Callback, used to write data to the output stream.
+ *
+ * @param app_ctx custom parameter, passed back to the function.
+ * @param buf buffer with data, cannot be NULL.
+ * @param len number of bytes to write.
+ * @return true if call was successfull and all data is written, or false otherwise.
+ */
 typedef bool rnp_output_writer_t(void *app_ctx, const void *buf, size_t len);
+
+/**
+ * @brief Callback, used to close output stream.
+ *
+ * @param app_ctx custom parameter, passed back to the function.
+ * @param discard true if the already written data should be deleted.
+ * @return void
+ */
 typedef void rnp_output_closer_t(void *app_ctx, bool discard);
 
 /**

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -171,10 +171,10 @@ typedef struct rnp_uid_handle_st *         rnp_uid_handle_t;
 typedef struct rnp_signature_handle_st *   rnp_signature_handle_t;
 
 /* Callbacks */
-typedef ssize_t rnp_input_reader_t(void *app_ctx, void *buf, size_t len);
-typedef void    rnp_input_closer_t(void *app_ctx);
-typedef bool    rnp_output_writer_t(void *app_ctx, const void *buf, size_t len);
-typedef void    rnp_output_closer_t(void *app_ctx, bool discard);
+typedef bool rnp_input_reader_t(void *app_ctx, void *buf, size_t len, size_t *read);
+typedef void rnp_input_closer_t(void *app_ctx);
+typedef bool rnp_output_writer_t(void *app_ctx, const void *buf, size_t len);
+typedef void rnp_output_closer_t(void *app_ctx, bool discard);
 
 /**
  * Callback used for getting a password.

--- a/src/examples/dump.c
+++ b/src/examples/dump.c
@@ -47,10 +47,15 @@ print_usage(char *program_name)
             basename(program_name));
 }
 
-static ssize_t
-stdin_reader(void *app_ctx, void *buf, size_t len)
+static bool
+stdin_reader(void *app_ctx, void *buf, size_t len, size_t *readres)
 {
-    return read(STDIN_FILENO, buf, len);
+    ssize_t res = read(STDIN_FILENO, buf, len);
+    if (res < 0) {
+        return false;
+    }
+    *readres = res;
+    return true;
 }
 
 static bool

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1661,18 +1661,14 @@ rnp_input_from_memory(rnp_input_t *input, const uint8_t buf[], size_t buf_len, b
     return RNP_SUCCESS;
 }
 
-static ssize_t
-input_reader_bounce(pgp_source_t *src, void *buf, size_t len)
+static bool
+input_reader_bounce(pgp_source_t *src, void *buf, size_t len, size_t *read)
 {
     rnp_input_t input = (rnp_input_t) src->param;
     if (!input->reader) {
-        return -1;
+        return false;
     }
-    size_t read = 0;
-    if (!input->reader(input->app_ctx, buf, len, &read)) {
-        return -1;
-    }
-    return read;
+    return input->reader(input->app_ctx, buf, len, read);
 }
 
 static void

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1668,7 +1668,11 @@ input_reader_bounce(pgp_source_t *src, void *buf, size_t len)
     if (!input->reader) {
         return -1;
     }
-    return input->reader(input->app_ctx, buf, len);
+    size_t read = 0;
+    if (!input->reader(input->app_ctx, buf, len, &read)) {
+        return -1;
+    }
+    return read;
 }
 
 static void

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -83,12 +83,13 @@ int get_packet_type(uint8_t ptag);
  */
 int stream_pkt_type(pgp_source_t *src);
 
-/** @brief Peek length of the packet header. Returns -1 on error.
+/** @brief Peek length of the packet header. Returns false on error.
  *  @param src source to read length from
- *  @return number of bytes in packet header or -1 if there is a read error or packet length
+ *  @param hdrlen header length will be put here on success. Cannot be NULL.
+ *  @return true on success or false if there is a read error or packet length
  *          is ill-formed
  **/
-ssize_t stream_pkt_hdr_len(pgp_source_t *src);
+bool stream_pkt_hdr_len(pgp_source_t *src, size_t *hdrlen);
 
 bool stream_intedeterminate_pkt_len(pgp_source_t *src);
 
@@ -96,24 +97,24 @@ bool stream_partial_pkt_len(pgp_source_t *src);
 
 size_t get_partial_pkt_len(uint8_t blen);
 
-ssize_t get_pkt_len(uint8_t *hdr);
-
-/** @brief Read packet length for fixed-size (say, small) packet. Returns -1 on error.
+/** @brief Read packet length for fixed-size (say, small) packet. Returns false on error.
  *  Will also read packet tag byte. We do not allow partial length here as well as large
- *  packets (so ignoring possible ssize_t overflow)
+ *  packets (so ignoring possible size_t overflow)
  *
  *  @param src source to read length from
- *  @return length of the packet or -1 if there is read error or packet length is ill-formed
+ *  @param pktlen packet length will be stored here on success. Cannot be NULL.
+ *  @return true on success or false if there is read error or packet length is ill-formed
  **/
-ssize_t stream_read_pkt_len(pgp_source_t *src);
+bool stream_read_pkt_len(pgp_source_t *src, size_t *pktlen);
 
 /** @brief Read partial packet chunk length.
  *
  *  @param src source to read length from
+ *  @param clen chunk length will be stored here on success. Cannot be NULL.
  *  @param last will be set to true if chunk is last (i.e. has non-partial length)
- *  @return length of the chunk or -1 if there is read error or packet length is ill-formed
+ *  @return true on success or false if there is read error or packet length is ill-formed
  **/
-ssize_t stream_read_partial_chunk_len(pgp_source_t *src, bool *last);
+bool stream_read_partial_chunk_len(pgp_source_t *src, size_t *clen, bool *last);
 
 /** @brief initialize writing of packet body
  *  @param body preallocated structure

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -149,15 +149,11 @@ static bool
 is_pgp_source(pgp_source_t *src)
 {
     uint8_t buf;
-    ssize_t read;
-    int     tag;
-
-    if ((read = src_peek(src, &buf, sizeof(buf))) < 1) {
+    if (!src_peek_eq(src, &buf, 1)) {
         return false;
     }
 
-    tag = get_packet_type(buf);
-    switch (tag) {
+    switch (get_packet_type(buf)) {
     case PGP_PKT_PK_SESSION_KEY:
     case PGP_PKT_SK_SESSION_KEY:
     case PGP_PKT_ONE_PASS_SIG:
@@ -172,49 +168,52 @@ is_pgp_source(pgp_source_t *src)
     }
 }
 
-static ssize_t
-partial_pkt_src_read(pgp_source_t *src, void *buf, size_t len)
+static bool
+partial_pkt_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
-    pgp_source_partial_param_t *param = (pgp_source_partial_param_t *) src->param;
-    ssize_t                     read;
-    ssize_t                     write = 0;
-
     if (src->eof) {
-        return 0;
+        *readres = 0;
+        return true;
     }
 
-    if (param == NULL) {
-        return -1;
+    pgp_source_partial_param_t *param = (pgp_source_partial_param_t *) src->param;
+    if (!param) {
+        return false;
     }
 
+    size_t read;
+    size_t write = 0;
     while (len > 0) {
         if (!param->pleft && param->last) {
             // we have the last chunk
-            return write;
+            *readres = write;
+            return true;
         }
         if (!param->pleft) {
             // reading next chunk
-            read = stream_read_partial_chunk_len(param->readsrc, &param->last);
-            if (read < 0) {
-                return -1;
+            ssize_t toread = stream_read_partial_chunk_len(param->readsrc, &param->last);
+            if (toread < 0) {
+                return false;
             }
+            read = toread;
             param->psize = read;
             param->pleft = read;
         }
 
         if (!param->pleft) {
-            return write;
+            *readres = write;
+            return true;
         }
 
         read = param->pleft > len ? len : param->pleft;
-        read = src_read(param->readsrc, buf, read);
-        if (read == 0) {
-            RNP_LOG("unexpected eof");
-            return write;
-        }
-        if (read < 0) {
+        if (!src_read(param->readsrc, buf, read, &read)) {
             RNP_LOG("failed to read data chunk");
-            return -1;
+            return false;
+        }
+        if (!read) {
+            RNP_LOG("unexpected eof");
+            *readres = write;
+            return true;
         }
         write += read;
         len -= read;
@@ -222,7 +221,8 @@ partial_pkt_src_read(pgp_source_t *src, void *buf, size_t len)
         param->pleft -= read;
     }
 
-    return write;
+    *readres = write;
+    return true;
 }
 
 static void
@@ -252,7 +252,7 @@ init_partial_pkt_src(pgp_source_t *src, pgp_source_t *readsrc)
 
     /* we are sure that there are 2 bytes in readsrc */
     param = (pgp_source_partial_param_t *) src->param;
-    (void) src_read(readsrc, buf, 2);
+    (void) src_read_eq(readsrc, buf, 2);
     param->type = get_packet_type(buf[0]);
     param->psize = get_partial_pkt_len(buf[1]);
     param->pleft = param->psize;
@@ -272,15 +272,14 @@ init_partial_pkt_src(pgp_source_t *src, pgp_source_t *readsrc)
     return RNP_SUCCESS;
 }
 
-static ssize_t
-literal_src_read(pgp_source_t *src, void *buf, size_t len)
+static bool
+literal_src_read(pgp_source_t *src, void *buf, size_t len, size_t *read)
 {
     pgp_source_literal_param_t *param = (pgp_source_literal_param_t *) src->param;
     if (!param) {
-        return -1;
+        return false;
     }
-
-    return src_read(param->pkt.readsrc, buf, len);
+    return src_read(param->pkt.readsrc, buf, len, read);
 }
 
 static void
@@ -299,19 +298,17 @@ literal_src_close(pgp_source_t *src)
     }
 }
 
-static ssize_t
-compressed_src_read(pgp_source_t *src, void *buf, size_t len)
+static bool
+compressed_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
-    ssize_t                        read = 0;
-    int                            ret;
     pgp_source_compressed_param_t *param = (pgp_source_compressed_param_t *) src->param;
-
     if (param == NULL) {
-        return -1;
+        return false;
     }
 
     if (src->eof || param->zend) {
-        return 0;
+        *readres = 0;
+        return true;
     }
 
     if ((param->alg == PGP_C_ZIP) || (param->alg == PGP_C_ZLIB)) {
@@ -322,17 +319,17 @@ compressed_src_read(pgp_source_t *src, void *buf, size_t len)
 
         while ((param->z.avail_out > 0) && (!param->zend)) {
             if (param->z.avail_in == 0) {
-                read = src_read(param->pkt.readsrc, param->in, sizeof(param->in));
-                if (read < 0) {
+                size_t read = 0;
+                if (!src_read(param->pkt.readsrc, param->in, sizeof(param->in), &read)) {
                     RNP_LOG("failed to read data");
-                    return -1;
+                    return false;
                 }
                 param->z.next_in = param->in;
                 param->z.avail_in = read;
                 param->inlen = read;
                 param->inpos = 0;
             }
-            ret = inflate(&param->z, Z_SYNC_FLUSH);
+            int ret = inflate(&param->z, Z_SYNC_FLUSH);
             if (ret == Z_STREAM_END) {
                 param->zend = true;
                 if (param->z.avail_in > 0) {
@@ -342,16 +339,16 @@ compressed_src_read(pgp_source_t *src, void *buf, size_t len)
             }
             if (ret != Z_OK) {
                 RNP_LOG("inflate error %d", ret);
-                return -1;
+                return false;
             }
             if (!param->z.avail_in && src_eof(param->pkt.readsrc)) {
                 RNP_LOG("unexpected end of zlib stream");
-                return -1;
+                return false;
             }
         }
-
         param->inpos = param->z.next_in - param->in;
-        return len - param->z.avail_out;
+        *readres = len - param->z.avail_out;
+        return true;
     }
 #ifdef HAVE_BZLIB_H
     if (param->alg == PGP_C_BZIP2) {
@@ -362,17 +359,17 @@ compressed_src_read(pgp_source_t *src, void *buf, size_t len)
 
         while ((param->bz.avail_out > 0) && (!param->zend)) {
             if (param->bz.avail_in == 0) {
-                read = src_read(param->pkt.readsrc, param->in, sizeof(param->in));
-                if (read < 0) {
+                size_t read = 0;
+                if (!src_read(param->pkt.readsrc, param->in, sizeof(param->in), &read)) {
                     RNP_LOG("failed to read data");
-                    return -1;
+                    return false;
                 }
                 param->bz.next_in = (char *) param->in;
                 param->bz.avail_in = read;
                 param->inlen = read;
                 param->inpos = 0;
             }
-            ret = BZ2_bzDecompress(&param->bz);
+            int ret = BZ2_bzDecompress(&param->bz);
             if (ret == BZ_STREAM_END) {
                 param->zend = true;
                 if (param->bz.avail_in > 0) {
@@ -381,20 +378,21 @@ compressed_src_read(pgp_source_t *src, void *buf, size_t len)
                 break;
             }
             if (ret != BZ_OK) {
-                RNP_LOG("inflate error %d", ret);
-                return -1;
+                RNP_LOG("bzdecompress error %d", ret);
+                return false;
             }
             if (!param->bz.avail_in && src_eof(param->pkt.readsrc)) {
                 RNP_LOG("unexpected end of bzip stream");
-                return -1;
+                return false;
             }
         }
 
         param->inpos = (uint8_t *) param->bz.next_in - param->in;
-        return len - param->bz.avail_out;
+        *readres = len - param->bz.avail_out;
+        return true;
     }
 #endif
-    return -1;
+    return false;
 }
 
 static void
@@ -470,12 +468,12 @@ encrypted_start_aead_chunk(pgp_source_encrypted_param_t *param, size_t idx, bool
 static bool
 encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 {
-    bool    lastchunk = false;
-    bool    chunkend = false;
-    bool    res = false;
-    ssize_t read;
-    ssize_t tagread;
-    ssize_t taglen;
+    bool   lastchunk = false;
+    bool   chunkend = false;
+    bool   res = false;
+    size_t read;
+    size_t tagread;
+    size_t taglen;
 
     param->cachepos = 0;
     param->cachelen = 0;
@@ -488,20 +486,20 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     taglen = pgp_cipher_aead_tag_len(param->aead_hdr.aalg);
     read = sizeof(param->cache) - 2 * PGP_AEAD_MAX_TAG_LEN;
 
-    if ((size_t) read >= param->chunklen - param->chunkin) {
+    if (read >= param->chunklen - param->chunkin) {
         read = param->chunklen - param->chunkin;
         chunkend = true;
     } else {
         read = read - read % pgp_cipher_aead_granularity(&param->decrypt);
     }
 
-    if ((read = src_read(param->pkt.readsrc, param->cache, read)) < 0) {
-        return read;
+    if (!src_read(param->pkt.readsrc, param->cache, read, &read)) {
+        return false;
     }
 
     /* checking whether we have enough input for the final tags */
-    if ((tagread = src_peek(param->pkt.readsrc, param->cache + read, taglen * 2)) < 0) {
-        return tagread;
+    if (!src_peek(param->pkt.readsrc, param->cache + read, taglen * 2, &tagread)) {
+        return false;
     }
 
     if (tagread < taglen * 2) {
@@ -579,8 +577,8 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     return res;
 }
 
-static ssize_t
-encrypted_src_read_aead(pgp_source_t *src, void *buf, size_t len)
+static bool
+encrypted_src_read_aead(pgp_source_t *src, void *buf, size_t len, size_t *read)
 {
     pgp_source_encrypted_param_t *param = (pgp_source_encrypted_param_t *) src->param;
     size_t                        cbytes;
@@ -589,7 +587,6 @@ encrypted_src_read_aead(pgp_source_t *src, void *buf, size_t len)
     do {
         /* check whether we have something in the cache */
         cbytes = param->cachelen - param->cachepos;
-
         if (cbytes > 0) {
             if (cbytes >= left) {
                 memcpy(buf, param->cache + param->cachepos, left);
@@ -597,58 +594,59 @@ encrypted_src_read_aead(pgp_source_t *src, void *buf, size_t len)
                 if (param->cachepos == param->cachelen) {
                     param->cachepos = param->cachelen = 0;
                 }
-                return len;
-            } else {
-                memcpy(buf, param->cache + param->cachepos, cbytes);
-                buf = (uint8_t *) buf + cbytes;
-                left -= cbytes;
-                param->cachepos = param->cachelen = 0;
+                *read = len;
+                return true;
             }
+            memcpy(buf, param->cache + param->cachepos, cbytes);
+            buf = (uint8_t *) buf + cbytes;
+            left -= cbytes;
+            param->cachepos = param->cachelen = 0;
         }
 
         /* read something into cache */
         if (!encrypted_src_read_aead_part(param)) {
-            return -1;
+            return false;
         }
     } while ((left > 0) && (param->cachelen > 0));
 
-    return len - left;
+    *read = len - left;
+    return true;
 }
 
-static ssize_t
-encrypted_src_read_cfb(pgp_source_t *src, void *buf, size_t len)
+static bool
+encrypted_src_read_cfb(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
     pgp_source_encrypted_param_t *param = (pgp_source_encrypted_param_t *) src->param;
-    ssize_t                       read;
-    ssize_t                       mdcread;
-    ssize_t                       mdcsub;
-    bool                          parsemdc = false;
-    uint8_t                       mdcbuf[MDC_V1_SIZE];
-    uint8_t                       hash[PGP_SHA1_HASH_SIZE];
-
     if (param == NULL) {
-        return -1;
+        return false;
     }
 
     if (src->eof) {
-        return 0;
+        *readres = 0;
+        return true;
     }
 
-    read = src_read(param->pkt.readsrc, buf, len);
-    if (read <= 0) {
-        return read;
+    size_t read;
+    if (!src_read(param->pkt.readsrc, buf, len, &read)) {
+        return false;
+    }
+    if (!read) {
+        *readres = 0;
+        return true;
     }
 
+    bool    parsemdc = false;
+    uint8_t mdcbuf[MDC_V1_SIZE];
     if (param->has_mdc) {
+        size_t mdcread = 0;
         /* make sure there are always 20 bytes left on input */
-        mdcread = src_peek(param->pkt.readsrc, mdcbuf, MDC_V1_SIZE);
+        if (!src_peek(param->pkt.readsrc, mdcbuf, MDC_V1_SIZE, &mdcread) ||
+            (mdcread + read < MDC_V1_SIZE)) {
+            RNP_LOG("wrong mdc read state");
+            return false;
+        }
         if (mdcread < MDC_V1_SIZE) {
-            if ((mdcread < 0) || (mdcread + read < MDC_V1_SIZE)) {
-                RNP_LOG("wrong mdc read state");
-                return -1;
-            }
-
-            mdcsub = MDC_V1_SIZE - mdcread;
+            size_t mdcsub = MDC_V1_SIZE - mdcread;
             memmove(&mdcbuf[mdcsub], mdcbuf, mdcread);
             memcpy(mdcbuf, (uint8_t *) buf + read - mdcsub, mdcsub);
             read -= mdcsub;
@@ -665,23 +663,23 @@ encrypted_src_read_cfb(pgp_source_t *src, void *buf, size_t len)
             pgp_cipher_cfb_decrypt(&param->decrypt, mdcbuf, mdcbuf, MDC_V1_SIZE);
             pgp_cipher_cfb_finish(&param->decrypt);
             pgp_hash_add(&param->mdc, mdcbuf, 2);
+            uint8_t hash[PGP_SHA1_HASH_SIZE] = {0};
             pgp_hash_finish(&param->mdc, hash);
 
             if ((mdcbuf[0] != MDC_PKT_TAG) || (mdcbuf[1] != MDC_V1_SIZE - 2)) {
                 RNP_LOG("mdc header check failed");
-                return -1;
+                return false;
             }
 
             if (memcmp(&mdcbuf[2], hash, PGP_SHA1_HASH_SIZE) != 0) {
                 RNP_LOG("mdc hash check failed");
-                return -1;
+                return false;
             }
-
             param->mdc_validated = true;
         }
     }
-
-    return read;
+    *readres = read;
+    return true;
 }
 
 static rnp_result_t
@@ -755,16 +753,14 @@ signed_src_update(pgp_source_t *src, const void *buf, size_t len)
     pgp_hash_list_update(param->hashes, buf, len);
 }
 
-static ssize_t
-signed_src_read(pgp_source_t *src, void *buf, size_t len)
+static bool
+signed_src_read(pgp_source_t *src, void *buf, size_t len, size_t *read)
 {
     pgp_source_signed_param_t *param = (pgp_source_signed_param_t *) src->param;
-
-    if (param == NULL) {
-        return -1;
+    if (!param) {
+        return false;
     }
-
-    return src_read(param->readsrc, buf, len);
+    return src_read(param->readsrc, buf, len, read);
 }
 
 static void
@@ -798,7 +794,7 @@ signed_read_single_signature(pgp_source_signed_param_t *param,
     pgp_signature_t *     newsig;
     pgp_signature_info_t *siginfo;
 
-    if (src_peek(readsrc, &ptag, 1) < 1) {
+    if (!src_peek_eq(readsrc, &ptag, 1)) {
         RNP_LOG("failed to read signature packet header");
         return RNP_ERROR_READ;
     }
@@ -1009,10 +1005,10 @@ cleartext_parse_headers(pgp_source_t *src)
     char                       hdr[1024] = {0};
     char *                     hval;
     pgp_hash_alg_t             halg;
-    ssize_t                    hdrlen;
+    size_t                     hdrlen;
 
     do {
-        if ((hdrlen = src_peek_line(param->readsrc, hdr, sizeof(hdr))) < 0) {
+        if (!src_peek_line(param->readsrc, hdr, sizeof(hdr), &hdrlen)) {
             RNP_LOG("failed to peek line");
             return false;
         }
@@ -1099,27 +1095,28 @@ cleartext_process_line(pgp_source_t *src, const uint8_t *buf, size_t len, bool e
     }
 }
 
-static ssize_t
-cleartext_src_read(pgp_source_t *src, void *buf, size_t len)
+static bool
+cleartext_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
-    uint8_t                    srcb[CT_BUF_LEN];
-    uint8_t *                  cur, *en, *bg;
-    ssize_t                    read = 0;
-    ssize_t                    origlen = len;
     pgp_source_signed_param_t *param = (pgp_source_signed_param_t *) src->param;
-
-    if (param == NULL) {
-        return -1;
+    if (!param) {
+        return false;
     }
 
+    uint8_t  srcb[CT_BUF_LEN];
+    uint8_t *cur, *en, *bg;
+    size_t   read = 0;
+    size_t   origlen = len;
+
     read = param->outlen - param->outpos;
-    if ((size_t) read >= len) {
+    if (read >= len) {
         memcpy(buf, param->out + param->outpos, len);
         param->outpos += len;
         if (param->outpos == param->outlen) {
             param->outpos = param->outlen = 0;
         }
-        return len;
+        *readres = len;
+        return true;
     } else if (read > 0) {
         memcpy(buf, param->out + param->outpos, read);
         len -= read;
@@ -1128,14 +1125,14 @@ cleartext_src_read(pgp_source_t *src, void *buf, size_t len)
     }
 
     if (param->clr_eod) {
-        return origlen - len;
+        *readres = origlen - len;
+        return true;
     }
 
     do {
-        read = src_peek(param->readsrc, srcb, sizeof(srcb));
-        if (read < 0) {
-            return -1;
-        } else if (read == 0) {
+        if (!src_peek(param->readsrc, srcb, sizeof(srcb), &read)) {
+            return false;
+        } else if (!read) {
             break;
         }
 
@@ -1178,7 +1175,7 @@ cleartext_src_read(pgp_source_t *src, void *buf, size_t len)
         buf = (uint8_t *) buf + read;
         len -= read;
 
-        if ((size_t) read == param->outlen) {
+        if (read == param->outlen) {
             param->outlen = 0;
         } else {
             param->outpos = read;
@@ -1190,7 +1187,8 @@ cleartext_src_read(pgp_source_t *src, void *buf, size_t len)
         }
     } while (1);
 
-    return origlen - len;
+    *readres = origlen - len;
+    return true;
 }
 
 static bool
@@ -1208,7 +1206,7 @@ encrypted_decrypt_cfb_header(pgp_source_encrypted_param_t *param,
     }
 
     /* reading encrypted header to check the password validity */
-    if (src_peek(param->pkt.readsrc, enchdr, blsize + 2) < blsize + 2) {
+    if (!src_peek_eq(param->pkt.readsrc, enchdr, blsize + 2)) {
         RNP_LOG("failed to read encrypted header");
         return false;
     }
@@ -1524,7 +1522,9 @@ init_packet_params(pgp_source_packet_param_t *param)
     }
 
     param->hdrlen = len;
-    src_peek(param->readsrc, param->hdr, param->hdrlen);
+    if (!src_peek_eq(param->readsrc, param->hdr, param->hdrlen)) {
+        return RNP_ERROR_READ;
+    }
 
     /* initialize partial reader if needed */
     if (stream_partial_pkt_len(param->readsrc)) {
@@ -1673,7 +1673,7 @@ init_compressed_src(pgp_source_t *src, pgp_source_t *readsrc)
     }
 
     /* Reading compression algorithm */
-    if (src_read(param->pkt.readsrc, &alg, 1) != 1) {
+    if (!src_read_eq(param->pkt.readsrc, &alg, 1)) {
         RNP_LOG("failed to read compression algorithm");
         errcode = RNP_ERROR_READ;
         goto finish;
@@ -1770,11 +1770,10 @@ encrypted_read_packet_data(pgp_source_encrypted_param_t *param)
 
     /* Reading pk/sk encrypted session key(s) */
     while (true) {
-        if (src_peek(param->pkt.readsrc, &ptag, 1) < 1) {
+        if (!src_peek_eq(param->pkt.readsrc, &ptag, 1)) {
             RNP_LOG("failed to read packet header");
             return RNP_ERROR_READ;
         }
-
         ptype = get_packet_type(ptag);
 
         if (ptype == PGP_PKT_SK_SESSION_KEY) {
@@ -1810,7 +1809,7 @@ encrypted_read_packet_data(pgp_source_encrypted_param_t *param)
     /* Reading header of encrypted packet */
     if (ptype == PGP_PKT_AEAD_ENCRYPTED) {
         param->aead = true;
-        if (src_peek(param->pkt.readsrc, hdr, 4) != 4) {
+        if (!src_peek_eq(param->pkt.readsrc, hdr, 4)) {
             return RNP_ERROR_READ;
         }
 
@@ -1994,7 +1993,7 @@ init_cleartext_signed_src(pgp_source_t *src)
     pgp_source_signed_param_t *param = (pgp_source_signed_param_t *) src->param;
 
     /* checking header line */
-    if (src_read(param->readsrc, buf, hdrlen) != hdrlen) {
+    if (!src_read_eq(param->readsrc, buf, hdrlen)) {
         RNP_LOG("failed to read header");
         return RNP_ERROR_READ;
     }
@@ -2015,9 +2014,8 @@ init_cleartext_signed_src(pgp_source_t *src)
         return RNP_ERROR_BAD_FORMAT;
     }
 
-    param->clr_fline = true;
-
     /* now we are good to go */
+    param->clr_fline = true;
     return RNP_SUCCESS;
 }
 
@@ -2061,7 +2059,7 @@ init_signed_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *read
 
     /* Reading one-pass and signature packets */
     while (true) {
-        if (src_peek(readsrc, &ptag, 1) < 1) {
+        if (!src_peek_eq(readsrc, &ptag, 1)) {
             RNP_LOG("failed to read packet header");
             errcode = RNP_ERROR_READ;
             goto finish;
@@ -2149,15 +2147,13 @@ static rnp_result_t
 init_packet_sequence(pgp_processing_ctx_t *ctx, pgp_source_t *src)
 {
     uint8_t       ptag;
-    ssize_t       read;
     int           type;
     pgp_source_t  psrc;
     pgp_source_t *lsrc = src;
     rnp_result_t  ret;
 
     while (1) {
-        read = src_peek(lsrc, &ptag, 1);
-        if (read < 1) {
+        if (!src_peek_eq(lsrc, &ptag, 1)) {
             RNP_LOG("cannot read packet tag");
             return RNP_ERROR_READ;
         }
@@ -2261,7 +2257,6 @@ init_armored_sequence(pgp_processing_ctx_t *ctx, pgp_source_t *src)
 rnp_result_t
 process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t *src)
 {
-    ssize_t              read;
     rnp_result_t         res = RNP_ERROR_BAD_FORMAT;
     rnp_result_t         fres;
     pgp_processing_ctx_t ctx;
@@ -2312,15 +2307,15 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t *src)
         }
 
         while (!datasrc.eof) {
-            read = src_read(&datasrc, readbuf, PGP_INPUT_CACHE_SIZE);
-            if (read < 0) {
+            size_t read = 0;
+            if (!src_read(&datasrc, readbuf, PGP_INPUT_CACHE_SIZE, &read)) {
                 res = RNP_ERROR_GENERIC;
                 break;
-            } else if (read > 0) {
+            }
+            if (read > 0) {
                 signed_src_update(ctx.signed_src, readbuf, read);
             }
         }
-
         src_close(&datasrc);
     } else {
         /* file processing case */
@@ -2337,8 +2332,8 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t *src)
 
         /* reading the input */
         while (!decsrc->eof) {
-            read = src_read(decsrc, readbuf, PGP_INPUT_CACHE_SIZE);
-            if (read < 0) {
+            size_t read = 0;
+            if (!src_read(decsrc, readbuf, PGP_INPUT_CACHE_SIZE, &read)) {
                 res = RNP_ERROR_GENERIC;
                 break;
             }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -682,7 +682,7 @@ signature_set_embedded_sig(pgp_signature_t *sig, pgp_signature_t *esig)
     pgp_sig_subpkt_t *subpkt = NULL;
     pgp_dest_t        memdst = {};
     pgp_source_t      memsrc = {};
-    ssize_t           len = 0;
+    size_t            len = 0;
     bool              res = false;
 
     if (init_mem_dest(&memdst, NULL, 0)) {
@@ -697,7 +697,7 @@ signature_set_embedded_sig(pgp_signature_t *sig, pgp_signature_t *esig)
         RNP_LOG("failed to init mem src");
         goto finish;
     }
-    if ((len = stream_read_pkt_len(&memsrc)) < 0) {
+    if (!stream_read_pkt_len(&memsrc, &len)) {
         RNP_LOG("wrong pkt len");
         goto finish;
     }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -709,7 +709,7 @@ signature_set_embedded_sig(pgp_signature_t *sig, pgp_signature_t *esig)
     }
 
     subpkt->hashed = 0;
-    if (src_read(&memsrc, subpkt->data, len) != len) {
+    if (!src_read_eq(&memsrc, subpkt->data, len)) {
         RNP_LOG("failed to read back signature");
         goto finish;
     }

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1681,7 +1681,6 @@ static rnp_result_t
 process_stream_sequence(pgp_source_t *src, pgp_dest_t *streams, unsigned count)
 {
     uint8_t *    readbuf = NULL;
-    ssize_t      read;
     pgp_dest_t * sstream = NULL; /* signed stream if any, to call signed_dst_update on it */
     pgp_dest_t * wstream = NULL; /* stream to dst_write() source data, may be empty */
     rnp_result_t ret = RNP_ERROR_GENERIC;
@@ -1704,8 +1703,8 @@ process_stream_sequence(pgp_source_t *src, pgp_dest_t *streams, unsigned count)
 
     /* processing source stream */
     while (!src->eof) {
-        read = src_read(src, readbuf, PGP_INPUT_CACHE_SIZE);
-        if (read < 0) {
+        size_t read = 0;
+        if (!src_read(src, readbuf, PGP_INPUT_CACHE_SIZE, &read)) {
             RNP_LOG("failed to read from source");
             ret = RNP_ERROR_READ;
             goto finish;

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1610,10 +1610,15 @@ cli_cfg_set_keystore_info(rnp_cfg_t *cfg)
     return true;
 }
 
-static ssize_t
-stdin_reader(void *app_ctx, void *buf, size_t len)
+static bool
+stdin_reader(void *app_ctx, void *buf, size_t len, size_t *readres)
 {
-    return read(STDIN_FILENO, buf, len);
+    ssize_t res = read(STDIN_FILENO, buf, len);
+    if (res < 0) {
+        return false;
+    }
+    *readres = res;
+    return true;
 }
 
 static bool

--- a/src/tests/partial-length.cpp
+++ b/src/tests/partial-length.cpp
@@ -218,8 +218,8 @@ TEST_F(rnp_tests, test_partial_length_first_packet_length)
     assert_int_equal(flags, PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT | PGP_PKT_LITDATA);
     // checking length
     bool last = true; // should be reset by stream_read_partial_chunk_len()
-    assert_true(stream_read_partial_chunk_len(&src, &last) >=
-                PGP_PARTIAL_PKT_FIRST_PART_MIN_SIZE);
+    assert_true(stream_read_partial_chunk_len(&src, &len, &last));
+    assert_true(len >= PGP_PARTIAL_PKT_FIRST_PART_MIN_SIZE);
     assert_false(last);
     // cleanup
     src_close(&src);

--- a/src/tests/partial-length.cpp
+++ b/src/tests/partial-length.cpp
@@ -214,7 +214,7 @@ TEST_F(rnp_tests, test_partial_length_first_packet_length)
     free_packet_body(&body);
     // checking next packet header (should be partial length literal data)
     uint8_t flags = 0;
-    assert_int_equal(src_read(&src, &flags, 1), 1);
+    assert_true(src_read_eq(&src, &flags, 1));
     assert_int_equal(flags, PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT | PGP_PKT_LITDATA);
     // checking length
     bool last = true; // should be reset by stream_read_partial_chunk_len()

--- a/src/tests/partial-length.cpp
+++ b/src/tests/partial-length.cpp
@@ -45,8 +45,8 @@ typedef struct {
 } dummy_reader_ctx_st;
 
 // reader of sequence of dummy bytes
-static ssize_t
-dummy_reader(void *app_ctx, void *buf, size_t len)
+static bool
+dummy_reader(void *app_ctx, void *buf, size_t len, size_t *read)
 {
     size_t               filled = 0;
     dummy_reader_ctx_st *ctx = NULL;
@@ -56,7 +56,8 @@ dummy_reader(void *app_ctx, void *buf, size_t len)
         memset(buf, ctx->dummy, filled);
         ctx->remaining -= filled;
     }
-    return filled;
+    *read = filled;
+    return true;
 }
 
 static void

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -101,33 +101,6 @@ file_empty(const char *path)
     return stat(path, &st) == 0 && S_ISREG(st.st_mode) && st.st_size == 0;
 }
 
-uint8_t *
-file_contents(const char *path, ssize_t *size)
-{
-    int         fd;
-    struct stat st;
-    uint8_t *   mem;
-
-    *size = -1;
-    if ((stat(path, &st) != 0) || (st.st_size == 0)) {
-        return NULL;
-    }
-
-#ifdef O_BINARY
-    fd = open(path, O_RDONLY | O_BINARY);
-#else
-    fd = open(path, O_RDONLY);
-#endif
-    if (fd < 0) {
-        return NULL;
-    }
-    if ((mem = (uint8_t *) malloc(st.st_size))) {
-        *size = read(fd, mem, st.st_size);
-    }
-    close(fd);
-    return mem;
-}
-
 std::string
 file_to_str(const std::string &path)
 {

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -77,9 +77,6 @@ off_t file_size(const char *path);
 /* Check if a directory exists */
 bool dir_exists(const char *path);
 
-/* Read file contents into the memory */
-uint8_t *file_contents(const char *path, ssize_t *size);
-
 /* Read file contents into the std::string */
 std::string file_to_str(const std::string &path);
 


### PR DESCRIPTION
This PR removes ssize_t (which is not well available in Windows) from the whole library.
While internal usage was mostly around src_read() function and is pretty safe, it make a breaking change for FFI interface, so ruby-rnp side should be updated.

Fixes #898