### PR TITLE
Add FFI function to export autocrypt-compatible key.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -853,6 +853,23 @@ RNP_API rnp_result_t rnp_op_generate_destroy(rnp_op_generate_t op);
 RNP_API rnp_result_t rnp_key_export(rnp_key_handle_t key, rnp_output_t output, uint32_t flags);
 
 /**
+ * @brief Export minimal key for autocrypt feature (just 5 packets: key, uid, signature,
+ *        encryption subkey, signature)
+ *
+ * @param key primary key handle, cannot be NULL.
+ * @param subkey subkey to export. May be NULL to pick the first suitable.
+ * @param uid userid to export. May be NULL if key has only one uid.
+ * @param output the stream to write to
+ * @param flags additional flags, must be 0 for now.
+ * @return RNP_SUCCESS on success, or any other value if failed.
+ */
+RNP_API rnp_result_t rnp_key_export_autocrypt(rnp_key_handle_t key,
+                                              rnp_key_handle_t subkey,
+                                              const char *     uid,
+                                              rnp_output_t     output,
+                                              uint32_t         flags);
+
+/**
  * @brief Generate and export primary key revocation signature.
  *        Note: to revoke a key you'll need to import this signature into the keystore or use
  *        rnp_key_revoke() function.

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1021,6 +1021,30 @@ pgp_key_latest_selfsig(pgp_key_t *key, pgp_sig_subpacket_type_t subpkt)
 }
 
 pgp_subsig_t *
+pgp_key_latest_uid_selfcert(pgp_key_t *key, uint32_t uid)
+{
+    uint32_t      latest = 0;
+    pgp_subsig_t *res = NULL;
+
+    for (size_t i = 0; i < pgp_key_get_subsig_count(key); i++) {
+        pgp_subsig_t *sig = pgp_key_get_subsig(key, i);
+        if (!sig->valid || (sig->uid != uid)) {
+            continue;
+        }
+        if (!pgp_sig_is_self_signature(key, sig)) {
+            continue;
+        }
+
+        uint32_t creation = signature_get_creation(&sig->sig);
+        if (creation >= latest) {
+            latest = creation;
+            res = sig;
+        }
+    }
+    return res;
+}
+
+pgp_subsig_t *
 pgp_key_latest_binding(pgp_key_t *subkey, bool validated)
 {
     uint32_t      latest = 0;

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -466,6 +466,18 @@ bool pgp_key_write_packets(const pgp_key_t *key, pgp_dest_t *dst);
  */
 bool pgp_key_write_xfer(pgp_dest_t *dst, const pgp_key_t *key, const rnp_key_store_t *keyring);
 
