### PR TITLE
Use std::vector to store signatures/uids/keys etc.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -155,7 +155,14 @@ size_t     rnp_key_store_get_key_count(const rnp_key_store_t *);
 pgp_key_t *rnp_key_store_get_key(const rnp_key_store_t *, size_t);
 list       rnp_key_store_get_keys(const rnp_key_store_t *);
 
-pgp_key_t *rnp_key_store_add_key(rnp_key_store_t *, pgp_key_t *);
+/**
+ * @brief Add key to the keystore, copying it.
+ *
+ * @param keyring allocated keyring, cannot be NULL.
+ * @param key key to be added, cannot be NULL.
+ * @return pointer to the added key or NULL if failed.
+ */
+pgp_key_t *rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *key);
 
 pgp_key_t *rnp_key_store_import_key(rnp_key_store_t *,
                                     pgp_key_t *,

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -427,10 +427,6 @@ end:
     // we don't need this as we have loaded the encrypted key into primary_sec
     transferable_key_destroy(&tkeysec);
     transferable_key_destroy(&tkeypub);
-    if (!ok) {
-        pgp_key_free_data(primary_pub);
-        pgp_key_free_data(primary_sec);
-    }
     return ok;
 }
 
@@ -559,10 +555,6 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
 end:
     transferable_subkey_destroy(&tskeysec);
     transferable_subkey_destroy(&tskeypub);
