### PR TITLE
Correct key fields calculation and sigs validation.

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -340,6 +340,7 @@ typedef enum {
  */
 
 typedef enum {
+    PGP_SIG_SUBPKT_UNKNOWN = 0,
     PGP_SIG_SUBPKT_CREATION_TIME = 2,       /* signature creation time */
     PGP_SIG_SUBPKT_EXPIRATION_TIME = 3,     /* signature expiration time */
     PGP_SIG_SUBPKT_EXPORT_CERT = 4,         /* exportable certification */

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -331,6 +331,18 @@ keygen_primary_merge_defaults(rnp_keygen_primary_desc_t *desc)
     }
 }
 
+static void
+pgp_key_mark_valid(pgp_key_t *key)
+{
+    key->valid = true;
+    key->validated = true;
+    for (size_t i = 0; i < pgp_key_get_subsig_count(key); i++) {
+        pgp_subsig_t *sub = pgp_key_get_subsig(key, i);
+        sub->validated = true;
+        sub->valid = true;
+    }
+}
+
 bool
 pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
                          bool                       merge_defaults,
@@ -408,11 +420,8 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
     }
 
     /* mark it as valid */
-    primary_pub->valid = true;
-    primary_pub->validated = true;
-    primary_sec->valid = true;
-    primary_sec->validated = true;
-
+    pgp_key_mark_valid(primary_pub);
+    pgp_key_mark_valid(primary_sec);
     ok = true;
 end:
     // free any user preferences
@@ -545,10 +554,8 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
         break;
     }
 
-    subkey_pub->valid = true;
-    subkey_pub->validated = true;
-    subkey_sec->valid = true;
-    subkey_sec->validated = true;
+    pgp_key_mark_valid(subkey_pub);
+    pgp_key_mark_valid(subkey_sec);
     ok = true;
 end:
     transferable_subkey_destroy(&tskeysec);

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -422,7 +422,8 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
     /* mark it as valid */
     pgp_key_mark_valid(primary_pub);
     pgp_key_mark_valid(primary_sec);
-    ok = true;
+    /* refresh key's data */
+    ok = pgp_key_refresh_data(primary_pub) && pgp_key_refresh_data(primary_sec);
 end:
     // free any user preferences
     pgp_free_user_prefs(&desc->cert.prefs);
@@ -556,7 +557,8 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
 
     pgp_key_mark_valid(subkey_pub);
     pgp_key_mark_valid(subkey_sec);
-    ok = true;
+    ok = pgp_subkey_refresh_data(subkey_pub, primary_pub) &&
+         pgp_subkey_refresh_data(subkey_sec, primary_sec);
 end:
     transferable_subkey_destroy(&tskeysec);
     transferable_subkey_destroy(&tskeypub);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1010,6 +1010,10 @@ pgp_subsig_from_signature(pgp_subsig_t *subsig, const pgp_signature_t *sig)
     }
     if (signature_has_key_server(&subsig->sig)) {
         subsig->prefs.key_server = (uint8_t *) signature_get_key_server(&subsig->sig);
+        if (!subsig->prefs.key_server) {
+            RNP_LOG("failed to alloc ks");
+            goto error;
+        }
     }
 
     return true;
@@ -1250,6 +1254,8 @@ pgp_subkey_refresh_data(pgp_key_t *sub, pgp_key_t *key)
     /* subkey flags */
     if (sig && signature_has_key_flags(&sig->sig)) {
         sub->key_flags = sig->key_flags;
+    } else {
+        sub->key_flags = pgp_pk_alg_capabilities(pgp_key_get_alg(sub));
     }
     /* revocation */
     pgp_key_clear_revokes(sub);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -273,6 +273,18 @@ pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt)
     return true;
 }
 
