### PR TITLE
Add ability to strip unneeded signatures from keys.

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -490,4 +490,19 @@ typedef enum pgp_key_store_format_t {
     PGP_KEY_STORE_G10,
 } pgp_key_store_format_t;
 
+/**
+ * Key stripping flags. The meaning is as following:
+ * PGP_KS_INVALID_SIG : remove invalid signatures (including expired ones)
+ * PGP_KS_UNKNOWN_SIG : remove signatures issued by unknown keys
+ * PGP_KS_ONLYOWN_SIG : leave only self-signatures, made by the primary key
+ * PGP_KS_UNUSED_SIG  : remove valid but no longer meaningful self-signatures (i.e. old direct
+ *                      key signatures, self certifications, subkey bindings).
+ */
+typedef enum {
+    PGP_KS_INVALID_SIG = 1U << 0,
+    PGP_KS_UNKNOWN_SIG = 1U << 1,
+    PGP_KS_UNUSED_SIG = 1U << 2,
+    PGP_KS_ONLYOWN_SIG = 1U << 3
+} pgp_key_strip_flags_t;
+
 #endif

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -261,6 +261,11 @@ pgp_subsig_t *pgp_key_replace_signature(pgp_key_t *      key,
                                         pgp_signature_t *oldsig,
                                         pgp_signature_t *newsig);
 
+bool pgp_key_strip_signatures(pgp_key_t *           key,
+                              pgp_key_strip_flags_t flags,
+                              rnp_key_store_t *     keyring,
+                              pgp_key_provider_t *  keyprov);
+
 /**
  * @brief Get the latest valid self-signature with information about the primary key,
  * containing the specified subpacket. It could be userid certification or direct-key


### PR DESCRIPTION
This PR adds FFI flags and functions which allows to strip unneeded signatures from the key.

Since that would be a bit too overcomplicated (and O(n^2)) if used with the previous rawpacket approach, it was changed to store rawpackets inside of the corresponding upper-level objects. 
Also those types were made more C++ for easier and cleaner memory management.

Still draft since requires to check for memory leaks/add FFI functions and tests.

Closes #1006 