-    if (!ok) {
-        pgp_key_free_data(subkey_pub);
-        pgp_key_free_data(subkey_sec);
-    }
     if (decrypted_primary_seckey) {
         free_key_pkt(decrypted_primary_seckey);
         free(decrypted_primary_seckey);

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -132,10 +132,7 @@ load_generated_g10_key(pgp_key_t *    dst,
     if (rnp_key_store_get_key_count(key_store) != 1) {
         goto end;
     }
-    memcpy(dst, rnp_key_store_get_key(key_store, 0), sizeof(*dst));
-    // we don't want the key store to free the internal key data
-    rnp_key_store_remove_key(key_store, (pgp_key_t *) rnp_key_store_get_key(key_store, 0));
-    ok = true;
+    ok = !pgp_key_copy(dst, rnp_key_store_get_key(key_store, 0), false);
 end:
     rnp_key_store_free(key_store);
     src_close(&memsrc);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1461,7 +1461,7 @@ pgp_key_add_rawpacket(pgp_key_t *key, void *data, size_t len, pgp_pkt_type_t tag
     return packet;
 }
 
-pgp_rawpacket_t *
+static pgp_rawpacket_t *
 pgp_key_add_stream_rawpacket(pgp_key_t *key, pgp_pkt_type_t tag, pgp_dest_t *memdst)
 {
     pgp_rawpacket_t *res =

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -302,7 +302,7 @@ pgp_key_free_data(pgp_key_t *key)
     for (n = 0; n < pgp_key_get_rawpacket_count(key); ++n) {
         pgp_rawpacket_free(pgp_key_get_rawpacket(key, n));
     }
-    list_destroy(&key->packets);
+    key->packets.clear();
 
     for (n = 0; n < pgp_key_get_subsig_count(key); n++) {
         pgp_subsig_free(pgp_key_get_subsig(key, n));
@@ -337,7 +337,7 @@ pgp_key_copy_raw_packets(pgp_key_t *dst, const pgp_key_t *src, bool pubonly)
     }
 
     for (size_t i = start; i < pgp_key_get_rawpacket_count(src); i++) {
-        pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(src, i);
+        const pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(src, i);
         if (!pgp_key_add_rawpacket(dst, pkt->raw, pkt->length, pkt->tag)) {
             return RNP_ERROR_OUT_OF_MEMORY;
         }
@@ -791,9 +791,9 @@ pgp_decrypt_seckey(const pgp_key_t *              key,
     pgp_key_pkt_t *               decrypted_seckey = NULL;
     typedef struct pgp_key_pkt_t *pgp_seckey_decrypt_t(
       const uint8_t *data, size_t data_len, const pgp_key_pkt_t *pubkey, const char *password);
-    pgp_seckey_decrypt_t *decryptor = NULL;
-    pgp_rawpacket_t *     packet = NULL;
-    char                  password[MAX_PASSWORD_LENGTH] = {0};
+    pgp_seckey_decrypt_t * decryptor = NULL;
+    const pgp_rawpacket_t *packet = NULL;
+    char                   password[MAX_PASSWORD_LENGTH] = {0};
 
     // sanity checks
     if (!key || !pgp_key_is_secret(key) || !provider) {
@@ -1457,12 +1457,17 @@ pgp_rawpacket_t *
 pgp_key_add_rawpacket(pgp_key_t *key, void *data, size_t len, pgp_pkt_type_t tag)
 {
     pgp_rawpacket_t *packet;
-    if (!(packet = (pgp_rawpacket_t *) list_append(&key->packets, NULL, sizeof(*packet)))) {
+
+    try {
+        key->packets.push_back({});
+        packet = &key->packets.back();
+    } catch (...) {
         return NULL;
     }
+
     if (data) {
         if (!(packet->raw = (uint8_t *) malloc(len))) {
-            list_remove((list_item *) packet);
+            key->packets.pop_back();
             return NULL;
         }
         memcpy(packet->raw, data, len);
@@ -1506,12 +1511,13 @@ pgp_key_add_sig_rawpacket(pgp_key_t *key, const pgp_signature_t *pkt)
     if (!pgp_signature_to_rawpacket(&rawpkt, pkt)) {
         return NULL;
     }
-    pgp_rawpacket_t *res =
-      (pgp_rawpacket_t *) list_append(&key->packets, &rawpkt, sizeof(rawpkt));
-    if (!res) {
+    try {
+        key->packets.push_back(rawpkt);
+        return &key->packets.back();
+    } catch (...) {
         pgp_rawpacket_free(&rawpkt);
+        return NULL;
     }
-    return res;
 }
 
 pgp_rawpacket_t *
@@ -1532,13 +1538,19 @@ pgp_key_add_uid_rawpacket(pgp_key_t *key, const pgp_userid_pkt_t *pkt)
 size_t
 pgp_key_get_rawpacket_count(const pgp_key_t *key)
 {
-    return list_length(key->packets);
+    return key->packets.size();
+}
+
+const pgp_rawpacket_t *
+pgp_key_get_rawpacket(const pgp_key_t *key, size_t idx)
+{
+    return (idx < key->packets.size()) ? &key->packets[idx] : NULL;
 }
 
 pgp_rawpacket_t *
-pgp_key_get_rawpacket(const pgp_key_t *key, size_t idx)
+pgp_key_get_rawpacket(pgp_key_t *key, size_t idx)
 {
-    return (pgp_rawpacket_t *) list_at(key->packets, idx);
+    return (idx < key->packets.size()) ? &key->packets[idx] : NULL;
 }
 
 size_t
@@ -2093,7 +2105,7 @@ pgp_key_write_packets(const pgp_key_t *key, pgp_dest_t *dst)
         return false;
     }
     for (size_t i = 0; i < pgp_key_get_rawpacket_count(key); i++) {
-        pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
+        const pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
         if (!pkt->raw || !pkt->length) {
             return false;
         }
@@ -2131,7 +2143,7 @@ write_xfer_packets(pgp_dest_t *           dst,
                    bool                   secret)
 {
     for (size_t i = 0; i < pgp_key_get_rawpacket_count(key); i++) {
-        pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
+        const pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
 
         if (!packet_matches(pkt->tag, secret)) {
             RNP_LOG("skipping packet with tag: %d", pkt->tag);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -239,7 +239,7 @@ bool
 pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt)
 {
     pgp_key_pkt_t keypkt = {};
-    memset(key, 0, sizeof(*key));
+    *key = {};
 
     if (!copy_key_pkt(&keypkt, pkt, false)) {
         RNP_LOG("failed to copy key packet");
@@ -356,7 +356,7 @@ pgp_key_copy_g10(pgp_key_t *dst, const pgp_key_t *src, bool pubonly)
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    memset(dst, 0, sizeof(*dst));
+    *dst = {};
 
     if (pgp_key_get_rawpacket_count(src) != 1) {
         RNP_LOG("wrong g10 key packets");
@@ -392,7 +392,7 @@ pgp_key_copy(pgp_key_t *dst, const pgp_key_t *src, bool pubonly)
 {
     rnp_result_t ret = RNP_ERROR_GENERIC;
     rnp_result_t tmpret;
-    memset(dst, 0, sizeof(*dst));
+    *dst = {};
 
     if (src->format == PGP_KEY_STORE_G10) {
         return pgp_key_copy_g10(dst, src, pubonly);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -82,9 +82,15 @@ struct pgp_key_t {
     pgp_key_store_format_t format;       /* the format of the key in packets[0] */
     bool                   valid;        /* this key is valid and usable */
     bool                   validated;    /* this key was validated */
-};
 
-struct pgp_key_t *pgp_key_new(void);
+    ~pgp_key_t();
+    pgp_key_t() = default;
+    pgp_key_t &operator=(pgp_key_t &&);
+    /* make sure we use only empty constructor/move operator */
+    pgp_key_t(const pgp_key_t &src) = delete;
+    pgp_key_t(pgp_key_t &&src) = delete;
+    pgp_key_t &operator=(const pgp_key_t &) = delete;
+};
 
 /**
  * @brief Create pgp_key_t object from the OpenPGP key packet.
@@ -94,20 +100,6 @@ struct pgp_key_t *pgp_key_new(void);
  * @return true if operation succeeded or false otherwise.
  */
 bool pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt);
-
-/** free the internal data of a key *and* the key structure itself
- *
- *  @param key the key
- **/
-void pgp_key_free(pgp_key_t *);
-
-/** free the internal data of a key
- *
- *  This does *not* free the key structure itself.
- *
- *  @param key the key
- **/
-void pgp_key_free_data(pgp_key_t *);
 
 /**
  * @brief Copy key, optionally copying only the public key part.

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -62,9 +62,9 @@
 
 /* describes a user's key */
 struct pgp_key_t {
-    list                         uids;    /* list of user ids as (char*) */
-    std::vector<pgp_rawpacket_t> packets; /* list of raw packets as pgp_rawpacket_t */
-    std::vector<pgp_subsig_t>    subsigs; /* list of signatures as pgp_subsig_t */
+    std::vector<pgp_userid_t>    uids;    /* array of user ids */
+    std::vector<pgp_rawpacket_t> packets; /* array of key packets */
+    std::vector<pgp_subsig_t>    subsigs; /* array of key signatures */
     list                         revokes; /* list of signature revocations pgp_revoke_t */
     list          subkey_grips; /* list of subkey grips (for primary keys) as uint8_t[20] */
     uint8_t       primary_grip[PGP_KEY_GRIP_SIZE]; /* grip of primary key (for subkeys) */
@@ -253,7 +253,9 @@ bool pgp_key_link_subkey_grip(pgp_key_t *key, pgp_key_t *subkey);
 
 size_t pgp_key_get_userid_count(const pgp_key_t *);
 
-pgp_userid_t *pgp_key_get_userid(const pgp_key_t *, size_t);
+const pgp_userid_t *pgp_key_get_userid(const pgp_key_t *, size_t);
+
+pgp_userid_t *pgp_key_get_userid(pgp_key_t *, size_t);
 
 pgp_revoke_t *pgp_key_get_userid_revoke(const pgp_key_t *, size_t userid);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -62,10 +62,10 @@
 
 /* describes a user's key */
 struct pgp_key_t {
-    list                      uids;    /* list of user ids as (char*) */
-    list                      packets; /* list of raw packets as pgp_rawpacket_t */
-    std::vector<pgp_subsig_t> subsigs; /* list of signatures as pgp_subsig_t */
-    list                      revokes; /* list of signature revocations pgp_revoke_t */
+    list                         uids;    /* list of user ids as (char*) */
+    std::vector<pgp_rawpacket_t> packets; /* list of raw packets as pgp_rawpacket_t */
+    std::vector<pgp_subsig_t>    subsigs; /* list of signatures as pgp_subsig_t */
+    list                         revokes; /* list of signature revocations pgp_revoke_t */
     list          subkey_grips; /* list of subkey grips (for primary keys) as uint8_t[20] */
     uint8_t       primary_grip[PGP_KEY_GRIP_SIZE]; /* grip of primary key (for subkeys) */
     bool          primary_grip_set;
@@ -320,7 +320,8 @@ pgp_rawpacket_t *pgp_key_add_uid_rawpacket(pgp_key_t *key, const pgp_userid_pkt_
 
 size_t pgp_key_get_rawpacket_count(const pgp_key_t *);
 
-pgp_rawpacket_t *pgp_key_get_rawpacket(const pgp_key_t *, size_t);
+pgp_rawpacket_t *      pgp_key_get_rawpacket(pgp_key_t *, size_t);
+const pgp_rawpacket_t *pgp_key_get_rawpacket(const pgp_key_t *, size_t);
 
 /**
  * @brief Get the number of pgp key's subkeys.

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -54,6 +54,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <vector>
 #include "pass-provider.h"
 #include <rekey/rnp_key_store.h>
 #include "crypto/symmetric.h"
@@ -61,10 +62,10 @@
 
 /* describes a user's key */
 struct pgp_key_t {
-    list          uids;         /* list of user ids as (char*) */
-    list          packets;      /* list of raw packets as pgp_rawpacket_t */
-    list          subsigs;      /* list of signatures as pgp_subsig_t */
-    list          revokes;      /* list of signature revocations pgp_revoke_t */
+    list                      uids;    /* list of user ids as (char*) */
+    list                      packets; /* list of raw packets as pgp_rawpacket_t */
+    std::vector<pgp_subsig_t> subsigs; /* list of signatures as pgp_subsig_t */
+    list                      revokes; /* list of signature revocations pgp_revoke_t */
     list          subkey_grips; /* list of subkey grips (for primary keys) as uint8_t[20] */
     uint8_t       primary_grip[PGP_KEY_GRIP_SIZE]; /* grip of primary key (for subkeys) */
     bool          primary_grip_set;
@@ -272,7 +273,8 @@ pgp_subsig_t *pgp_key_add_subsig(pgp_key_t *);
 
 size_t pgp_key_get_subsig_count(const pgp_key_t *);
 
-pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
+const pgp_subsig_t *pgp_key_get_subsig(const pgp_key_t *, size_t);
+pgp_subsig_t *      pgp_key_get_subsig(pgp_key_t *, size_t);
 
 bool pgp_subsig_from_signature(pgp_subsig_t *subsig, const pgp_signature_t *sig);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -65,7 +65,7 @@ struct pgp_key_t {
     std::vector<pgp_userid_t>    uids;    /* array of user ids */
     std::vector<pgp_rawpacket_t> packets; /* array of key packets */
     std::vector<pgp_subsig_t>    subsigs; /* array of key signatures */
-    list                         revokes; /* list of signature revocations pgp_revoke_t */
+    std::vector<pgp_revoke_t>    revokes; /* array of revocations */
     list          subkey_grips; /* list of subkey grips (for primary keys) as uint8_t[20] */
     uint8_t       primary_grip[PGP_KEY_GRIP_SIZE]; /* grip of primary key (for subkeys) */
     bool          primary_grip_set;
@@ -257,7 +257,7 @@ const pgp_userid_t *pgp_key_get_userid(const pgp_key_t *, size_t);
 
 pgp_userid_t *pgp_key_get_userid(pgp_key_t *, size_t);
 
-pgp_revoke_t *pgp_key_get_userid_revoke(const pgp_key_t *, size_t userid);
+const pgp_revoke_t *pgp_key_get_userid_revoke(const pgp_key_t *, size_t userid);
 
 bool pgp_key_has_userid(const pgp_key_t *, const char *);
 
@@ -267,7 +267,9 @@ pgp_revoke_t *pgp_key_add_revoke(pgp_key_t *);
 
 size_t pgp_key_get_revoke_count(const pgp_key_t *);
 
-pgp_revoke_t *pgp_key_get_revoke(const pgp_key_t *, size_t);
+const pgp_revoke_t *pgp_key_get_revoke(const pgp_key_t *, size_t);
+
+pgp_revoke_t *pgp_key_get_revoke(pgp_key_t *key, size_t idx);
 
 void revoke_free(pgp_revoke_t *revoke);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1087,7 +1087,6 @@ do_load_keys(rnp_ffi_t              ffi,
 
             if (!rnp_key_store_add_key(ffi->secring, key)) {
                 FFI_LOG(ffi, "Failed to add secret key");
-                pgp_key_free_data(&keycp);
                 ret = RNP_ERROR_GENERIC;
                 goto done;
             }
@@ -1112,18 +1111,15 @@ do_load_keys(rnp_ffi_t              ffi,
 
         if (key_needs_conversion(key, ffi->pubring)) {
             FFI_LOG(ffi, "This key format conversion is not yet supported");
-            pgp_key_free_data(&keycp);
             ret = RNP_ERROR_NOT_IMPLEMENTED;
             goto done;
         }
 
         if (!rnp_key_store_add_key(ffi->pubring, &keycp)) {
             FFI_LOG(ffi, "Failed to add public key");
-            pgp_key_free_data(&keycp);
             ret = RNP_ERROR_GENERIC;
             goto done;
         }
-        pgp_key_free_data(&keycp);
     }
 
     // success, even if we didn't actually load any
@@ -3329,7 +3325,6 @@ rnp_key_remove(rnp_key_handle_t key, uint32_t flags)
         if (!key->ffi->pubring || !key->pub) {
             return RNP_ERROR_BAD_PARAMETERS;
         }
-        pgp_key_free_data(key->pub);
         if (!rnp_key_store_remove_key(key->ffi->pubring, key->pub)) {
             return RNP_ERROR_KEY_NOT_FOUND;
         }
@@ -3339,7 +3334,6 @@ rnp_key_remove(rnp_key_handle_t key, uint32_t flags)
         if (!key->ffi->secring || !key->sec) {
             return RNP_ERROR_BAD_PARAMETERS;
         }
-        pgp_key_free_data(key->sec);
         if (!rnp_key_store_remove_key(key->ffi->secring, key->sec)) {
             return RNP_ERROR_KEY_NOT_FOUND;
         }
@@ -4002,10 +3996,6 @@ rnp_generate_key_json(rnp_ffi_t ffi, const char *json, char **results)
 
     ret = RNP_SUCCESS;
 done:
-    pgp_key_free_data(&primary_pub);
-    pgp_key_free_data(&primary_sec);
-    pgp_key_free_data(&sub_pub);
-    pgp_key_free_data(&sub_sec);
     json_object_put(jso);
     free(identifier_type);
     free(identifier);
@@ -4681,17 +4671,13 @@ done:
         op->password = NULL;
     }
     if (ret && op->gen_pub) {
-        pgp_key_free_data(op->gen_pub);
         rnp_key_store_remove_key(op->ffi->pubring, op->gen_pub);
         op->gen_pub = NULL;
     }
     if (ret && op->gen_sec) {
-        pgp_key_free_data(op->gen_sec);
         rnp_key_store_remove_key(op->ffi->secring, op->gen_sec);
         op->gen_sec = NULL;
     }
-    pgp_key_free_data(&sec);
-    pgp_key_free_data(&pub);
     return ret;
 }
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -5196,7 +5196,7 @@ rnp_uid_is_revoked(rnp_uid_handle_t uid, bool *result)
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    pgp_revoke_t *revoke = pgp_key_get_userid_revoke(uid->key, uid->idx);
+    const pgp_revoke_t *revoke = pgp_key_get_userid_revoke(uid->key, uid->idx);
     *result = revoke != NULL;
     return RNP_SUCCESS;
 }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3772,10 +3772,10 @@ rnp_generate_key_json(rnp_ffi_t ffi, const char *json, char **results)
     rnp_action_keygen_t keygen_desc = {};
     char *              identifier_type = NULL;
     char *              identifier = NULL;
-    pgp_key_t           primary_pub = {0};
-    pgp_key_t           primary_sec = {0};
-    pgp_key_t           sub_pub = {0};
-    pgp_key_t           sub_sec = {0};
+    pgp_key_t           primary_pub = {};
+    pgp_key_t           primary_sec = {};
+    pgp_key_t           sub_pub = {};
+    pgp_key_t           sub_sec = {};
     json_object *       jsoprimary = NULL;
     json_object *       jsosub = NULL;
     json_tokener_error  error;
@@ -6725,7 +6725,7 @@ key_iter_get_item(const rnp_identifier_iterator_t it, char *buf, size_t buf_len)
         }
         break;
     case PGP_KEY_SEARCH_USERID: {
-        pgp_userid_t *uid = pgp_key_get_userid(key, it->uididx);
+        const pgp_userid_t *uid = pgp_key_get_userid(key, it->uididx);
         if (!uid) {
             return false;
         }

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1166,7 +1166,6 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
     ret = true;
 done:
     src_close(&memsrc);
-    pgp_key_free_data(&key);
     if (!ret) {
         free_key_pkt(&seckey);
     }

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1104,7 +1104,7 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
                            const pgp_key_provider_t *key_provider)
 {
     const pgp_key_t *pubkey = NULL;
-    pgp_key_t        key = {0};
+    pgp_key_t        key = {};
     pgp_key_pkt_t    seckey = {};
     pgp_source_t     memsrc = {};
     bool             ret = false;

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1166,9 +1166,9 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
     ret = true;
 done:
     src_close(&memsrc);
+    pgp_key_free_data(&key);
     if (!ret) {
         free_key_pkt(&seckey);
-        pgp_key_free_data(&key);
     }
     return ret;
 }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -305,7 +305,7 @@ rnp_key_write_packets_stream(const pgp_key_t *key, pgp_dest_t *dst)
         return false;
     }
     for (size_t i = 0; i < pgp_key_get_rawpacket_count(key); i++) {
-        pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
+        const pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, i);
         if (!pkt->raw || !pkt->length) {
             return false;
         }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -207,7 +207,7 @@ error:
 bool
 rnp_key_from_transferable_key(pgp_key_t *key, pgp_transferable_key_t *tkey)
 {
-    memset(key, 0, sizeof(*key));
+    *key = {};
     /* create key */
     if (!pgp_key_from_pkt(key, &tkey->key)) {
         return false;
@@ -237,7 +237,7 @@ rnp_key_from_transferable_subkey(pgp_key_t *                subkey,
                                  pgp_transferable_subkey_t *tskey,
                                  pgp_key_t *                primary)
 {
-    memset(subkey, 0, sizeof(*subkey));
+    *subkey = {};
 
     /* create key */
     if (!pgp_key_from_pkt(subkey, &tskey->subkey)) {

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -449,7 +449,7 @@ rnp_key_store_refresh_subkey_grips(rnp_key_store_t *keyring, pgp_key_t *key)
         }
 
         for (unsigned i = 0; i < pgp_key_get_subsig_count(skey); i++) {
-            pgp_subsig_t *subsig = pgp_key_get_subsig(skey, i);
+            const pgp_subsig_t *subsig = pgp_key_get_subsig(skey, i);
 
             if (subsig->sig.type != PGP_SIG_SUBKEY) {
                 continue;
@@ -823,7 +823,7 @@ rnp_key_store_get_primary_key(const rnp_key_store_t *keyring, const pgp_key_t *s
     }
 
     for (unsigned i = 0; i < pgp_key_get_subsig_count(subkey); i++) {
-        pgp_subsig_t *subsig = pgp_key_get_subsig(subkey, i);
+        const pgp_subsig_t *subsig = pgp_key_get_subsig(subkey, i);
         if (subsig->sig.type != PGP_SIG_SUBKEY) {
             continue;
         }

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1010,6 +1010,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
           psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         assert_rnp_failure(signature_validate_certification(
           ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
+        pgp_key_free_data(&pub);
+        pgp_key_free_data(&sec);
 
         // validate via an alternative method
         // primary_pub + pubring
@@ -1135,6 +1137,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_true(sub_pub->validated);
         assert_true(sub_sec->valid);
         assert_true(sub_sec->validated);
+        pgp_key_free_data(&pub);
+        pgp_key_free_data(&sec);
 
         // validate via an alternative method
         sub_pub->valid = false;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -915,8 +915,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
     // primary
     {
-        pgp_key_t                 pub = {0};
-        pgp_key_t                 sec = {0};
+        pgp_key_t                 pub = {};
+        pgp_key_t                 sec = {};
         rnp_keygen_primary_desc_t desc;
         pgp_fingerprint_t         fp = {};
         pgp_sig_subpkt_t *        subpkt = NULL;
@@ -1055,8 +1055,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
     // sub
     {
-        pgp_key_t                pub = {0};
-        pgp_key_t                sec = {0};
+        pgp_key_t                pub = {};
+        pgp_key_t                sec = {};
         rnp_keygen_subkey_desc_t desc;
         pgp_fingerprint_t        fp = {};
         pgp_sig_subpkt_t *       subpkt = NULL;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1010,8 +1010,6 @@ TEST_F(rnp_tests, test_generated_key_sigs)
           psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         assert_rnp_failure(signature_validate_certification(
           ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
-        pgp_key_free_data(&pub);
-        pgp_key_free_data(&sec);
 
         // validate via an alternative method
         // primary_pub + pubring
@@ -1137,8 +1135,6 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_true(sub_pub->validated);
         assert_true(sub_sec->valid);
         assert_true(sub_sec->validated);
-        pgp_key_free_data(&pub);
-        pgp_key_free_data(&sec);
 
         // validate via an alternative method
         sub_pub->valid = false;

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -77,7 +77,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
         assert_non_null(tmp = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
 
         // steal this key from the store
-        key = (pgp_key_t *) calloc(1, sizeof(*key));
+        key = new pgp_key_t();
         assert_non_null(key);
         pgp_key_copy(key, tmp, false);
         rnp_key_store_free(ks);
@@ -248,5 +248,5 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
     assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.u, &u));
 
     // cleanup
-    pgp_key_free(key);
+    delete key;
 }

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -75,13 +75,11 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
         pgp_key_t *tmp = NULL;
         assert_non_null(tmp = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
-        assert_non_null(tmp);
 
         // steal this key from the store
         key = (pgp_key_t *) calloc(1, sizeof(*key));
         assert_non_null(key);
-        memcpy(key, tmp, sizeof(*key));
-        assert_true(rnp_key_store_remove_key(ks, tmp));
+        pgp_key_copy(key, tmp, false);
         rnp_key_store_free(ks);
     }
 

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -71,6 +71,7 @@ TEST_F(rnp_tests, test_key_store_search)
             }
             // add to the store
             assert_true(rnp_key_store_add_key(store, &key));
+            pgp_key_free_data(&key);
         }
     }
 

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -71,7 +71,6 @@ TEST_F(rnp_tests, test_key_store_search)
             }
             // add to the store
             assert_true(rnp_key_store_add_key(store, &key));
-            pgp_key_free_data(&key);
         }
     }
 

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -52,7 +52,7 @@ TEST_F(rnp_tests, test_key_store_search)
     // add our fake test keys
     for (size_t i = 0; i < ARRAY_SIZE(testdata); i++) {
         for (size_t n = 0; n < testdata[i].count; n++) {
-            pgp_key_t key = {0};
+            pgp_key_t key = {};
 
             key.pkt.tag = PGP_PKT_PUBLIC_KEY;
             key.pkt.version = PGP_V4;

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -713,7 +713,7 @@ TEST_F(rnp_tests, test_load_merge)
 
 TEST_F(rnp_tests, test_load_public_from_secret)
 {
-    pgp_key_t *      key, *skey1, *skey2, keycp;
+    pgp_key_t *      key, *skey1, *skey2, keycp = {};
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     uint8_t          sub1id[PGP_KEY_ID_SIZE];
     uint8_t          sub2id[PGP_KEY_ID_SIZE];
@@ -741,7 +741,6 @@ TEST_F(rnp_tests, test_load_public_from_secret)
       memcmp(pgp_key_get_subkey_grip(&keycp, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PKT_SECRET_KEY);
-    pgp_key_free_data(&keycp);
 
     /* copy the public part */
     assert_rnp_success(pgp_key_copy(&keycp, key, true));
@@ -755,7 +754,6 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
-    pgp_key_free_data(&keycp);
     /* subkey 1 */
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
     assert_false(pgp_key_is_secret(&keycp));
@@ -768,7 +766,6 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
-    pgp_key_free_data(&keycp);
     /* subkey 2 */
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
     assert_false(pgp_key_is_secret(&keycp));
@@ -781,7 +778,6 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
-    pgp_key_free_data(&keycp);
     /* save pubring */
     assert_true(rnp_key_store_write_to_path(pubstore));
     rnp_key_store_free(pubstore);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -755,6 +755,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
+    pgp_key_free_data(&keycp);
     /* subkey 1 */
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
     assert_false(pgp_key_is_secret(&keycp));
@@ -767,6 +768,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
+    pgp_key_free_data(&keycp);
     /* subkey 2 */
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
     assert_false(pgp_key_is_secret(&keycp));
@@ -779,6 +781,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
+    pgp_key_free_data(&keycp);
     /* save pubring */
     assert_true(rnp_key_store_write_to_path(pubstore));
     rnp_key_store_free(pubstore);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -84,8 +84,8 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     assert_true(pgp_key_is_locked(key));
 
     // decrypt the key
-    pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, 0);
-    pgp_key_pkt_t *  seckey =
+    const pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, 0);
+    pgp_key_pkt_t *        seckey =
       pgp_decrypt_seckey_pgp(pkt->raw, pkt->length, pgp_key_get_pkt(key), "password");
     assert_non_null(seckey);
 

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -46,7 +46,7 @@ find_subsig(const pgp_key_t *key, const char *userid)
     }
     // find the subsig index
     for (size_t i = 0; i < pgp_key_get_subsig_count(key); i++) {
-        pgp_subsig_t *subsig = pgp_key_get_subsig(key, i);
+        const pgp_subsig_t *subsig = pgp_key_get_subsig(key, i);
         if ((int) subsig->uid == uididx) {
             return subsig;
         }


### PR DESCRIPTION
This would significantly speed things up for the large keys.
Also move us closer to the C++ approach: pgp_key_t now is treated as C++ object with constructors/destructors instead of direct memory copying/deletion/etc.

Fixes #1101 