### PR TITLE
Armor line length

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2325,6 +2325,14 @@ RNP_API rnp_result_t rnp_identifier_iterator_destroy(rnp_identifier_iterator_t i
  */
 RNP_API rnp_result_t rnp_output_pipe(rnp_input_t input, rnp_output_t output);
 
+/** Set line length for armored output
+ *
+ *  @param output stream to configure
+ *  @param llen line length in characters [16..76]
+ *  @return RNP_SUCCESS on success, or any other value on error
+ */
+RNP_API rnp_result_t rnp_output_armor_set_line_length(rnp_output_t output, size_t llen);
+
 #if defined(__cplusplus)
 }
 

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2317,6 +2317,14 @@ RNP_API rnp_result_t rnp_identifier_iterator_next(rnp_identifier_iterator_t it,
  */
 RNP_API rnp_result_t rnp_identifier_iterator_destroy(rnp_identifier_iterator_t it);
 
+/** Read from input and write to output
+ *
+ *  @param input stream to read data from
+ *  @param output stream to write data to
+ *  @return RNP_SUCCESS on success, or any other value on error
+ */
+RNP_API rnp_result_t rnp_output_pipe(rnp_input_t input, rnp_output_t output);
+
 #if defined(__cplusplus)
 }
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7223,3 +7223,12 @@ rnp_output_pipe(rnp_input_t input, rnp_output_t output)
     output->keep = !ret;
     return ret;
 }
+
+rnp_result_t
+rnp_output_armor_set_line_length(rnp_output_t output, size_t llen)
+{
+    if (!output || !llen) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    return armored_dst_set_line_length(&output->dst, llen);
+}

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7212,3 +7212,14 @@ rnp_dearmor(rnp_input_t input, rnp_output_t output)
     output->keep = !ret;
     return ret;
 }
+
+rnp_result_t
+rnp_output_pipe(rnp_input_t input, rnp_output_t output)
+{
+    if (!input || !output) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    rnp_result_t ret = dst_write_src(&input->src, &output->dst);
+    output->keep = !ret;
+    return ret;
+}

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -961,7 +961,7 @@ is_armored_dest(pgp_dest_t *dst)
 rnp_result_t
 armored_dst_set_line_length(pgp_dest_t *dst, size_t llen)
 {
-    if (!dst || llen < ARMORED_MIN_LINE_LENGTH || llen > ARMORED_MAX_LINE_LENGTH ||
+    if (!dst || (llen < ARMORED_MIN_LINE_LENGTH) || (llen > ARMORED_MAX_LINE_LENGTH) ||
         !dst->param || !is_armored_dest(dst)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -1022,7 +1022,7 @@ rnp_dearmor_source(pgp_source_t *src, pgp_dest_t *dst)
         /* initializing armored message */
         res = init_armored_src(&armorsrc, src);
         if (res) {
-            goto finish;
+            return res;
         }
     } else {
         RNP_LOG("source is not armored data");
@@ -1030,7 +1030,10 @@ rnp_dearmor_source(pgp_source_t *src, pgp_dest_t *dst)
     }
     /* Reading data from armored source and writing it to the output */
     res = dst_write_src(&armorsrc, dst);
-finish:
+    if (res) {
+        RNP_LOG("dearmoring failed");
+    }
+
     src_close(&armorsrc);
     return res;
 }
@@ -1041,12 +1044,14 @@ rnp_armor_source(pgp_source_t *src, pgp_dest_t *dst, pgp_armored_msg_t msgtype)
     pgp_dest_t   armordst = {0};
     rnp_result_t res = init_armored_dst(&armordst, dst, msgtype);
     if (res) {
-        goto finish;
+        return res;
     }
 
     res = dst_write_src(src, &armordst);
+    if (res) {
+        RNP_LOG("armoring failed");
+    }
 
-finish:
     dst_close(&armordst, res != RNP_SUCCESS);
     return res;
 }

--- a/src/librepgp/stream-armor.h
+++ b/src/librepgp/stream-armor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -88,10 +88,24 @@ pgp_armored_msg_t rnp_armored_get_type(pgp_source_t *src);
  **/
 bool is_armored_source(pgp_source_t *src);
 
+/* @brief Check whether destination is armored
+ * @param dest initialized destination
+ * @return true if destination is armored or false otherwise
+ **/
+bool is_armored_dest(pgp_dest_t *dst);
+
 /* @brief Check whether source is cleartext signed
  * @param src initialized source with some data
  * @return true if source could be a cleartext signed data or false otherwise
  **/
 bool is_cleartext_source(pgp_source_t *src);