+static void
+pgp_key_clear_revokes(pgp_key_t *key)
+{
+    key->revoked = false;
+    for (size_t i = 0; i < pgp_key_get_revoke_count(key); i++) {
+        revoke_free(pgp_key_get_revoke(key, i));
+    }
+    list_destroy(&key->revokes);
+    revoke_free(&key->revocation);
+    memset(&key->revocation, 0, sizeof(key->revocation));
+}
+
 void
 pgp_key_free_data(pgp_key_t *key)
 {
@@ -297,11 +309,7 @@ pgp_key_free_data(pgp_key_t *key)
     }
     list_destroy(&key->subsigs);
 
-    for (n = 0; n < pgp_key_get_revoke_count(key); n++) {
-        revoke_free(pgp_key_get_revoke(key, n));
-    }
-    list_destroy(&key->revokes);
-    revoke_free(&key->revocation);
+    pgp_key_clear_revokes(key);
     free(key->primary_grip);
     key->primary_grip = NULL;
     list_destroy(&key->subkey_grips);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1665,6 +1665,8 @@ pgp_key_validate_primary(pgp_key_t *key)
             if (uid) {
                 signature_check_certification(&sinfo, pgp_key_get_pkt(key), &uid->pkt);
                 has_cert = sinfo.valid && !sinfo.expired;
+                sig->validated = true;
+                sig->valid = sinfo.valid && !sinfo.expired;
             }
             continue;
         }
@@ -1675,6 +1677,8 @@ pgp_key_validate_primary(pgp_key_t *key)
             sinfo.signer = key;
             sinfo.signer_valid = true;
             signature_check_direct(&sinfo, pgp_key_get_pkt(key));
+            sig->validated = true;
+            sig->valid = sinfo.valid;
             /* revocation signature cannot expire */
             if (sinfo.valid) {
                 return RNP_SUCCESS;
@@ -1706,6 +1710,8 @@ pgp_key_validate_subkey(pgp_key_t *subkey, pgp_key_t *key)
             sinfo.signer = key;
             sinfo.signer_valid = true;
             signature_check_binding(&sinfo, pgp_key_get_pkt(key), pgp_key_get_pkt(subkey));
+            sig->validated = true;
+            sig->valid = sinfo.valid && !sinfo.expired;
             has_binding = sinfo.valid && !sinfo.expired;
             continue;
         }
@@ -1717,6 +1723,8 @@ pgp_key_validate_subkey(pgp_key_t *subkey, pgp_key_t *key)
             sinfo.signer_valid = true;
             signature_check_subkey_revocation(
               &sinfo, pgp_key_get_pkt(key), pgp_key_get_pkt(subkey));
