### PR TITLE
Make hex2bin utilize rnp_hex_decode.

### DIFF
--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -423,7 +423,14 @@ rnp_hex_encode(
 size_t
 rnp_hex_decode(const char *hex, uint8_t *buf, size_t buf_len)
 {
-    if (botan_hex_decode(hex, strlen(hex), buf, &buf_len) != 0) {
+    size_t hexlen = strlen(hex);
+
+    /* check for 0x prefix */
+    if ((hexlen >= 2) && (hex[0] == '0') && ((hex[1] == 'x') || (hex[1] == 'X'))) {
+        hex += 2;
+        hexlen -= 2;
+    }
+    if (botan_hex_decode(hex, hexlen, buf, &buf_len) != 0) {
         RNP_LOG("Hex decode failed on string: %s", hex);
         return 0;
     }
@@ -457,50 +464,8 @@ rnp_strip_eol(char *s)
 bool
 hex2bin(const char *hex, size_t hexlen, uint8_t *bin, size_t len, size_t *out)
 {
-    bool    haslow = false;
-    uint8_t low = 0;
-    size_t  binlen = 0;
-
-    *out = 0;
-    if (hexlen < 1) {
-        return false;
-    }
-
-    /* check for 0x prefix */
-    if ((hexlen >= 2) && (hex[0] == '0') && ((hex[1] == 'x') || (hex[1] == 'X'))) {
-        hex += 2;
-        hexlen -= 2;
-    }
-
-    haslow = hexlen % 2;
-    for (size_t i = 0; i < hexlen; i++) {
-        if ((hex[i] == ' ') || (hex[i] == '\t')) {
-            continue;
-        }
-
-        if ((hex[i] >= '0') && (hex[i] <= '9')) {
-            low = (low << 4) | (hex[i] - '0');
-        } else if ((hex[i] >= 'a') && (hex[i] <= 'f')) {
-            low = (low << 4) | (hex[i] - ('a' - 10));
-        } else if ((hex[i] >= 'A') && (hex[i] <= 'F')) {
-            low = (low << 4) | (hex[i] - ('A' - 10));
-        } else {
-            return false;
-        }
-
-        /* we had low bits before - so have the whole byte now */
-        if (haslow) {
-            if (binlen < len) {
-                bin[binlen] = low;
-            }
-            binlen++;
-            low = 0;
-        }
-        haslow = !haslow;
-    }
-
-    *out = binlen;
-    return true;
+    *out = rnp_hex_decode(hex, bin, len);
+    return *out != 0;
 }
 
 /* Shortcut function to add field checking it for null to avoid allocation failure.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(rnp_tests
   streams.cpp
   support.cpp
   user-prefs.cpp
+  utils-hex2bin.cpp
   utils-list.cpp
   utils-rnpcfg.cpp
   issues/1030.cpp

--- a/src/tests/utils-hex2bin.cpp
+++ b/src/tests/utils-hex2bin.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rnp_tests.h"
+#include <rnp/rnp_sdk.h>
+
+TEST_F(rnp_tests, test_utils_hex2bin)
+{
+    // with 0x prefix
+    {
+        uint8_t     buf[4];
+        const char *hex = "0xfeedbeef";
+        size_t      outsz = 0;
+
+        assert_true(hex2bin(hex, strlen(hex), buf, sizeof(buf), &outsz));
+        assert_int_equal(outsz, 4);
+        assert_int_equal(0, memcmp(buf, "\xfe\xed\xbe\xef", 4));
+    }
+    // with 0X prefix, capital
+    {
+        uint8_t     buf[4];
+        const char *hex = "0XFEEDBEEF";
+        size_t      outsz = 0;
+
+        assert_true(hex2bin(hex, strlen(hex), buf, sizeof(buf), &outsz));
+        assert_int_equal(outsz, 4);
+        assert_int_equal(0, memcmp(buf, "\xfe\xed\xbe\xef", 4));
+    }
+    // without 0x prefix
+    {
+        uint8_t     buf[4];
+        const char *hex = "feedbeef";
+        size_t      outsz = 0;
+
+        assert_true(hex2bin(hex, strlen(hex), buf, sizeof(buf), &outsz));
+        assert_int_equal(outsz, 4);
+        assert_int_equal(0, memcmp(buf, "\xfe\xed\xbe\xef", 4));
+    }
+    // keyid with spaces
+    {
+        uint8_t     buf[PGP_KEY_ID_SIZE];
+        const char *hex = "4be1 47bb 22df 1e60";
+        size_t      outsz = 0;
+
+        assert_true(hex2bin(hex, strlen(hex), buf, sizeof(buf), &outsz));
+        assert_int_equal(outsz, PGP_KEY_ID_SIZE);
+        assert_int_equal(0, memcmp(buf, "\x4b\xe1\x47\xbb\x22\xdf\x1e\x60", PGP_KEY_ID_SIZE));
+    }
+    // keyid with spaces and tab
+    {
+        uint8_t     buf[PGP_KEY_ID_SIZE];
+        const char *hex = "    4be147bb\t22df1e60   ";
+        size_t      outsz = 0;
+
+        assert_true(hex2bin(hex, strlen(hex), buf, sizeof(buf), &outsz));
+        assert_int_equal(outsz, PGP_KEY_ID_SIZE);
+        assert_int_equal(0, memcmp(buf, "\x4b\xe1\x47\xbb\x22\xdf\x1e\x60", PGP_KEY_ID_SIZE));
+    }
+}


### PR DESCRIPTION
The implementation of hex2bin had some bugs, mostly with handling whitespace.