### PR TITLE
Fix possible rare failure in test_key_unlock_pgp() test.

### DIFF
--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -145,9 +145,10 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     // verify (negative)
     std::fstream verf("dummyfile.dat.pgp",
                       std::ios_base::binary | std::ios_base::out | std::ios_base::in);
-    off_t        versize = file_size("dummyfile.dat.pgp");
-    verf.seekg(versize - 3, std::ios::beg);
-    verf.write("\x0C", 1);
+    verf.seekg(-3, std::ios::end);
+    char bt = verf.peek() ^ 0xff;
+    verf.seekp(-3, std::ios::end);
+    verf.write(&bt, 1);
     verf.close();
     assert_false(cli_rnp_process_file(&rnp));
 


### PR DESCRIPTION
It's quite logical that we should not attempt to modify the signature by writing constant value inside of it - it may match already existing one in 1 in 256 cases.

Fixes #994 