### PR TITLE
Allow to process raw literal packets.

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2869,7 +2869,7 @@ rnp_op_verify_execute(rnp_op_verify_t op)
     handler.param = op;
     handler.ctx = &op->rnpctx;
 
-    rnp_result_t ret = process_pgp_source(&handler, &op->input->src);
+    rnp_result_t ret = process_pgp_source(&handler, op->input->src);
     if (op->output) {
         dst_flush(&op->output->dst);
         op->output->keep = ret == RNP_SUCCESS;
@@ -3257,7 +3257,7 @@ rnp_decrypt(rnp_ffi_t ffi, rnp_input_t input, rnp_output_t output)
     handler.param = output;
     handler.ctx = &rnpctx;
 
-    rnp_result_t ret = process_pgp_source(&handler, &input->src);
+    rnp_result_t ret = process_pgp_source(&handler, input->src);
     dst_flush(&output->dst);
     output->keep = (ret == RNP_SUCCESS);
     return ret;

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -2196,8 +2196,8 @@ init_packet_sequence(pgp_processing_ctx_t &ctx, pgp_source_t &src)
             ret = init_compressed_src(&psrc, lsrc);
             break;
         case PGP_PKT_LITDATA:
-            if ((lsrc->type != PGP_STREAM_ENCRYPTED) && (lsrc->type != PGP_STREAM_SIGNED) &&
-                (lsrc->type != PGP_STREAM_COMPRESSED)) {
+            if ((lsrc != &src) && (lsrc->type != PGP_STREAM_ENCRYPTED) &&
+                (lsrc->type != PGP_STREAM_SIGNED) && (lsrc->type != PGP_STREAM_COMPRESSED)) {
                 RNP_LOG("unexpected literal pkt");
                 ret = RNP_ERROR_BAD_FORMAT;
                 break;

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -81,7 +81,7 @@ typedef struct pgp_parse_handler_t {
  * @param src initialized source with cache
  * @return RNP_SUCCESS on success or error code otherwise
  **/
-rnp_result_t process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t *src);
+rnp_result_t process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t &src);
 
 /* @brief Init source with OpenPGP compressed data packet
  * @param src allocated pgp_source_t structure

--- a/src/tests/data/test_messages/message.txt.literal
+++ b/src/tests/data/test_messages/message.txt.literal
@@ -1,0 +1,3 @@
+¨ùbmessage.txt_ª4This is test message to be signed, and/or encrypted, cleartext signed and detached signed.
+It will use keys from keyrings/1.
+End of message.

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -303,6 +303,8 @@ void test_ffi_key_import_edge_cases(void **state);
 
 void test_ffi_key_remove(void **state);
 
+void test_ffi_literal_packet(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
This PR fixes issue #1191, allowing to process messages wrapped just to the literal packet.
Also it adds some more C++ refactoring  to pgp_processing_ctx_t.