### PR TITLE
build: Bump required CMake version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@
 # 3.10+ for gtest_discover_tests (parallel rnp_tests)
 # 3.12+ for NAMELINK_COMPONENT (for better RPM packaging)
 # 3.12+ for Python3 find module
-cmake_minimum_required(VERSION 3.12)
+# 3.14+ for object library link dependency propagation
+cmake_minimum_required(VERSION 3.14)
 
 # contact email, other info
 include(cmake/info.cmake)


### PR DESCRIPTION
I should have bumped the cmake version requirement in #1182. From [the changelog](https://cmake.org/cmake/help/v3.14/release/3.14.html):
```
Object library linking has been fixed to propagate private link libraries of object libraries to consuming targets.
```

Fixes #1196 