### PR TITLE
Install automake for macos GHA.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,8 @@ task:
     LOCAL_BUILDS: /home/rnpuser/local-builds
     LOCAL_INSTALLS: /home/rnpuser/local-installs
   user_setup_script: |
+    # workaround 'pkg: repository meta has wrong version 2'
+    env ASSUME_ALWAYS_YES=yes pkg bootstrap -f
     pkg install -y sudo
     # add rnpuser
     pw useradd -n rnpuser -m

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -4,7 +4,7 @@ set -ex
 . ci/utils.inc.sh
 
 macos_install() {
-  [ "${CI-}" = true ] || brew bundle
+  brew bundle
 }
 
 freebsd_install() {


### PR DESCRIPTION
Looks like something changed in GHA macos runner, preventing correct installation of json-c. Attempting to fix it.