### PR TITLE
Remove flag CLI_SEARCH_SUBKEYS_AFTER. Fixes #1153

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1636,8 +1636,8 @@ stdout_writer(void *app_ctx, const void *buf, size_t len)
 bool
 cli_rnp_export_keys(cli_rnp_t *rnp, const char *filter)
 {
-    bool secret = rnp_cfg_getbool(cli_rnp_cfg(rnp), CFG_SECRET);
-    int  flags = CLI_SEARCH_SUBKEYS_AFTER | (secret ? CLI_SEARCH_SECRET : 0);
+    bool                          secret = rnp_cfg_getbool(cli_rnp_cfg(rnp), CFG_SECRET);
+    int                           flags = secret ? CLI_SEARCH_SECRET : 0;
     std::vector<rnp_key_handle_t> keys;
 
     if (!cli_rnp_keys_matching_string(rnp, keys, filter, flags)) {

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1533,6 +1533,29 @@ class Misc(unittest.TestCase):
             raise_err('message having largest possible partial packet verification failed', err)
         return
 
+    def test_rnp_single_export(self):
+        # Import key with subkeys, then export it, test that it is exported once.
+        # See issue #1153
+        clear_keyrings()
+        # Import Alice's secret key and subkey
+        ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import', data_path('test_key_validity/alice-sub-sec.pgp')])
+        if ret != 0:
+            raise_err('Alice secret key import failed')
+        # Export key
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export', 'Alice'])
+        if ret != 0: raise_err('key export failed', err)
+        pubpath = path.join(RNPDIR, 'Alice-export-test.asc')
+        with open(pubpath, 'w+') as f:
+            f.write(out)
+        # List exported key packets
+        params = ['--list-packets', pubpath]
+        ret, out, err = run_proc(RNP, params)
+        if ret != 0:
+            raise_err('packet listing failed', err)
+        compare_file_ex(data_path('test_single_export_subkeys/list_key_export_single.txt'), out,
+                        'exported packets mismatch')
+        return
+
     def test_rnp_list_packets(self):
         # List packets in humand-readable format
         params = ['--list-packets', data_path('test_list_packets/ecc-p256-pub.asc')]

--- a/src/tests/data/test_single_export_subkeys/list_key_export_single.txt
+++ b/src/tests/data/test_single_export_subkeys/list_key_export_single.txt
@@ -1,0 +1,75 @@
+:armored input
+:off 0: packet header 0xc633 (tag 6, len 51)
+Public key packet
+    version: 4
+    creation time: 1577369391 (??? ??? ?? ??:??:?? 2019)
+    public key algorithm: 22 (EdDSA)
+    public key material:
+        ecc p: 263 bits
+        ecc curve: Ed25519
+    keyid: 0x0451409669ffde3c
+:off 53: packet header 0xcd11 (tag 13, len 17)
+UserID packet
+    id: Alice <alice@rnp>
+:off 72: packet header 0xc290 (tag 2, len 144)
+Signature packet
+    version: 4
+    type: 19 (Positive User ID certification)
+    public key algorithm: 22 (EdDSA)
+    hash algorithm: 8 (SHA256)
+    hashed subpackets:
+        :type 33, len 21
+        issuer fingerprint: 0x73edcc9119afc8e2dbbdcde50451409669ffde3c (20 bytes)
+        :type 2, len 4
+        signature creation time: 1577369391 (??? ??? ?? ??:??:?? 2019)
+        :type 27, len 1
+        key flags: 0x03 ( certify sign )
+        :type 11, len 4
+        preferred symmetric algorithms: AES-256, AES-192, AES-128, TripleDES (9, 8, 7, 2)
+        :type 21, len 5
+        preferred hash algorithms: SHA512, SHA384, SHA256, SHA224, SHA1 (10, 9, 8, 11, 2)
+        :type 22, len 3
+        preferred compression algorithms: ZLib, BZip2, ZIP (2, 3, 1)
+        :type 30, len 1
+        features: 0x01 ( mdc )
+        :type 23, len 1
+        key server preferences
+        no-modify: 1
+    unhashed subpackets:
+        :type 16, len 8
+        issuer key ID: 0x0451409669ffde3c
+    lbits: 0x249d
+    signature material:
+        ecc r: 255 bits
+        ecc s: 256 bits
+:off 218: packet header 0xce57 (tag 14, len 87)
+Public subkey packet
+    version: 4
+    creation time: 1577455297 (??? ??? ?? ??:??:?? 2019)
+    public key algorithm: 18 (ECDH)
+    public key material:
+        ecdh p: 515 bits
+        ecdh curve: brainpoolP256r1
+        ecdh hash algorithm: 8 (SHA256)
+        ecdh key wrap algorithm: 7
+    keyid: 0xdd23ceb7febeff17
+:off 307: packet header 0xc278 (tag 2, len 120)
+Signature packet
+    version: 4
+    type: 24 (Subkey Binding Signature)
+    public key algorithm: 22 (EdDSA)
+    hash algorithm: 8 (SHA256)
+    hashed subpackets:
+        :type 33, len 21
+        issuer fingerprint: 0x73edcc9119afc8e2dbbdcde50451409669ffde3c (20 bytes)
+        :type 2, len 4
+        signature creation time: 1577455297 (??? ??? ?? ??:??:?? 2019)
+        :type 27, len 1
+        key flags: 0x0c ( encrypt_comm encrypt_storage )
+    unhashed subpackets:
+        :type 16, len 8
+        issuer key ID: 0x0451409669ffde3c
+    lbits: 0xa1a0
+    signature material:
+        ecc r: 256 bits
+        ecc s: 254 bits


### PR DESCRIPTION
Fixes double export of keys having subkeys.
If the found key has subkeys, they are exported
anyway by rnp_key_export() with RNP_KEY_EXPORT_SUBKEYS flag set.