### PR TITLE
FFI: Fix and improve rnp_key_remove().

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -206,7 +206,7 @@ pgp_key_t *rnp_key_store_import_signature(rnp_key_store_t *        keyring,
                                           const pgp_signature_t *  sig,
                                           pgp_sig_import_status_t *status);
 
-bool rnp_key_store_remove_key(rnp_key_store_t *, const pgp_key_t *);
+bool rnp_key_store_remove_key(rnp_key_store_t *, const pgp_key_t *, bool);
 
 pgp_key_t *rnp_key_store_get_key_by_id(rnp_key_store_t *, const unsigned char *, pgp_key_t *);
 

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -46,6 +46,7 @@ typedef uint32_t rnp_result_t;
 
 #define RNP_KEY_REMOVE_PUBLIC (1U << 0)
 #define RNP_KEY_REMOVE_SECRET (1U << 1)
+#define RNP_KEY_REMOVE_SUBKEYS (1U << 2)
 
 #define RNP_KEY_UNLOAD_PUBLIC (1U << 0)
 #define RNP_KEY_UNLOAD_SECRET (1U << 1)
@@ -884,7 +885,8 @@ rnp_result_t rnp_key_revoke(rnp_key_handle_t key,
  *  Note: you need to call rnp_save_keys() to write updated keyring(s) out.
  *        Other handles of the same key should not be used after this call.
  * @param key pointer to the key handle.
- * @param flags see RNP_KEY_REMOVE_* constants.
+ * @param flags see RNP_KEY_REMOVE_* constants. Flag RNP_REMOVE_SUBKEYS will work only for
+ *              primary key, and remove all of it's subkeys as well.
  * @return RNP_SUCCESS or error code if failed.
  */
 rnp_result_t rnp_key_remove(rnp_key_handle_t key, uint32_t flags);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1310,6 +1310,15 @@ pgp_key_add_subkey_grip(pgp_key_t *key, const pgp_key_grip_t &grip)
     }
 }
 
+void
+pgp_key_remove_subkey_grip(pgp_key_t *key, const pgp_key_grip_t &grip)
+{
+    auto it = std::find(key->subkey_grips.begin(), key->subkey_grips.end(), grip);
+    if (it != key->subkey_grips.end()) {
+        key->subkey_grips.erase(it);
+    }
+}
+
 const pgp_key_grip_t &
 pgp_key_get_subkey_grip(const pgp_key_t *key, size_t idx)
 {

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -328,6 +328,14 @@ size_t pgp_key_get_subkey_count(const pgp_key_t *key);
 bool pgp_key_add_subkey_grip(pgp_key_t *key, const pgp_key_grip_t &grip);
 
 /**
+ * @brief Remove subkey grip from key's list.
+ *
+ * @param key key pointer to the primary key
+ * @param grip subkey's grip.
+ */
+void pgp_key_remove_subkey_grip(pgp_key_t *key, const pgp_key_grip_t &grip);
+
+/**
  * @brief Get the pgp key's subkey grip
  *
  * @param key key pointer to the primary key

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -4765,11 +4765,11 @@ done:
         op->password = NULL;
     }
     if (ret && op->gen_pub) {
-        rnp_key_store_remove_key(op->ffi->pubring, op->gen_pub);
+        rnp_key_store_remove_key(op->ffi->pubring, op->gen_pub, false);
         op->gen_pub = NULL;
     }
     if (ret && op->gen_sec) {
-        rnp_key_store_remove_key(op->ffi->secring, op->gen_sec);
+        rnp_key_store_remove_key(op->ffi->secring, op->gen_sec, false);
         op->gen_sec = NULL;
     }
     return ret;

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -188,7 +188,7 @@ rnp_key_store_add_transferable_key(rnp_key_store_t *keyring, pgp_transferable_ke
     return true;
 error:
     /* during key addition all fields are copied so will be cleaned below */
-    rnp_key_store_remove_key(keyring, addkey);
+    rnp_key_store_remove_key(keyring, addkey, false);
     return false;
 }
 

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -677,12 +677,37 @@ rnp_key_store_import_signature(rnp_key_store_t *        keyring,
 }
 
 bool
