### PR TITLE
tests: Use a specific Google Test commit.

### DIFF
--- a/src/tests/gtest-CMakeLists.txt.in
+++ b/src/tests/gtest-CMakeLists.txt.in
@@ -5,8 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
-  GIT_SHALLOW       yes
+  GIT_TAG           c43f710
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
This should prevent random breakage and can be updated periodically as
needed.