### PR TITLE
Update errored subkey dumping with primary's keyid.

### DIFF
--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -48,6 +48,10 @@ void set_rnp_log_switch(int8_t);
 
 #define RNP_LOG_KEY(msg, key)                                                                \
     do {                                                                                     \
+        if (!key) {                                                                          \
+            RNP_LOG(msg, "(null)");                                                          \
+            break;                                                                           \
+        }                                                                                    \
         char keyid[PGP_KEY_ID_SIZE * 2 + 1] = {0};                                           \
         rnp_hex_encode(                                                                      \
           pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, keyid, sizeof(keyid), RNP_HEX_LOWERCASE); \

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -104,6 +104,7 @@ rnp_key_store_add_transferable_subkey(rnp_key_store_t *          keyring,
     /* create subkey */
     if (!rnp_key_from_transferable_subkey(&skey, tskey, pkey)) {
         RNP_LOG_KEY_PKT("failed to create subkey %s", &tskey->subkey);
+        RNP_LOG_KEY("primary key is %s", pkey);
         return false;
     }
 

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -438,6 +438,7 @@ rnp_key_store_add_subkey(rnp_key_store_t *keyring, pgp_key_t *srckey, pgp_key_t 
         /* in case we already have key let's merge it in */
         if (!rnp_key_store_merge_subkey(oldkey, srckey, primary)) {
             RNP_LOG_KEY("failed to merge subkey %s", srckey);
+            RNP_LOG_KEY("primary key is %s", primary);
             return NULL;
         }
     } else {
@@ -451,12 +452,14 @@ rnp_key_store_add_subkey(rnp_key_store_t *keyring, pgp_key_t *srckey, pgp_key_t 
         }
         if (pgp_key_copy(oldkey, srckey, false)) {
             RNP_LOG_KEY("key %s copying failed", srckey);
+            RNP_LOG_KEY("primary key is %s", primary);
             keyring->keys.pop_back();
             keyring->keybygrip.erase(pgp_key_get_grip(srckey));
             return NULL;
         }
         if (primary && !pgp_key_link_subkey_grip(primary, oldkey)) {
             RNP_LOG_KEY("failed to link subkey %s grip", oldkey);
+            RNP_LOG_KEY("primary key is %s", primary);
         }
     }
 
@@ -467,6 +470,7 @@ rnp_key_store_add_subkey(rnp_key_store_t *keyring, pgp_key_t *srckey, pgp_key_t 
     }
     if (!pgp_subkey_refresh_data(oldkey, primary)) {
         RNP_LOG_KEY("Failed to refresh subkey %s data", srckey);
+        RNP_LOG_KEY("primary key is %s", primary);
     }
     return oldkey;
 }
@@ -508,7 +512,7 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
         }
         /* primary key may be added after subkeys, so let's handle this case correctly */
         if (!rnp_key_store_refresh_subkey_grips(keyring, added_key)) {
-            RNP_LOG_KEY("failed to refresh subkey %s grips", added_key);
+            RNP_LOG_KEY("failed to refresh subkey grips for %s", added_key);
         }
     }
 


### PR DESCRIPTION
This PR updates #1166. It appears that during troubleshooting it's not easy to locate primary key's id using the GnuPG/other tools.