-rnp_key_store_remove_key(rnp_key_store_t *keyring, const pgp_key_t *key)
+rnp_key_store_remove_key(rnp_key_store_t *keyring, const pgp_key_t *key, bool subkeys)
 {
     auto it = keyring->keybygrip.find(pgp_key_get_grip(key));
     if (it == keyring->keybygrip.end()) {
         return false;
     }
+
+    /* cleanup primary_grip (or subkey)/subkey_grips */
+    if (pgp_key_is_primary_key(key) && pgp_key_get_subkey_count(key)) {
+        for (size_t i = 0; i < pgp_key_get_subkey_count(key); i++) {
+            auto it = keyring->keybygrip.find(pgp_key_get_subkey_grip(key, i));
+            if (it == keyring->keybygrip.end()) {
+                continue;
+            }
+            /* if subkeys are deleted then no need to update grips */
+            if (subkeys) {
+                keyring->keys.erase(it->second);
+                keyring->keybygrip.erase(it);
+                continue;
+            }
+            it->second->primary_grip = {};
+            it->second->primary_grip_set = false;
+        }
+    }
+    if (pgp_key_is_subkey(key) && pgp_key_has_primary_grip(key)) {
+        pgp_key_t *primary = rnp_key_store_get_primary_key(keyring, key);
+        if (primary) {
+            pgp_key_remove_subkey_grip(primary, pgp_key_get_grip(key));
+        }
+    }
+
     keyring->keys.erase(it->second);
     keyring->keybygrip.erase(it);
     return true;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -679,13 +679,13 @@ rnp_key_store_import_signature(rnp_key_store_t *        keyring,
 bool
 rnp_key_store_remove_key(rnp_key_store_t *keyring, const pgp_key_t *key)
 {
-    keyring->keybygrip.erase(pgp_key_get_grip(key));
-    size_t oldsize = keyring->keys.size();
-    keyring->keys.erase(std::remove_if(keyring->keys.begin(),
-                                       keyring->keys.end(),
-                                       [key](pgp_key_t &_key) { return key == &_key; }));
-
-    return oldsize != keyring->keys.size();
+    auto it = keyring->keybygrip.find(pgp_key_get_grip(key));
+    if (it == keyring->keybygrip.end()) {
+        return false;
+    }
+    keyring->keys.erase(it->second);
+    keyring->keybygrip.erase(it);
+    return true;
 }
 
 /**

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -732,12 +732,11 @@ rnp_key_store_get_key_by_id(rnp_key_store_t *keyring, const uint8_t *keyid, pgp_
 const pgp_key_t *
 rnp_key_store_get_key_by_grip(const rnp_key_store_t *keyring, const pgp_key_grip_t &grip)
 {
-    try {
-        return &*keyring->keybygrip.at(grip);
-    } catch (const std::exception &e) {
-        RNP_LOG("%s", e.what());
+    auto it = keyring->keybygrip.find(grip);
+    if (it == keyring->keybygrip.end()) {
         return NULL;
     }
+    return &*it->second;
 }
 
 pgp_key_t *

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(rnp_tests
   utils-rnpcfg.cpp
   issues/1030.cpp
   issues/1115.cpp
+  issues/1171.cpp
 )
 
 target_include_directories(rnp_tests

--- a/src/tests/issues/1171.cpp
+++ b/src/tests/issues/1171.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../rnp_tests.h"
+#include "../support.h"
+#include <librepgp/stream-ctx.h>
+#include "pgp-key.h"
+#include "ffi-priv-types.h"
+
+TEST_F(rnp_tests, test_issue_1171_key_import_and_remove)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    rnp_input_t input = NULL;
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/alice-sub-pub.pgp"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+
+    rnp_key_handle_t key = NULL;
+    assert_rnp_success(
+      rnp_locate_key(ffi, "grip", "3E3D52A346F0AD47754611B078117C240ED237E9", &key));
+    assert_non_null(key);
+    assert_rnp_success(rnp_key_remove(key, RNP_KEY_REMOVE_PUBLIC));
+    assert_rnp_success(rnp_key_handle_destroy(key));
+
+    assert_rnp_success(
+      rnp_locate_key(ffi, "grip", "3E3D52A346F0AD47754611B078117C240ED237E9", &key));
+    assert_null(key);
+
+    assert_rnp_success(
+      rnp_locate_key(ffi, "grip", "128E494F41F107E119AA1EEF7850C375A804341C", &key));
+    assert_non_null(key);
+    uint32_t bits = 0;
+    assert_rnp_success(rnp_key_get_bits(key, &bits));
+    assert_int_equal(bits, 256);
+
+    /* directly use rnp_key_store_get_key_by_grip() which caused crash */
+    pgp_key_t *subkey =
+      rnp_key_store_get_key_by_grip(ffi->pubring, pgp_key_get_grip(key->pub));
+    assert_int_equal(pgp_key_get_bits(subkey), 256);
+    assert_rnp_success(rnp_key_handle_destroy(key));
+
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/alice-sub-pub.pgp"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+
+    rnp_ffi_destroy(ffi);
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -371,6 +371,10 @@ void test_kbx_nsigs(void **state);
 
 void test_issue_1115(void **state);
 
+void issue_1030_rnpkeys_secret_keys_unprotected(void **state);
+
+void test_issue_1171_key_import_and_remove(void **state);
+
 void test_log_switch(void **state);
 
 #define assert_true(a) EXPECT_TRUE((a))

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -297,6 +297,8 @@ void test_ffi_decrypt_wrong_mpi_bits(void **state);
 
 void test_ffi_key_import_edge_cases(void **state);
 
+void test_ffi_key_remove(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
This PR:
- fixes #1171 and adds test for it.
- adds new flag RNP_KEY_REMOVE_SUBKEYS, allowing to remove subkey together with the primary key, making things faster and easier.
- adds test for rnp_key_remove() FFI function