+            sig->validated = true;
+            sig->valid = sinfo.valid;
             /* revocation signature cannot expire */
             if (sinfo.valid) {
                 return RNP_SUCCESS;

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1988,6 +1988,14 @@ pgp_key_validate_primary(pgp_key_t *key)
         }
 
         if (pgp_sig_is_self_signature(key, sig) && !has_cert) {
+            /* check whether key is expired */
+            if (signature_has_key_expiration(&sig->sig)) {
+                time_t expiry =
+                  pgp_key_get_creation(key) + signature_get_key_expiration(&sig->sig);
+                if (expiry < time(NULL)) {
+                    continue;
+                }
+            }
             has_cert = true;
         } else if (pgp_sig_is_key_revocation(key, sig)) {
             return RNP_SUCCESS;
@@ -2018,6 +2026,14 @@ pgp_key_validate_subkey(pgp_key_t *subkey, pgp_key_t *key)
         }
 
         if (pgp_sig_is_subkey_binding(subkey, sig) && !has_binding) {
+            /* check whether subkey is expired */
+            if (signature_has_key_expiration(&sig->sig)) {
+                time_t expiry =
+                  pgp_key_get_creation(subkey) + signature_get_key_expiration(&sig->sig);
+                if (expiry < time(NULL)) {
+                    continue;
+                }
+            }
             has_binding = true;
         } else if (pgp_sig_is_subkey_revocation(subkey, sig)) {
             return RNP_SUCCESS;

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -295,6 +295,10 @@ pgp_subsig_t *pgp_key_latest_selfsig(pgp_key_t *key, pgp_sig_subpacket_type_t su
  */
 pgp_subsig_t *pgp_key_latest_binding(pgp_key_t *subkey, bool validated);
 
+bool pgp_key_refresh_data(pgp_key_t *key);
+
+bool pgp_subkey_refresh_data(pgp_key_t *sub, pgp_key_t *key);
+
 void pgp_subsig_free(pgp_subsig_t *subsig);
 
 pgp_rawpacket_t *pgp_key_add_rawpacket(pgp_key_t *, void *, size_t, pgp_pkt_type_t);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -273,6 +273,8 @@ size_t pgp_key_get_subsig_count(const pgp_key_t *);
 
 pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
 
+bool pgp_subsig_from_signature(pgp_subsig_t *subsig, const pgp_signature_t *sig);
+
 /**
  * @brief Get the latest valid self-signature with information about the primary key,
  * containing the specified subpacket. It could be userid certification or direct-key

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -273,6 +273,26 @@ size_t pgp_key_get_subsig_count(const pgp_key_t *);
 
 pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
 
+/**
+ * @brief Get the latest valid self-signature with information about the primary key,
+ * containing the specified subpacket. It could be userid certification or direct-key
+ * signature.
+ *
+ * @param key key which should be searched for signature.
+ * @param subpkt subpacket type. Pass 0 to return just latest signature.
+ * @return pointer to signature object or NULL if failed/not found.
+ */
+pgp_subsig_t *pgp_key_latest_selfsig(pgp_key_t *key, pgp_sig_subpacket_type_t subpkt);
+
+/**
+ * @brief Get the latest valid subkey binding.
+ *
+ * @param subkey subkey which should be searched for signature.
+ * @param validated set to true whether binding signature must be validated
+ * @return pointer to signature object or NULL if failed/not found.
+ */
+pgp_subsig_t *pgp_key_latest_binding(pgp_key_t *subkey, bool validated);
+
 void pgp_subsig_free(pgp_subsig_t *subsig);
 
 pgp_rawpacket_t *pgp_key_add_rawpacket(pgp_key_t *, void *, size_t, pgp_pkt_type_t);

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -378,6 +378,8 @@ typedef struct pgp_subsig_t {
     uint8_t          trustamount; /* amount of trust */
     uint8_t          key_flags;   /* key flags for certification/direct key sig */
     pgp_user_prefs_t prefs;       /* user preferences for certification sig */
+    bool             validated;   /* signature was validated */
+    bool             valid;       /* signature was validated and is valid */
 } pgp_subsig_t;
 
 typedef struct pgp_userid_t {

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -719,11 +719,15 @@ transferable_key_revoke(const pgp_key_pkt_t *key,
         RNP_LOG("failed to set issuer key id");
         goto end;
     }
-    if (!signature_calculate_direct(key, sig, signer)) {
-        RNP_LOG("failed to calculate signature");
-        goto end;
+
+    if (is_primary_key_pkt(key->tag)) {
+        res = signature_calculate_direct(key, sig, signer);
+    } else {
+        res = signature_calculate_binding(signer, key, sig, false);
     }
-    res = true;
+    if (!res) {
+        RNP_LOG("failed to calculate signature");
+    }
 end:
     if (!res && sig) {
         free_signature(sig);

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -128,4 +128,8 @@ bool signature_calculate_certification(const pgp_key_pkt_t *   key,
                                        pgp_signature_t *       sig,
                                        const pgp_key_pkt_t *   signer);
 
+bool signature_calculate_direct(const pgp_key_pkt_t *key,
+                                pgp_signature_t *    sig,
+                                const pgp_key_pkt_t *signer);
+
 #endif

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -123,4 +123,9 @@ rnp_result_t encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t 
 
 void forget_secret_key_fields(pgp_key_material_t *key);
 
+bool signature_calculate_certification(const pgp_key_pkt_t *   key,
+                                       const pgp_userid_pkt_t *uid,
+                                       pgp_signature_t *       sig,
+                                       const pgp_key_pkt_t *   signer);
+
 #endif

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -132,4 +132,9 @@ bool signature_calculate_direct(const pgp_key_pkt_t *key,
                                 pgp_signature_t *    sig,
                                 const pgp_key_pkt_t *signer);
 
+bool signature_calculate_binding(const pgp_key_pkt_t *key,
+                                 const pgp_key_pkt_t *sub,
+                                 pgp_signature_t *    sig,
+                                 bool                 subsign);
+
 #endif

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1178,34 +1178,13 @@ signature_check_certification(pgp_signature_info_t *  sinfo,
                               const pgp_key_pkt_t *   key,
                               const pgp_userid_pkt_t *uid)
 {
-    pgp_hash_t   hash = {};
-    uint8_t      keyid[PGP_KEY_ID_SIZE];
-    rnp_result_t res = RNP_ERROR_SIGNATURE_INVALID;
+    pgp_hash_t hash = {};
 
     if (!signature_hash_certification(sinfo->sig, key, uid, &hash)) {
         return RNP_ERROR_BAD_FORMAT;
     }
 
-    res = signature_check(sinfo, &hash);
-
-    if (res) {
-        return res;
-    }
-
-    /* check key expiration time, only for self-signature. While sinfo->expired tells about
-       the signature expiry, we'll use it for bkey expiration as well */
-    if (signature_get_keyid(sinfo->sig, keyid) &&
-        !memcmp(keyid, pgp_key_get_keyid(sinfo->signer), PGP_KEY_ID_SIZE)) {
-        uint32_t expiry = signature_get_key_expiration(sinfo->sig);
-        uint32_t now = time(NULL);
-
-        if (expiry && (key->creation_time + expiry < now)) {
-            RNP_LOG("key expired %d seconds ago", (int) now - expiry - key->creation_time);
-            sinfo->expired = true;
-        }
-    }
-
-    return res;
+    return signature_check(sinfo, &hash);
 }
 
 rnp_result_t
@@ -1227,19 +1206,6 @@ signature_check_binding(pgp_signature_info_t *sinfo,
     }
 
     res = signature_check(sinfo, &hash);
-
-    /* check subkey expiration time. While sinfo->expired tells about the signature expiry,
-       we'll use it for subkey expiration as well */
-    if (!res) {
-        uint32_t expiry = signature_get_key_expiration(sinfo->sig);
-        uint32_t now = time(NULL);
-
-        if (expiry && (subkey->creation_time + expiry < now)) {
-            RNP_LOG("subkey expired %d seconds ago",
-                    (int) now - expiry - subkey->creation_time);
-            sinfo->expired = true;
-        }
-    }
 
     /* check primary key binding signature if any */
     if (!res && (signature_get_key_flags(sinfo->sig) & PGP_KF_SIGN)) {

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1024,11 +1024,13 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         pgp_subsig_t *sig = pgp_key_get_subsig(primary_pub, 0);
         assert_non_null(sig);
         sig->sig.hashed_data[10] ^= 0xff;
+        sig->validated = false;
         // ensure validation fails
         assert_rnp_success(pgp_key_validate(primary_pub, pubring));
         assert_false(primary_pub->valid);
         // restore the original data
         sig->sig.hashed_data[10] ^= 0xff;
+        sig->validated = false;
         assert_rnp_success(pgp_key_validate(primary_pub, pubring));
         assert_true(primary_pub->valid);
     }


### PR DESCRIPTION
This is a bit wide PR is part of the work on ability to update key expiration (as well as other fields).
Main feature here is moving from old incorrect way of key fields calculation (previously we just set key fields once new signature is added, without checking sigs validity and creation date).
Now it behave correctly by using data only from valid self-signatures, using the latest one as the source of key data (as key expiration, preferred algorithms and so on).

As a side effect of the changes different not so clearly related things were fixed here:
- issue #1092 (expired key)
- issue #1089 (wrong key expiration time)
- incorrect generation of subkey revocation signature
- issue #1020 (wrong subkey flags check)

Normally I would issue separate PRs for all these things, but now I'm a bit on rush with Thunderbird features implementation so allowed myself to put all these things into the single PR.

Fixes #1092, fixes #1089, fixes #1020.