+/**
+ * @brief Export key with subkey as it is required by Autocrypt (5-packet sequence: key, uid,
+ *        sig, subkey, sig).
+ *
+ * @param dst stream to write packets
+ * @param key primary key
+ * @param sub subkey
+ * @param uid index of uid to export
+ * @return true on success or false otherwise
+ */
+bool pgp_key_write_autocrypt(pgp_dest_t &dst, pgp_key_t &key, pgp_key_t &sub, size_t uid);
+
 /** find a key suitable for a particular operation
  *
  *  If the key passed is suitable, it will be returned.

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3512,6 +3512,87 @@ rnp_key_export(rnp_key_handle_t handle, rnp_output_t output, uint32_t flags)
 }
 
 static pgp_key_t *
+find_encrypting_subkey(rnp_ffi_t ffi, const pgp_key_t &primary)
+{
+    pgp_key_search_t search = {};
+    search.type = PGP_KEY_SEARCH_FINGERPRINT;
+
+    for (auto &fp : primary.subkey_fps) {
+        search.by.fingerprint = fp;
+        pgp_key_t *subkey = find_key(ffi, &search, KEY_TYPE_PUBLIC, true);
+        if (!subkey) {
+            subkey = find_key(ffi, &search, KEY_TYPE_SECRET, true);
+        }
+        if (subkey && subkey->valid && pgp_key_can_encrypt(subkey)) {
+            return subkey;
+        }
+    }
+    return NULL;
+}
+
+rnp_result_t
+rnp_key_export_autocrypt(rnp_key_handle_t key,
+                         rnp_key_handle_t subkey,
+                         const char *     uid,
+                         rnp_output_t     output,
+                         uint32_t         flags)
+{
+    if (!key || !output) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    if (flags) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    /* Get the primary key */
+    pgp_key_t *primary = get_key_prefer_public(key);
+    if (!primary || !pgp_key_is_primary_key(primary) || !primary->valid ||
+        !pgp_key_can_sign(primary)) {
+        FFI_LOG(key->ffi, "No valid signing primary key");
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    /* Get encrypting subkey */
+    pgp_key_t *sub = NULL;
+    if (subkey) {
+        sub = get_key_prefer_public(subkey);
+        if (sub && (!sub->valid || !pgp_key_can_encrypt(sub))) {
+            FFI_LOG(key->ffi, "Invalid or non-encrypting subkey");
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+    } else {
+        sub = find_encrypting_subkey(key->ffi, *primary);
+    }
+    if (!sub) {
+        FFI_LOG(key->ffi, "No encrypting subkey");
+        return RNP_ERROR_KEY_NOT_FOUND;
+    }
+    /* Get userid */
+    size_t uididx = pgp_key_get_userid_count(primary);
+    if (uid) {
+        for (size_t idx = 0; idx < primary->uids.size(); idx++) {
+            if (primary->uids[idx].str == uid) {
+                uididx = idx;
+                break;
+            }
+        }
+    } else {
+        if (pgp_key_get_userid_count(primary) > 1) {
+            FFI_LOG(key->ffi, "Ambiguous userid");
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        uididx = 0;
+    }
+    if (uididx >= pgp_key_get_userid_count(primary)) {
+        FFI_LOG(key->ffi, "Userid not found");
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    if (!pgp_key_write_autocrypt(output->dst, *primary, *sub, uididx)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    return RNP_SUCCESS;
+}
+
+static pgp_key_t *
 rnp_key_get_revoker(rnp_key_handle_t key)
 {
     pgp_key_t *exkey = get_key_prefer_public(key);

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -9274,3 +9274,198 @@ TEST_F(rnp_tests, test_ffi_literal_packet)
 
     rnp_ffi_destroy(ffi);
 }
+
+static bool
+check_key_autocrypt(rnp_output_t       memout,
+                    const std::string &keyid,
+                    const std::string &subid,
+                    const std::string &uid)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    uint8_t *buf = NULL;
+    size_t   len = 0;
+    if (rnp_output_memory_get_buf(memout, &buf, &len, false) || !buf || !len) {
+        return false;
+    }
+    rnp_input_t input = NULL;
+    rnp_input_from_memory(&input, buf, len, false);
+    if (rnp_import_keys(
+          ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS | RNP_LOAD_SAVE_SECRET_KEYS, NULL)) {
+        return false;
+    }
+    rnp_input_destroy(input);
+    size_t count = 0;
+    rnp_get_public_key_count(ffi, &count);
+    if (count != 2) {
+        return false;
+    }
+    rnp_get_secret_key_count(ffi, &count);
+    if (count != 0) {
+        return false;
+    }
+    rnp_key_handle_t key = NULL;
+    if (rnp_locate_key(ffi, "keyid", keyid.c_str(), &key) || !key) {
+        return false;
+    }
+    rnp_key_handle_t sub = NULL;
+    if (rnp_locate_key(ffi, "keyid", subid.c_str(), &sub) || !sub) {
+        return false;
+    }
+    if (!key->pub->valid || !sub->pub->valid) {
+        return false;
+    }
+    if ((key->pub->subsigs.size() != 1) || (sub->pub->subsigs.size() != 1)) {
+        return false;
+    }
+    if (!pgp_key_can_sign(key->pub) || !pgp_key_can_encrypt(sub->pub)) {
+        return false;
+    }
+    if ((key->pub->uids.size() != 1) || (key->pub->uids[0].str != uid)) {
+        return false;
+    }
+    rnp_key_handle_destroy(key);
+    rnp_key_handle_destroy(sub);
+    rnp_ffi_destroy(ffi);
+    return true;
+}
+
+TEST_F(rnp_tests, test_ffi_key_export_autocrypt)
+{
+    rnp_ffi_t ffi = NULL;
+    test_ffi_init(&ffi);
+
+    rnp_key_handle_t key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "7bc6709b15c23a4a", &key));
+    rnp_key_handle_t sub = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "8a05b89fad5aded1", &sub));
+
+    /* edge cases */
+    assert_rnp_failure(rnp_key_export_autocrypt(key, NULL, NULL, NULL, 0));
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, sub, NULL, output, 17));
+    assert_rnp_failure(rnp_key_export_autocrypt(NULL, sub, "key0-uid0", output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, sub, NULL, output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, key, NULL, output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, key, "key0-uid0", output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(sub, sub, "key0-uid0", output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(sub, key, "key0-uid0", output, 0));
+    assert_int_equal(output->dst.writeb, 0);
+
+    /* export key + uid1 + sub2 */
+    assert_rnp_success(rnp_key_export_autocrypt(key, sub, "key0-uid1", output, 0));
+    assert_true(
+      check_key_autocrypt(output, "7bc6709b15c23a4a", "8a05b89fad5aded1", "key0-uid1"));
+    rnp_output_destroy(output);
+
+    /* export key + uid0 + sub1 (fail) */
+    rnp_key_handle_destroy(sub);
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "1d7e8a5393c997a8", &sub));
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, sub, "key0-uid0", output, 0));
+    assert_int_equal(output->dst.writeb, 0);
+    rnp_key_handle_destroy(sub);
+
+    /* export key without specifying subkey */
+    assert_rnp_success(rnp_key_export_autocrypt(key, NULL, "key0-uid2", output, 0));
+    assert_true(
+      check_key_autocrypt(output, "7bc6709b15c23a4a", "1ed63ee56fadc34d", "key0-uid2"));
+    rnp_output_destroy(output);
+
+    /* remove first subkey and export again */
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "1ed63ee56fadc34d", &sub));
+    assert_rnp_success(rnp_key_remove(sub, RNP_KEY_REMOVE_PUBLIC));
+    rnp_key_handle_destroy(sub);
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_key_export_autocrypt(key, NULL, "key0-uid0", output, 0));
+    assert_true(
+      check_key_autocrypt(output, "7bc6709b15c23a4a", "8a05b89fad5aded1", "key0-uid0"));
+    rnp_output_destroy(output);
+    rnp_key_handle_destroy(key);
+
+    /* export key with single uid and subkey */
+    assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_PUBLIC | RNP_KEY_UNLOAD_SECRET));
+    rnp_input_t input = NULL;
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/alice-sub-pub.pgp"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "0451409669ffde3c", &key));
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_key_export_autocrypt(key, NULL, NULL, output, 0));
+    assert_true(check_key_autocrypt(
+      output, "0451409669ffde3c", "dd23ceb7febeff17", "Alice <alice@rnp>"));
+    rnp_output_destroy(output);
+    rnp_key_handle_destroy(key);
+
+    /* export key with sign-only subkey: fail */
+    assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_PUBLIC | RNP_KEY_UNLOAD_SECRET));
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/alice-sign-sub-pub.pgp"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "0451409669ffde3c", &key));
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "22f3a217c0e439cb", &sub));
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, sub, NULL, output, 0));
+    assert_int_equal(output->dst.writeb, 0);
+    assert_rnp_failure(rnp_key_export_autocrypt(key, NULL, NULL, output, 0));
+    assert_int_equal(output->dst.writeb, 0);
+    rnp_output_destroy(output);
+    rnp_key_handle_destroy(key);
+    rnp_key_handle_destroy(sub);
+
+    /* export key without subkey: fail */
+    assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_PUBLIC | RNP_KEY_UNLOAD_SECRET));
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_key_validity/alice-pub.asc"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "0451409669ffde3c", &key));
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_failure(rnp_key_export_autocrypt(key, NULL, NULL, output, 0));
+    assert_int_equal(output->dst.writeb, 0);
+    rnp_output_destroy(output);
+    rnp_key_handle_destroy(key);
+
+    /* export secret key: make sure public is exported */
+    assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_PUBLIC | RNP_KEY_UNLOAD_SECRET));
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/alice-sub-sec.pgp"));
+    assert_rnp_success(rnp_import_keys(
+      ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS | RNP_LOAD_SAVE_SECRET_KEYS, NULL));
+    rnp_input_destroy(input);
+    assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_PUBLIC));
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "0451409669ffde3c", &key));
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_key_export_autocrypt(key, NULL, NULL, output, 0));
+    assert_true(check_key_autocrypt(
+      output, "0451409669ffde3c", "dd23ceb7febeff17", "Alice <alice@rnp>"));
+    rnp_output_destroy(output);
+    rnp_key_handle_destroy(key);
+
+    /* make sure that only self-certification is exported */
+    assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_PUBLIC | RNP_KEY_UNLOAD_SECRET));
+    /* load key alice with 2 self-sigs, one of those is expired */
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/case9/pubring.gpg"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+    /* add one corrupted alice's signature and one valid from Basil */
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_key_validity/case2/pubring.gpg"));
+    assert_rnp_success(rnp_import_keys(ffi, input, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(input);
+
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "0451409669ffde3c", &key));
+    assert_int_equal(key->pub->subsigs.size(), 4);
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_key_export_autocrypt(key, NULL, NULL, output, 0));
+    assert_true(check_key_autocrypt(
+      output, "0451409669ffde3c", "dd23ceb7febeff17", "Alice <alice@rnp>"));
+    rnp_output_destroy(output);
+    rnp_key_handle_destroy(key);
+
+    rnp_ffi_destroy(ffi);
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -309,6 +309,8 @@ void test_ffi_key_remove(void **state);
 
 void test_ffi_literal_packet(void **state);
 
+void test_ffi_key_export_autocrypt(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
While this first planned as part of signature stripping work, I decided to do it as separate function due to requirements of autocrypt: be able to export single key with single uid and single subkey (see https://github.com/rnpgp/rnp/issues/1006#issuecomment-647536642).

Part if the issue #1006, and related to still draft PR #1136 