+
+/** Set line length for armoring
+ *
+ *  @param dst initialized dest to write armored data to
+ *  @param llen line length in characters
+ *  @return RNP_SUCCESS on success, or any other value on error
+ */
+rnp_result_t armored_dst_set_line_length(pgp_dest_t *dst, size_t llen);
 
 #endif

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -352,5 +352,12 @@ void *mem_dest_own_memory(pgp_dest_t *dst);
  *  @return RNP_SUCCESS or error code
  **/
 rnp_result_t init_null_dest(pgp_dest_t *dst);
+
+/** @brief reads from source and writes to destination
+ *  @param src initialized source
+ *  @param dst initialized destination
+ *  @return RNP_SUCCESS or error code
+ **/
+rnp_result_t dst_write_src(pgp_source_t *src, pgp_dest_t *dst);
 
 #endif

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(rnp_tests
   load-pgp.cpp
   log-switch.cpp
   partial-length.cpp
+  pipe.cpp
   rnp_tests.cpp
   s2k-iterations.cpp
   streams.cpp

--- a/src/tests/pipe.cpp
+++ b/src/tests/pipe.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017-2020 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fstream>
+#include <vector>
+#include <string>
+
+#include <rnp/rnp.h>
+#include "rnp_tests.h"
+#include "support.h"
+#include "utils.h"
+#include <json.h>
+#include <vector>
+#include <string>
+
+// this reader produces errors
+static bool
+error_reader(void *app_ctx, void *buf, size_t len, size_t *read)
+{
+    return false;
+}
+
+// this writer produces errors
+static bool
+error_writer(void *app_ctx, const void *buf, size_t len)
+{
+    return false;
+}
+
+TEST_F(rnp_tests, test_pipe)
+{
+    uint8_t *         buf = NULL;
+    size_t            buf_size = 0;
+    rnp_input_t       input = NULL;
+    rnp_output_t      output = NULL;
+    const std::string msg("this is a test");
+
+    assert_rnp_success(
+      rnp_input_from_memory(&input, (const uint8_t *) msg.data(), msg.size(), true));
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+
+    assert_rnp_failure(rnp_output_pipe(input, NULL));
+    assert_rnp_failure(rnp_output_pipe(NULL, output));
+    assert_rnp_success(rnp_output_pipe(input, output));
+    assert_rnp_success(rnp_output_finish(output));
+    assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &buf_size, false));
+    std::string data = std::string(buf, buf + buf_size);
+    assert_string_equal(data.c_str(), msg.c_str());
+
+    assert_rnp_success(rnp_input_destroy(input));
+    assert_rnp_success(rnp_output_destroy(output));
+}
+
+TEST_F(rnp_tests, test_pipe_source_error)
+{
+    rnp_input_t  input = NULL;
+    rnp_output_t output = NULL;
+
+    assert_rnp_success(rnp_input_from_callback(&input, error_reader, NULL, NULL));
+    assert_rnp_success(rnp_output_to_null(&output));
+
+    assert_rnp_failure(rnp_output_pipe(input, output));
+
+    assert_rnp_success(rnp_input_destroy(input));
+    assert_rnp_success(rnp_output_destroy(output));
+}
+
+TEST_F(rnp_tests, test_pipe_dest_error)
+{
+    rnp_input_t       input = NULL;
+    rnp_output_t      output = NULL;
+    const std::string msg("this is a test");
+
+    assert_rnp_success(
+      rnp_input_from_memory(&input, (const uint8_t *) msg.data(), msg.size(), true));
+    assert_rnp_success(rnp_output_to_callback(&output, error_writer, NULL, NULL));
+
+    assert_rnp_failure(rnp_output_pipe(input, output));
+
+    assert_rnp_success(rnp_input_destroy(input));
+    assert_rnp_success(rnp_output_destroy(output));
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -223,9 +223,13 @@ void test_ffi_signatures_detached_memory_g10(void **state);
 
 void test_ffi_enarmor_dearmor(void **state);
 
+void test_ffi_customized_enarmor(void **state);
+
 void test_ffi_version(void **state);
 
 void test_ffi_key_export(void **state);
+
+void test_ffi_key_export_customized_enarmor(void **state);
 
 void test_ffi_key_dump(void **state);
 

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -373,6 +373,12 @@ void test_partial_length_largest(void **state);
 
 void test_partial_length_first_packet_length(void **state);
 
+void test_pipe(void **state);
+
+void test_pipe_source_error(void **state);
+
+void test_pipe_dest_error(void **state);
+
 void test_kbx_nsigs(void **state);
 
 void test_issue_1115(void **state);


### PR DESCRIPTION
I have added `rnp_pipe` to pipe from input to output, as well as `rnp_output_armor_set_line_length` as siggested,
so it is now possible to do:
```
rnp_output_to_armor(...)
rnp_output_armor_set_line_length(...);
rnp_pipe(...);
```
Fixes #1099 