### PR TITLE
Reduce memory usage in library

### DIFF
--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -426,9 +426,6 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
 end:
     // free any user preferences
     pgp_free_user_prefs(&desc->cert.prefs);
-    // we don't need this as we have loaded the encrypted key into primary_sec
-    transferable_key_destroy(&tkeysec);
-    transferable_key_destroy(&tkeypub);
     return ok;
 }
 
@@ -555,8 +552,6 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
     ok = pgp_subkey_refresh_data(subkey_pub, primary_pub) &&
          pgp_subkey_refresh_data(subkey_sec, primary_sec);
 end:
-    transferable_subkey_destroy(&tskeysec);
-    transferable_subkey_destroy(&tskeypub);
     if (decrypted_primary_seckey) {
         free_key_pkt(decrypted_primary_seckey);
         free(decrypted_primary_seckey);

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -133,7 +133,7 @@ load_generated_g10_key(pgp_key_t *    dst,
     // if a primary key is provided, it should match the sub with regards to type
     assert(!primary_key ||
            (pgp_key_is_secret(primary_key) == pgp_key_is_secret(&key_store->keys.front())));
-    ok = !pgp_key_copy(dst, &key_store->keys.front(), false);
+    ok = !pgp_key_copy(*dst, key_store->keys.front(), false);
 end:
     delete key_store;
     src_close(&memsrc);

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -378,19 +378,19 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
         goto end;
     }
 
-    uid = transferable_key_add_userid(&tkeysec, (char *) desc->cert.userid);
+    uid = transferable_key_add_userid(tkeysec, (char *) desc->cert.userid);
     if (!uid) {
         RNP_LOG("failed to add userid");
         goto end;
     }
 
     if (!transferable_userid_certify(
-          &tkeysec.key, uid, &tkeysec.key, desc->crypto.hash_alg, &desc->cert)) {
+          tkeysec.key, *uid, tkeysec.key, desc->crypto.hash_alg, desc->cert)) {
         RNP_LOG("failed to certify key");
         goto end;
     }
 
-    if (!transferable_key_copy(&tkeypub, &tkeysec, true)) {
+    if (!transferable_key_copy(tkeypub, tkeysec, true)) {
         RNP_LOG("failed to copy public key part");
         goto end;
     }
@@ -514,12 +514,12 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
     }
 
     if (!transferable_subkey_bind(
-          primary_seckey, &tskeysec, desc->crypto.hash_alg, &desc->binding)) {
+          *primary_seckey, tskeysec, desc->crypto.hash_alg, desc->binding)) {
         RNP_LOG("failed to add subkey binding signature");
         goto end;
     }
 
-    if (!transferable_subkey_copy(&tskeypub, &tskeysec, true)) {
+    if (!transferable_subkey_copy(tskeypub, tskeysec, true)) {
         RNP_LOG("failed to copy public subkey part");
         goto end;
     }

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -823,11 +823,10 @@ pgp_key_has_signature(const pgp_key_t *key, const pgp_signature_t *sig)
 {
     for (size_t i = 0; i < pgp_key_get_subsig_count(key); i++) {
         const pgp_subsig_t *subsig = pgp_key_get_subsig(key, i);
-        if (signature_pkt_equal(&subsig->sig, sig)) {
+        if (subsig->sig == *sig) {
             return true;
         }
     }
-
     return false;
 }
 
@@ -837,7 +836,7 @@ pgp_key_replace_signature(pgp_key_t *key, pgp_signature_t *oldsig, pgp_signature
     pgp_subsig_t *subsig = NULL;
     for (size_t i = 0; i < pgp_key_get_subsig_count(key); i++) {
         subsig = pgp_key_get_subsig(key, i);
-        if (signature_pkt_equal(&subsig->sig, oldsig)) {
+        if (subsig->sig == *oldsig) {
             break;
         }
         subsig = NULL;
@@ -1712,7 +1711,7 @@ pgp_key_add_userid_certified(pgp_key_t *              key,
     }
     /* uid.uid.uid looks really weird */
     memcpy(uid.uid.uid, (char *) cert->userid, uid.uid.uid_len);
-    if (!transferable_userid_certify(seckey, &uid, seckey, hash_alg, cert)) {
+    if (!transferable_userid_certify(*seckey, uid, *seckey, hash_alg, *cert)) {
         RNP_LOG("failed to add userid certification");
         return false;
     }

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -111,7 +111,7 @@ bool pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt);
  *               secret to public
  * @return RNP_SUCCESS if operation succeeded or error code otherwise
  */
-rnp_result_t pgp_key_copy(pgp_key_t *dst, const pgp_key_t *src, bool pubonly);
+rnp_result_t pgp_key_copy(pgp_key_t &dst, const pgp_key_t &src, bool pubonly);
 
 /**
  * @brief Copy calculated key fields (grip, userid list, etc). Does not copy key packet/raw
@@ -121,7 +121,7 @@ rnp_result_t pgp_key_copy(pgp_key_t *dst, const pgp_key_t *src, bool pubonly);
  * @param src source key
  * @return RNP_SUCCESS if operation succeeded or error code otherwise
  */
-rnp_result_t pgp_key_copy_fields(pgp_key_t *dst, const pgp_key_t *src);
+rnp_result_t pgp_key_copy_fields(pgp_key_t &dst, const pgp_key_t &src);
 
 void pgp_free_user_prefs(pgp_user_prefs_t *prefs);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -6583,20 +6583,22 @@ add_json_secret_mpis(json_object *jso, pgp_key_t *key)
 static rnp_result_t
 add_json_sig_mpis(json_object *jso, const pgp_signature_t *sig)
 {
+    pgp_signature_material_t material = {};
+    parse_signature_material(*sig, material);
     switch (sig->palg) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
-        return add_json_mpis(jso, "sig", &sig->material.rsa.s, NULL);
+        return add_json_mpis(jso, "sig", &material.rsa.s, NULL);
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
-        return add_json_mpis(jso, "r", &sig->material.eg.r, "s", &sig->material.eg.s, NULL);
+        return add_json_mpis(jso, "r", &material.eg.r, "s", &material.eg.s, NULL);
     case PGP_PKA_DSA:
-        return add_json_mpis(jso, "r", &sig->material.dsa.r, "s", &sig->material.dsa.s, NULL);
+        return add_json_mpis(jso, "r", &material.dsa.r, "s", &material.dsa.s, NULL);
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
-        return add_json_mpis(jso, "r", &sig->material.ecc.r, "s", &sig->material.ecc.s, NULL);
+        return add_json_mpis(jso, "r", &material.ecc.r, "s", &material.ecc.s, NULL);
     default:
         // TODO: we could use info->unknown and add a hex string of raw data here
         return RNP_ERROR_NOT_SUPPORTED;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1494,11 +1494,11 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    rnp_result_t                 ret = RNP_ERROR_GENERIC;
-    json_object *                jsores = NULL;
-    json_object *                jsosigs = NULL;
-    std::vector<pgp_signature_t> sigs;
-    rnp_result_t                 sigret = process_pgp_signatures(&input->src, sigs);
+    rnp_result_t         ret = RNP_ERROR_GENERIC;
+    json_object *        jsores = NULL;
+    json_object *        jsosigs = NULL;
+    pgp_signature_list_t sigs;
+    rnp_result_t         sigret = process_pgp_signatures(&input->src, sigs);
     if (sigret) {
         ret = sigret;
         FFI_LOG(ffi, "failed to parse signature(s)");
@@ -3767,7 +3767,7 @@ rnp_key_get_revocation(rnp_ffi_t         ffi,
         return RNP_ERROR_BAD_PASSWORD;
     }
     *sig =
-      transferable_key_revoke(pgp_key_get_pkt(key), pgp_key_get_pkt(revoker), halg, &revinfo);
+      transferable_key_revoke(*pgp_key_get_pkt(key), *pgp_key_get_pkt(revoker), halg, revinfo);
     if (!*sig) {
         FFI_LOG(ffi, "Failed to generate revocation signature");
     }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1182,7 +1182,7 @@ do_load_keys(rnp_ffi_t              ffi,
             continue;
         }
 
-        if ((tmpret = pgp_key_copy(&keycp, &key, true))) {
+        if ((tmpret = pgp_key_copy(keycp, key, true))) {
             ret = tmpret;
             goto done;
         }

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -221,6 +221,13 @@ typedef struct pgp_signature_t {
 
     /* v4 - only fields */
     list subpkts;
+
+    pgp_signature_t();
+    pgp_signature_t(const pgp_signature_t &src);
+    pgp_signature_t(pgp_signature_t &&src);
+    pgp_signature_t &operator=(pgp_signature_t &&src);
+    pgp_signature_t &operator=(const pgp_signature_t &src);
+    ~pgp_signature_t();
 } pgp_signature_t;
 
 /* Signature subpacket, see 5.2.3.1 in RFC 4880 and RFC 4880 bis 02 */

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -296,8 +296,8 @@ typedef struct pgp_sig_subpkt_t {
             pgp_hash_alg_t   halg;
             uint8_t *        hash;
             unsigned         hlen;
-        } sig_target;        /* 5.2.3.25.  Signature Target */
-        pgp_signature_t sig; /* 5.2.3.27. Embedded Signature */
+        } sig_target;         /* 5.2.3.25.  Signature Target */
+        pgp_signature_t *sig; /* 5.2.3.27. Embedded Signature */
         struct {
             uint8_t  version;
             uint8_t *fp;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -203,32 +203,7 @@ typedef struct pgp_userid_pkt_t {
     size_t         uid_len;
 } pgp_userid_pkt_t;
 
-typedef struct pgp_signature_t {
-    pgp_version_t version;
-    /* common v3 and v4 fields */
-    pgp_sig_type_t   type;
-    pgp_pubkey_alg_t palg;
-    pgp_hash_alg_t   halg;
-    uint8_t          lbits[2];
-    uint8_t *        hashed_data;
-    size_t           hashed_len;
-    uint8_t *        material_buf; /* raw signature material */
-    size_t           material_len; /* raw signature material length */
-
-    /* v3 - only fields */
-    uint32_t     creation_time;
-    pgp_key_id_t signer;
-
-    /* v4 - only fields */
-    list subpkts;
-
-    pgp_signature_t();
-    pgp_signature_t(const pgp_signature_t &src);
-    pgp_signature_t(pgp_signature_t &&src);
-    pgp_signature_t &operator=(pgp_signature_t &&src);
-    pgp_signature_t &operator=(const pgp_signature_t &src);
-    ~pgp_signature_t();
-} pgp_signature_t;
+typedef struct pgp_signature_t pgp_signature_t;
 
 /* Signature subpacket, see 5.2.3.1 in RFC 4880 and RFC 4880 bis 02 */
 typedef struct pgp_sig_subpkt_t {
@@ -311,7 +286,41 @@ typedef struct pgp_sig_subpkt_t {
             unsigned len;
         } issuer_fp; /* 5.2.3.28.  Issuer Fingerprint, RFC 4880 bis 04 */
     } fields;        /* parsed contents of the subpacket */
+
+    pgp_sig_subpkt_t();
+    pgp_sig_subpkt_t(const pgp_sig_subpkt_t &src);
+    pgp_sig_subpkt_t(pgp_sig_subpkt_t &&src);
+    pgp_sig_subpkt_t &operator=(pgp_sig_subpkt_t &&src);
+    pgp_sig_subpkt_t &operator=(const pgp_sig_subpkt_t &src);
+    ~pgp_sig_subpkt_t();
 } pgp_sig_subpkt_t;
+
+typedef struct pgp_signature_t {
+    pgp_version_t version;
+    /* common v3 and v4 fields */
+    pgp_sig_type_t   type;
+    pgp_pubkey_alg_t palg;
+    pgp_hash_alg_t   halg;
+    uint8_t          lbits[2];
+    uint8_t *        hashed_data;
+    size_t           hashed_len;
+    uint8_t *        material_buf; /* raw signature material */
+    size_t           material_len; /* raw signature material length */
+
+    /* v3 - only fields */
+    uint32_t     creation_time;
+    pgp_key_id_t signer;
+
+    /* v4 - only fields */
+    std::vector<pgp_sig_subpkt_t> subpkts;
+
+    pgp_signature_t();
+    pgp_signature_t(const pgp_signature_t &src);
+    pgp_signature_t(pgp_signature_t &&src);
+    pgp_signature_t &operator=(pgp_signature_t &&src);
+    pgp_signature_t &operator=(const pgp_signature_t &src);
+    ~pgp_signature_t();
+} pgp_signature_t;
 
 /** pgp_rawpacket_t */
 typedef struct pgp_rawpacket_t {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -319,6 +319,8 @@ typedef struct pgp_signature_t {
     pgp_signature_t(pgp_signature_t &&src);
     pgp_signature_t &operator=(pgp_signature_t &&src);
     pgp_signature_t &operator=(const pgp_signature_t &src);
+    bool             operator==(const pgp_signature_t &src) const;
+    bool             operator!=(const pgp_signature_t &src) const;
     ~pgp_signature_t();
 } pgp_signature_t;
 

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -212,8 +212,8 @@ typedef struct pgp_signature_t {
     uint8_t          lbits[2];
     uint8_t *        hashed_data;
     size_t           hashed_len;
-
-    pgp_signature_material_t material;
+    uint8_t *        material_buf; /* raw signature material */
+    size_t           material_len; /* raw signature material length */
 
     /* v3 - only fields */
     uint32_t     creation_time;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -314,7 +314,7 @@ typedef struct pgp_signature_t {
     /* v4 - only fields */
     std::vector<pgp_sig_subpkt_t> subpkts;
 
-    pgp_signature_t();
+    pgp_signature_t() : hashed_data(NULL), material_buf(NULL){};
     pgp_signature_t(const pgp_signature_t &src);
     pgp_signature_t(pgp_signature_t &&src);
     pgp_signature_t &operator=(pgp_signature_t &&src);

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -420,13 +420,11 @@ typedef struct pgp_subsig_t {
     bool             valid;       /* signature was validated and is valid */
 
     pgp_subsig_t() = default;
+    pgp_subsig_t(const pgp_subsig_t &src);
     pgp_subsig_t(pgp_subsig_t &&src);
     pgp_subsig_t &operator=(pgp_subsig_t &&src);
     pgp_subsig_t &operator=(const pgp_subsig_t &src);
     ~pgp_subsig_t();
-
-    /* make sure we use only explicitly defined constructors/operators */
-    pgp_subsig_t(const pgp_subsig_t &) = delete;
 } pgp_subsig_t;
 
 typedef struct pgp_userid_t {
@@ -435,12 +433,12 @@ typedef struct pgp_userid_t {
     std::string      str;    /* Human-readable representation of the userid */
 
     pgp_userid_t() = default;
+    pgp_userid_t(const pgp_userid_t &src);
     pgp_userid_t(pgp_userid_t &&src);
     pgp_userid_t &operator=(const pgp_userid_t &src);
     ~pgp_userid_t();
 
     /* make sure we use only explicitly defined constructors/operators */
-    pgp_userid_t(const pgp_userid_t &) = delete;
     pgp_userid_t &operator=(pgp_userid_t &&) = delete;
 } pgp_userid_t;
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1144,7 +1144,7 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
             goto done;
         }
 
-        if (pgp_key_copy_fields(&key, pubkey)) {
+        if (pgp_key_copy_fields(key, *pubkey)) {
             RNP_LOG("failed to copy key fields");
             goto done;
         }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -246,38 +246,32 @@ rnp_key_from_transferable_subkey(pgp_key_t *                subkey,
 rnp_result_t
 rnp_key_store_pgp_read_from_src(rnp_key_store_t *keyring, pgp_source_t *src)
 {
-    pgp_key_sequence_t        keys = {};
-    pgp_transferable_subkey_t tskey = {};
-    rnp_result_t              ret = RNP_ERROR_GENERIC;
+    rnp_result_t ret = RNP_ERROR_GENERIC;
 
     /* check whether we have transferable subkey in source */
     if (is_subkey_pkt(stream_pkt_type(src))) {
-        if ((ret = process_pgp_subkey(src, &tskey, keyring->skip_parsing_errors))) {
+        pgp_transferable_subkey_t tskey = {};
+        ret = process_pgp_subkey(*src, tskey, keyring->skip_parsing_errors);
+        if (ret) {
             return ret;
         }
-        ret = rnp_key_store_add_transferable_subkey(keyring, &tskey, NULL) ?
-                RNP_SUCCESS :
-                RNP_ERROR_BAD_STATE;
-        transferable_subkey_destroy(&tskey);
-        return ret;
+        return rnp_key_store_add_transferable_subkey(keyring, &tskey, NULL) ?
+                 RNP_SUCCESS :
+                 RNP_ERROR_BAD_STATE;
     }
 
     /* process armored or raw transferable key packets sequence(s) */
-    if ((ret = process_pgp_keys(src, &keys, keyring->skip_parsing_errors))) {
+    pgp_key_sequence_t keys = {};
+    if ((ret = process_pgp_keys(src, keys, keyring->skip_parsing_errors))) {
         return ret;
     }
 
     for (list_item *key = list_front(keys.keys); key; key = list_next(key)) {
         if (!rnp_key_store_add_transferable_key(keyring, (pgp_transferable_key_t *) key)) {
-            ret = RNP_ERROR_BAD_STATE;
-            goto done;
+            return RNP_ERROR_BAD_STATE;
         }
     }
-
-    ret = RNP_SUCCESS;
-done:
-    key_sequence_destroy(&keys);
-    return ret;
+    return RNP_SUCCESS;
 }
 
 bool

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -207,9 +207,8 @@ rnp_key_from_transferable_key(pgp_key_t *key, pgp_transferable_key_t *tkey)
     }
 
     /* add userids and their signatures */
-    for (list_item *uid = list_front(tkey->userids); uid; uid = list_next(uid)) {
-        pgp_transferable_userid_t *tuid = (pgp_transferable_userid_t *) uid;
-        if (!rnp_key_add_transferable_userid(key, tuid)) {
+    for (auto &uid : tkey->userids) {
+        if (!rnp_key_add_transferable_userid(key, &uid)) {
             return false;
         }
     }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -261,13 +261,13 @@ rnp_key_store_pgp_read_from_src(rnp_key_store_t *keyring, pgp_source_t *src)
     }
 
     /* process armored or raw transferable key packets sequence(s) */
-    pgp_key_sequence_t keys = {};
+    pgp_key_sequence_t keys;
     if ((ret = process_pgp_keys(src, keys, keyring->skip_parsing_errors))) {
         return ret;
     }
 
-    for (list_item *key = list_front(keys.keys); key; key = list_next(key)) {
-        if (!rnp_key_store_add_transferable_key(keyring, (pgp_transferable_key_t *) key)) {
+    for (auto &key : keys.keys) {
+        if (!rnp_key_store_add_transferable_key(keyring, &key)) {
             return RNP_ERROR_BAD_STATE;
         }
     }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -84,10 +84,10 @@ rnp_key_add_signature(pgp_key_t *key, const pgp_signature_t *sig)
 }
 
 static bool
-rnp_key_add_signatures(pgp_key_t *key, list signatures)
+rnp_key_add_signatures(pgp_key_t *key, pgp_signature_list_t &signatures)
 {
-    for (list_item *sig = list_front(signatures); sig; sig = list_next(sig)) {
-        if (!rnp_key_add_signature(key, (pgp_signature_t *) sig)) {
+    for (auto &sig : signatures) {
+        if (!rnp_key_add_signature(key, &sig)) {
             return false;
         }
     }

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -174,9 +174,8 @@ rnp_key_store_add_transferable_key(rnp_key_store_t *keyring, pgp_transferable_ke
     }
 
     /* add subkeys */
-    for (list_item *skey = list_front(tkey->subkeys); skey; skey = list_next(skey)) {
-        pgp_transferable_subkey_t *subkey = (pgp_transferable_subkey_t *) skey;
-        if (!rnp_key_store_add_transferable_subkey(keyring, subkey, addkey)) {
+    for (auto &subkey : tkey->subkeys) {
+        if (!rnp_key_store_add_transferable_subkey(keyring, &subkey, addkey)) {
             RNP_LOG("Failed to add subkey to key store.");
             goto error;
         }

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -249,12 +249,12 @@ rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *prim
         return false;
     }
 
-    if (transferable_subkey_from_key(&dstkey, dst)) {
+    if (transferable_subkey_from_key(dstkey, *dst)) {
         RNP_LOG("failed to get transferable key from dstkey");
         return false;
     }
 
-    if (transferable_subkey_from_key(&srckey, src)) {
+    if (transferable_subkey_from_key(srckey, *src)) {
         RNP_LOG("failed to get transferable key from srckey");
         return false;
     }
@@ -266,7 +266,7 @@ rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *prim
         srckey.subkey = tmp;
     }
 
-    if (transferable_subkey_merge(&dstkey, &srckey)) {
+    if (transferable_subkey_merge(dstkey, srckey)) {
         RNP_LOG("failed to merge transferable subkeys");
         return false;
     }
@@ -307,12 +307,12 @@ rnp_key_store_merge_key(pgp_key_t *dst, const pgp_key_t *src)
         return false;
     }
 
-    if (transferable_key_from_key(&dstkey, dst)) {
+    if (transferable_key_from_key(dstkey, *dst)) {
         RNP_LOG("failed to get transferable key from dstkey");
         return false;
     }
 
-    if (transferable_key_from_key(&srckey, src)) {
+    if (transferable_key_from_key(srckey, *src)) {
         RNP_LOG("failed to get transferable key from srckey");
         return false;
     }
@@ -325,7 +325,7 @@ rnp_key_store_merge_key(pgp_key_t *dst, const pgp_key_t *src)
         /* no subkey processing here - they are separated from the main key */
     }
 
-    if (transferable_key_merge(&dstkey, &srckey)) {
+    if (transferable_key_merge(dstkey, srckey)) {
         RNP_LOG("failed to merge transferable keys");
         return false;
     }

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -456,7 +456,7 @@ rnp_key_store_add_subkey(rnp_key_store_t *keyring, pgp_key_t *srckey, pgp_key_t 
             RNP_LOG("%s", e.what());
             return NULL;
         }
-        if (pgp_key_copy(oldkey, srckey, false)) {
+        if (pgp_key_copy(*oldkey, *srckey, false)) {
             RNP_LOG_KEY("key %s copying failed", srckey);
             RNP_LOG_KEY("primary key is %s", primary);
             keyring->keys.pop_back();
@@ -510,7 +510,7 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
             RNP_LOG("%s", e.what());
             return NULL;
         }
-        if (pgp_key_copy(added_key, srckey, false)) {
+        if (pgp_key_copy(*added_key, *srckey, false)) {
             RNP_LOG_KEY("key %s copying failed", srckey);
             keyring->keys.pop_back();
             keyring->keybyfp.erase(pgp_key_get_fp(srckey));
@@ -544,7 +544,7 @@ rnp_key_store_import_key(rnp_key_store_t *        keyring,
     bool       changed = false;
 
     /* add public key */
-    if (pgp_key_copy(&keycp, srckey, pubkey)) {
+    if (pgp_key_copy(keycp, *srckey, pubkey)) {
         RNP_LOG_KEY("failed to create key %s copy", srckey);
         return NULL;
     }

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -630,7 +630,7 @@ signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, pgp_sig_subpkt_t 
         break;
     case PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE:
         dst_printf(dst, "%s:\n", sname);
-        stream_dump_signature_pkt(ctx, &subpkt->fields.sig, dst);
+        stream_dump_signature_pkt(ctx, subpkt->fields.sig, dst);
         break;
     case PGP_SIG_SUBPKT_ISSUER_FPR:
         dst_print_hex(
@@ -1592,7 +1592,7 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *ctx, pgp_sig_subpkt_t *subpkt, jso
         if (!sig || !obj_add_field_json(obj, "signature", sig)) {
             return false;
         }
-        return !stream_dump_signature_pkt_json(ctx, &subpkt->fields.sig, sig);
+        return !stream_dump_signature_pkt_json(ctx, subpkt->fields.sig, sig);
     }
     case PGP_SIG_SUBPKT_ISSUER_FPR:
         return obj_add_hex_json(

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -759,7 +759,6 @@ stream_dump_signature(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
     }
 
     stream_dump_signature_pkt(ctx, &sig, dst);
-    free_signature(&sig);
 }
 
 static rnp_result_t
@@ -1752,10 +1751,7 @@ stream_dump_signature_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *
     if (stream_parse_signature(src, &sig)) {
         return RNP_SUCCESS;
     }
-
-    rnp_result_t ret = stream_dump_signature_pkt_json(ctx, &sig, pkt);
-    free_signature(&sig);
-    return ret;
+    return stream_dump_signature_pkt_json(ctx, &sig, pkt);
 }
 
 static rnp_result_t

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -517,85 +517,85 @@ static void         stream_dump_signature_pkt(rnp_dump_ctx_t * ctx,
                                               pgp_dest_t *     dst);
 
 static void
-signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, pgp_sig_subpkt_t *subpkt)
+signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, const pgp_sig_subpkt_t &subpkt)
 {
-    const char *sname = pgp_str_from_map(subpkt->type, sig_subpkt_type_map);
+    const char *sname = pgp_str_from_map(subpkt.type, sig_subpkt_type_map);
 
-    switch (subpkt->type) {
+    switch (subpkt.type) {
     case PGP_SIG_SUBPKT_CREATION_TIME:
-        dst_print_time(dst, sname, subpkt->fields.create);
+        dst_print_time(dst, sname, subpkt.fields.create);
         break;
     case PGP_SIG_SUBPKT_EXPIRATION_TIME:
-        dst_print_expiration(dst, sname, subpkt->fields.expiry);
+        dst_print_expiration(dst, sname, subpkt.fields.expiry);
         break;
     case PGP_SIG_SUBPKT_EXPORT_CERT:
-        dst_printf(dst, "%s: %d\n", sname, (int) subpkt->fields.exportable);
+        dst_printf(dst, "%s: %d\n", sname, (int) subpkt.fields.exportable);
         break;
     case PGP_SIG_SUBPKT_TRUST:
         dst_printf(dst,
                    "%s: amount %d, level %d\n",
                    sname,
-                   (int) subpkt->fields.trust.amount,
-                   (int) subpkt->fields.trust.level);
+                   (int) subpkt.fields.trust.amount,
+                   (int) subpkt.fields.trust.level);
         break;
     case PGP_SIG_SUBPKT_REGEXP:
-        dst_print_raw(dst, sname, subpkt->fields.regexp.str, subpkt->fields.regexp.len);
+        dst_print_raw(dst, sname, subpkt.fields.regexp.str, subpkt.fields.regexp.len);
         break;
     case PGP_SIG_SUBPKT_REVOCABLE:
-        dst_printf(dst, "%s: %d\n", sname, (int) subpkt->fields.revocable);
+        dst_printf(dst, "%s: %d\n", sname, (int) subpkt.fields.revocable);
         break;
     case PGP_SIG_SUBPKT_KEY_EXPIRY:
-        dst_print_expiration(dst, sname, subpkt->fields.expiry);
+        dst_print_expiration(dst, sname, subpkt.fields.expiry);
         break;
     case PGP_SIG_SUBPKT_PREFERRED_SKA:
         dst_print_algs(dst,
                        "preferred symmetric algorithms",
-                       subpkt->fields.preferred.arr,
-                       subpkt->fields.preferred.len,
+                       subpkt.fields.preferred.arr,
+                       subpkt.fields.preferred.len,
                        symm_alg_map);
         break;
     case PGP_SIG_SUBPKT_REVOCATION_KEY:
         dst_printf(dst, "%s\n", sname);
-        dst_printf(dst, "class: %d\n", (int) subpkt->fields.revocation_key.klass);
-        dst_print_palg(dst, NULL, subpkt->fields.revocation_key.pkalg);
+        dst_printf(dst, "class: %d\n", (int) subpkt.fields.revocation_key.klass);
+        dst_print_palg(dst, NULL, subpkt.fields.revocation_key.pkalg);
         dst_print_hex(
-          dst, "fingerprint", subpkt->fields.revocation_key.fp, PGP_FINGERPRINT_SIZE, true);
+          dst, "fingerprint", subpkt.fields.revocation_key.fp, PGP_FINGERPRINT_SIZE, true);
         break;
     case PGP_SIG_SUBPKT_ISSUER_KEY_ID:
-        dst_print_hex(dst, sname, subpkt->fields.issuer, PGP_KEY_ID_SIZE, false);
+        dst_print_hex(dst, sname, subpkt.fields.issuer, PGP_KEY_ID_SIZE, false);
         break;
     case PGP_SIG_SUBPKT_NOTATION_DATA:
         break;
     case PGP_SIG_SUBPKT_PREFERRED_HASH:
         dst_print_algs(dst,
                        "preferred hash algorithms",
-                       subpkt->fields.preferred.arr,
-                       subpkt->fields.preferred.len,
+                       subpkt.fields.preferred.arr,
+                       subpkt.fields.preferred.len,
                        hash_alg_map);
         break;
     case PGP_SIG_SUBPKT_PREF_COMPRESS:
         dst_print_algs(dst,
                        "preferred compression algorithms",
-                       subpkt->fields.preferred.arr,
-                       subpkt->fields.preferred.len,
+                       subpkt.fields.preferred.arr,
+                       subpkt.fields.preferred.len,
                        z_alg_map);
         break;
     case PGP_SIG_SUBPKT_KEYSERV_PREFS:
         dst_printf(dst, "%s\n", sname);
-        dst_printf(dst, "no-modify: %d\n", (int) subpkt->fields.ks_prefs.no_modify);
+        dst_printf(dst, "no-modify: %d\n", (int) subpkt.fields.ks_prefs.no_modify);
         break;
     case PGP_SIG_SUBPKT_PREF_KEYSERV:
         dst_print_raw(
-          dst, sname, subpkt->fields.preferred_ks.uri, subpkt->fields.preferred_ks.len);
+          dst, sname, subpkt.fields.preferred_ks.uri, subpkt.fields.preferred_ks.len);
         break;
     case PGP_SIG_SUBPKT_PRIMARY_USER_ID:
-        dst_printf(dst, "%s: %d\n", sname, (int) subpkt->fields.primary_uid);
+        dst_printf(dst, "%s: %d\n", sname, (int) subpkt.fields.primary_uid);
         break;
     case PGP_SIG_SUBPKT_POLICY_URI:
-        dst_print_raw(dst, sname, subpkt->fields.policy.uri, subpkt->fields.policy.len);
+        dst_print_raw(dst, sname, subpkt.fields.policy.uri, subpkt.fields.policy.len);
         break;
     case PGP_SIG_SUBPKT_KEY_FLAGS: {
-        uint8_t flg = subpkt->fields.key_flags;
+        uint8_t flg = subpkt.fields.key_flags;
         dst_printf(dst, "%s: 0x%02x ( ", sname, flg);
         dst_printf(dst, "%s", flg ? "" : "none");
         dst_printf(dst, "%s", flg & PGP_KF_CERTIFY ? "certify " : "");
@@ -609,44 +609,44 @@ signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, pgp_sig_subpkt_t 
         break;
     }
     case PGP_SIG_SUBPKT_SIGNERS_USER_ID:
-        dst_print_raw(dst, sname, subpkt->fields.signer.uid, subpkt->fields.signer.len);
+        dst_print_raw(dst, sname, subpkt.fields.signer.uid, subpkt.fields.signer.len);
         break;
     case PGP_SIG_SUBPKT_REVOCATION_REASON: {
-        int         code = subpkt->fields.revocation_reason.code;
+        int         code = subpkt.fields.revocation_reason.code;
         const char *reason = pgp_str_from_map(code, revoc_reason_map);
         dst_printf(dst, "%s: %d (%s)\n", sname, code, reason);
         dst_print_raw(dst,
                       "message",
-                      subpkt->fields.revocation_reason.str,
-                      subpkt->fields.revocation_reason.len);
+                      subpkt.fields.revocation_reason.str,
+                      subpkt.fields.revocation_reason.len);
         break;
     }
     case PGP_SIG_SUBPKT_FEATURES:
-        dst_printf(dst, "%s: 0x%02x ( ", sname, subpkt->data[0]);
-        dst_printf(dst, "%s", subpkt->fields.features.mdc ? "mdc " : "");
-        dst_printf(dst, "%s", subpkt->fields.features.aead ? "aead " : "");
-        dst_printf(dst, "%s", subpkt->fields.features.key_v5 ? "v5 keys " : "");
+        dst_printf(dst, "%s: 0x%02x ( ", sname, subpkt.data[0]);
+        dst_printf(dst, "%s", subpkt.fields.features.mdc ? "mdc " : "");
+        dst_printf(dst, "%s", subpkt.fields.features.aead ? "aead " : "");
+        dst_printf(dst, "%s", subpkt.fields.features.key_v5 ? "v5 keys " : "");
         dst_printf(dst, ")\n");
         break;
     case PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE:
         dst_printf(dst, "%s:\n", sname);
-        stream_dump_signature_pkt(ctx, subpkt->fields.sig, dst);
+        stream_dump_signature_pkt(ctx, subpkt.fields.sig, dst);
         break;
     case PGP_SIG_SUBPKT_ISSUER_FPR:
         dst_print_hex(
-          dst, sname, subpkt->fields.issuer_fp.fp, subpkt->fields.issuer_fp.len, true);
+          dst, sname, subpkt.fields.issuer_fp.fp, subpkt.fields.issuer_fp.len, true);
         break;
     case PGP_SIG_SUBPKT_PREFERRED_AEAD:
         dst_print_algs(dst,
                        "preferred aead algorithms",
-                       subpkt->fields.preferred.arr,
-                       subpkt->fields.preferred.len,
+                       subpkt.fields.preferred.arr,
+                       subpkt.fields.preferred.len,
                        aead_alg_map);
         break;
     default:
         if (!ctx->dump_packets) {
             indent_dest_increase(dst);
-            dst_hexdump(dst, subpkt->data, subpkt->len);
+            dst_hexdump(dst, subpkt.data, subpkt.len);
             indent_dest_decrease(dst);
         }
     }
@@ -660,21 +660,19 @@ signature_dump_subpackets(rnp_dump_ctx_t * ctx,
 {
     bool empty = true;
 
-    for (list_item *li = list_front(sig->subpkts); li; li = list_next(li)) {
-        pgp_sig_subpkt_t *subpkt = (pgp_sig_subpkt_t *) li;
-        if (subpkt->hashed != hashed) {
+    for (auto &subpkt : sig->subpkts) {
+        if (subpkt.hashed != hashed) {
             continue;
         }
         empty = false;
-        dst_printf(dst, ":type %d, len %d", (int) subpkt->type, (int) subpkt->len);
-        dst_printf(dst, "%s\n", subpkt->critical ? ", critical" : "");
+        dst_printf(dst, ":type %d, len %d", (int) subpkt.type, (int) subpkt.len);
+        dst_printf(dst, "%s\n", subpkt.critical ? ", critical" : "");
         if (ctx->dump_packets) {
             dst_printf(dst, ":subpacket contents:\n");
             indent_dest_increase(dst);
-            dst_hexdump(dst, subpkt->data, subpkt->len);
+            dst_hexdump(dst, subpkt.data, subpkt.len);
             indent_dest_decrease(dst);
         }
-
         signature_dump_subpacket(ctx, dst, subpkt);
     }
 
@@ -1450,85 +1448,87 @@ static rnp_result_t stream_dump_signature_pkt_json(rnp_dump_ctx_t *       ctx,
                                                    json_object *          pkt);
 
 static bool
-signature_dump_subpacket_json(rnp_dump_ctx_t *ctx, pgp_sig_subpkt_t *subpkt, json_object *obj)
+signature_dump_subpacket_json(rnp_dump_ctx_t *        ctx,
+                              const pgp_sig_subpkt_t &subpkt,
+                              json_object *           obj)
 {
-    switch (subpkt->type) {
+    switch (subpkt.type) {
     case PGP_SIG_SUBPKT_CREATION_TIME:
         return obj_add_field_json(
-          obj, "creation time", json_object_new_int64(subpkt->fields.create));
+          obj, "creation time", json_object_new_int64(subpkt.fields.create));
     case PGP_SIG_SUBPKT_EXPIRATION_TIME:
         return obj_add_field_json(
-          obj, "expiration time", json_object_new_int64(subpkt->fields.expiry));
+          obj, "expiration time", json_object_new_int64(subpkt.fields.expiry));
     case PGP_SIG_SUBPKT_EXPORT_CERT:
         return obj_add_field_json(
-          obj, "exportable", json_object_new_boolean(subpkt->fields.exportable));
+          obj, "exportable", json_object_new_boolean(subpkt.fields.exportable));
     case PGP_SIG_SUBPKT_TRUST:
         return obj_add_field_json(
-                 obj, "amount", json_object_new_int(subpkt->fields.trust.amount)) &&
+                 obj, "amount", json_object_new_int(subpkt.fields.trust.amount)) &&
                obj_add_field_json(
-                 obj, "level", json_object_new_int(subpkt->fields.trust.level));
+                 obj, "level", json_object_new_int(subpkt.fields.trust.level));
     case PGP_SIG_SUBPKT_REGEXP:
         return obj_add_field_json(
           obj,
           "regexp",
-          json_object_new_string_len(subpkt->fields.regexp.str, subpkt->fields.regexp.len));
+          json_object_new_string_len(subpkt.fields.regexp.str, subpkt.fields.regexp.len));
     case PGP_SIG_SUBPKT_REVOCABLE:
         return obj_add_field_json(
-          obj, "revocable", json_object_new_boolean(subpkt->fields.revocable));
+          obj, "revocable", json_object_new_boolean(subpkt.fields.revocable));
     case PGP_SIG_SUBPKT_KEY_EXPIRY:
         return obj_add_field_json(
-          obj, "key expiration", json_object_new_int64(subpkt->fields.expiry));
+          obj, "key expiration", json_object_new_int64(subpkt.fields.expiry));
     case PGP_SIG_SUBPKT_PREFERRED_SKA:
         return subpacket_obj_add_algs(obj,
                                       "algorithms",
-                                      subpkt->fields.preferred.arr,
-                                      subpkt->fields.preferred.len,
+                                      subpkt.fields.preferred.arr,
+                                      subpkt.fields.preferred.len,
                                       symm_alg_map);
     case PGP_SIG_SUBPKT_PREFERRED_HASH:
         return subpacket_obj_add_algs(obj,
                                       "algorithms",
-                                      subpkt->fields.preferred.arr,
-                                      subpkt->fields.preferred.len,
+                                      subpkt.fields.preferred.arr,
+                                      subpkt.fields.preferred.len,
                                       hash_alg_map);
     case PGP_SIG_SUBPKT_PREF_COMPRESS:
         return subpacket_obj_add_algs(obj,
                                       "algorithms",
-                                      subpkt->fields.preferred.arr,
-                                      subpkt->fields.preferred.len,
+                                      subpkt.fields.preferred.arr,
+                                      subpkt.fields.preferred.len,
                                       z_alg_map);
     case PGP_SIG_SUBPKT_PREFERRED_AEAD:
         return subpacket_obj_add_algs(obj,
                                       "algorithms",
-                                      subpkt->fields.preferred.arr,
-                                      subpkt->fields.preferred.len,
+                                      subpkt.fields.preferred.arr,
+                                      subpkt.fields.preferred.len,
                                       aead_alg_map);
     case PGP_SIG_SUBPKT_REVOCATION_KEY:
         return obj_add_field_json(
-                 obj, "class", json_object_new_int(subpkt->fields.revocation_key.klass)) &&
+                 obj, "class", json_object_new_int(subpkt.fields.revocation_key.klass)) &&
                obj_add_field_json(
-                 obj, "algorithm", json_object_new_int(subpkt->fields.revocation_key.pkalg)) &&
+                 obj, "algorithm", json_object_new_int(subpkt.fields.revocation_key.pkalg)) &&
                obj_add_hex_json(
-                 obj, "fingerprint", subpkt->fields.revocation_key.fp, PGP_FINGERPRINT_SIZE);
+                 obj, "fingerprint", subpkt.fields.revocation_key.fp, PGP_FINGERPRINT_SIZE);
     case PGP_SIG_SUBPKT_ISSUER_KEY_ID:
-        return obj_add_hex_json(obj, "issuer keyid", subpkt->fields.issuer, PGP_KEY_ID_SIZE);
+        return obj_add_hex_json(obj, "issuer keyid", subpkt.fields.issuer, PGP_KEY_ID_SIZE);
     case PGP_SIG_SUBPKT_KEYSERV_PREFS:
         return obj_add_field_json(
-          obj, "no-modify", json_object_new_boolean(subpkt->fields.ks_prefs.no_modify));
+          obj, "no-modify", json_object_new_boolean(subpkt.fields.ks_prefs.no_modify));
     case PGP_SIG_SUBPKT_PREF_KEYSERV:
         return obj_add_field_json(obj,
                                   "uri",
-                                  json_object_new_string_len(subpkt->fields.preferred_ks.uri,
-                                                             subpkt->fields.preferred_ks.len));
+                                  json_object_new_string_len(subpkt.fields.preferred_ks.uri,
+                                                             subpkt.fields.preferred_ks.len));
     case PGP_SIG_SUBPKT_PRIMARY_USER_ID:
         return obj_add_field_json(
-          obj, "primary", json_object_new_boolean(subpkt->fields.primary_uid));
+          obj, "primary", json_object_new_boolean(subpkt.fields.primary_uid));
     case PGP_SIG_SUBPKT_POLICY_URI:
         return obj_add_field_json(
           obj,
           "uri",
-          json_object_new_string_len(subpkt->fields.policy.uri, subpkt->fields.policy.len));
+          json_object_new_string_len(subpkt.fields.policy.uri, subpkt.fields.policy.len));
     case PGP_SIG_SUBPKT_KEY_FLAGS: {
-        uint8_t flg = subpkt->fields.key_flags;
+        uint8_t flg = subpkt.fields.key_flags;
         if (!obj_add_field_json(obj, "flags", json_object_new_int(flg))) {
             return false;
         }
@@ -1570,43 +1570,42 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *ctx, pgp_sig_subpkt_t *subpkt, jso
         return obj_add_field_json(
           obj,
           "uid",
-          json_object_new_string_len(subpkt->fields.signer.uid, subpkt->fields.signer.len));
+          json_object_new_string_len(subpkt.fields.signer.uid, subpkt.fields.signer.len));
     case PGP_SIG_SUBPKT_REVOCATION_REASON: {
         if (!obj_add_intstr_json(
-              obj, "code", subpkt->fields.revocation_reason.code, revoc_reason_map)) {
+              obj, "code", subpkt.fields.revocation_reason.code, revoc_reason_map)) {
             return false;
         }
         return obj_add_field_json(
           obj,
           "message",
-          json_object_new_string_len(subpkt->fields.revocation_reason.str,
-                                     subpkt->fields.revocation_reason.len));
+          json_object_new_string_len(subpkt.fields.revocation_reason.str,
+                                     subpkt.fields.revocation_reason.len));
     }
     case PGP_SIG_SUBPKT_FEATURES:
         return obj_add_field_json(
-                 obj, "mdc", json_object_new_boolean(subpkt->fields.features.mdc)) &&
+                 obj, "mdc", json_object_new_boolean(subpkt.fields.features.mdc)) &&
                obj_add_field_json(
-                 obj, "aead", json_object_new_boolean(subpkt->fields.features.aead)) &&
+                 obj, "aead", json_object_new_boolean(subpkt.fields.features.aead)) &&
                obj_add_field_json(
-                 obj, "v5 keys", json_object_new_boolean(subpkt->fields.features.key_v5));
+                 obj, "v5 keys", json_object_new_boolean(subpkt.fields.features.key_v5));
     case PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE: {
         json_object *sig = json_object_new_object();
         if (!sig || !obj_add_field_json(obj, "signature", sig)) {
             return false;
         }
-        return !stream_dump_signature_pkt_json(ctx, subpkt->fields.sig, sig);
+        return !stream_dump_signature_pkt_json(ctx, subpkt.fields.sig, sig);
     }
     case PGP_SIG_SUBPKT_ISSUER_FPR:
         return obj_add_hex_json(
-          obj, "fingerprint", subpkt->fields.issuer_fp.fp, subpkt->fields.issuer_fp.len);
+          obj, "fingerprint", subpkt.fields.issuer_fp.fp, subpkt.fields.issuer_fp.len);
     case PGP_SIG_SUBPKT_NOTATION_DATA:
     default:
         if (!ctx->dump_packets) {
-            return obj_add_hex_json(obj, "raw", subpkt->data, subpkt->len);
+            return obj_add_hex_json(obj, "raw", subpkt.data, subpkt.len);
         }
         return true;
     }
-
     return true;
 }
 
@@ -1615,31 +1614,30 @@ signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp_signature_t *sig)
 {
     json_object *res = json_object_new_array();
 
-    for (list_item *li = list_front(sig->subpkts); li; li = list_next(li)) {
-        pgp_sig_subpkt_t *subpkt = (pgp_sig_subpkt_t *) li;
-        json_object *     jso_subpkt = json_object_new_object();
+    for (auto &subpkt : sig->subpkts) {
+        json_object *jso_subpkt = json_object_new_object();
         if (json_object_array_add(res, jso_subpkt)) {
             json_object_put(jso_subpkt);
             goto error;
         }
 
-        if (!obj_add_intstr_json(jso_subpkt, "type", subpkt->type, sig_subpkt_type_map)) {
+        if (!obj_add_intstr_json(jso_subpkt, "type", subpkt.type, sig_subpkt_type_map)) {
             goto error;
         }
-        if (!obj_add_field_json(jso_subpkt, "length", json_object_new_int(subpkt->len))) {
-            goto error;
-        }
-        if (!obj_add_field_json(
-              jso_subpkt, "hashed", json_object_new_boolean(subpkt->hashed))) {
+        if (!obj_add_field_json(jso_subpkt, "length", json_object_new_int(subpkt.len))) {
             goto error;
         }
         if (!obj_add_field_json(
-              jso_subpkt, "critical", json_object_new_boolean(subpkt->critical))) {
+              jso_subpkt, "hashed", json_object_new_boolean(subpkt.hashed))) {
+            goto error;
+        }
+        if (!obj_add_field_json(
+              jso_subpkt, "critical", json_object_new_boolean(subpkt.critical))) {
             goto error;
         }
 
         if (ctx->dump_packets &&
-            !obj_add_hex_json(jso_subpkt, "raw", subpkt->data, subpkt->len)) {
+            !obj_add_hex_json(jso_subpkt, "raw", subpkt.data, subpkt.len)) {
             goto error;
         }
 

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -40,65 +40,30 @@
 #include "types.h"
 #include "fingerprint.h"
 #include "pgp-key.h"
-#include "list.h"
 #include "crypto.h"
 #include "crypto/signatures.h"
 #include "../librekey/key_store_pgp.h"
 #include <set>
-
-static bool
-copy_signatures(list *dst, const list *src)
-{
-    for (list_item *sig = list_front(*src); sig; sig = list_next(sig)) {
-        pgp_signature_t *newsig = (pgp_signature_t *) list_append(dst, NULL, sizeof(*newsig));
-        if (!newsig) {
-            signature_list_destroy(dst);
-            return false;
-        }
-        try {
-            *newsig = *((pgp_signature_t *) sig);
-        } catch (const std::exception &e) {
-            RNP_LOG("%s", e.what());
-            return false;
-        }
-    }
-    return true;
-}
-
-static bool
-list_has_signature(const list *lst, const pgp_signature_t *sig)
-{
-    for (list_item *lsig = list_front(*lst); lsig; lsig = list_next(lsig)) {
-        if (signature_pkt_equal((pgp_signature_t *) lsig, sig)) {
-            return true;
-        }
-    }
-    return false;
-}
+#include <algorithm>
 
 /**
- * @brief Add signatures from src to list dst, skipping the duplicates.
+ * @brief Add signatures from src to dst, skipping the duplicates.
  *
- * @param dst List which will contain all distinct signatures from src and dst
- * @param src List to merge signatures from
+ * @param dst Vector which will contain all distinct signatures from src and dst
+ * @param src Vector to merge signatures from
  * @return true on success or false otherwise. On failure dst may have some sigs appended.
  */
 static rnp_result_t
-merge_signatures(list *dst, const list *src)
+merge_signatures(pgp_signature_list_t &dst, const pgp_signature_list_t &src)
 {
-    for (list_item *sig = list_front(*src); sig; sig = list_next(sig)) {
-        if (list_has_signature(dst, (pgp_signature_t *) sig)) {
-            continue;
-        }
-        pgp_signature_t *newsig = (pgp_signature_t *) list_append(dst, NULL, sizeof(*newsig));
-        if (!newsig) {
-            return RNP_ERROR_OUT_OF_MEMORY;
-        }
+    for (auto &sig : src) {
         try {
-            *newsig = *((pgp_signature_t *) sig);
+            if (std::find(dst.begin(), dst.end(), sig) != dst.end()) {
+                continue;
+            }
+            dst.emplace_back(sig);
         } catch (const std::exception &e) {
             RNP_LOG("%s", e.what());
-            list_remove((list_item *) newsig);
             return RNP_ERROR_OUT_OF_MEMORY;
         }
     }
@@ -106,109 +71,104 @@ merge_signatures(list *dst, const list *src)
 }
 
 static rnp_result_t
-transferable_userid_merge(pgp_transferable_userid_t *dst, const pgp_transferable_userid_t *src)
+transferable_userid_merge(pgp_transferable_userid_t &dst, const pgp_transferable_userid_t &src)
 {
-    if (!userid_pkt_equal(&dst->uid, &src->uid)) {
+    if (!userid_pkt_equal(&dst.uid, &src.uid)) {
         RNP_LOG("wrong userid merge attempt");
         return RNP_ERROR_BAD_PARAMETERS;
     }
-
-    return merge_signatures(&dst->signatures, &src->signatures);
+    return merge_signatures(dst.signatures, src.signatures);
 }
 
 bool
-transferable_subkey_copy(pgp_transferable_subkey_t *      dst,
-                         const pgp_transferable_subkey_t *src,
+transferable_subkey_copy(pgp_transferable_subkey_t &      dst,
+                         const pgp_transferable_subkey_t &src,
                          bool                             pubonly)
 {
-    if (!copy_key_pkt(&dst->subkey, &src->subkey, pubonly)) {
+    if (!copy_key_pkt(&dst.subkey, &src.subkey, pubonly)) {
         RNP_LOG("failed to copy subkey pkt");
         return false;
     }
-
-    if (!copy_signatures(&dst->signatures, &src->signatures)) {
-        RNP_LOG("failed to copy subkey signatures");
+    try {
+        dst.signatures = src.signatures;
+    } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
         return false;
     }
     return true;
 }
 
 rnp_result_t
-transferable_subkey_from_key(pgp_transferable_subkey_t *dst, const pgp_key_t *key)
+transferable_subkey_from_key(pgp_transferable_subkey_t &dst, const pgp_key_t &key)
 {
     pgp_source_t memsrc = {};
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
-    if (!rnp_key_to_src(key, &memsrc)) {
+    if (!rnp_key_to_src(&key, &memsrc)) {
         return RNP_ERROR_BAD_STATE;
     }
 
-    ret = process_pgp_subkey(memsrc, *dst, false);
+    ret = process_pgp_subkey(memsrc, dst, false);
     src_close(&memsrc);
     return ret;
 }
 
 rnp_result_t
-transferable_subkey_merge(pgp_transferable_subkey_t *dst, const pgp_transferable_subkey_t *src)
+transferable_subkey_merge(pgp_transferable_subkey_t &dst, const pgp_transferable_subkey_t &src)
 {
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
-    if (!key_pkt_equal(&dst->subkey, &src->subkey, true)) {
+    if (!key_pkt_equal(&dst.subkey, &src.subkey, true)) {
         RNP_LOG("wrong subkey merge call");
         return RNP_ERROR_BAD_PARAMETERS;
     }
-
-    if ((ret = merge_signatures(&dst->signatures, &src->signatures))) {
+    if ((ret = merge_signatures(dst.signatures, src.signatures))) {
         RNP_LOG("failed to merge signatures");
     }
     return ret;
 }
 
 bool
-transferable_key_copy(pgp_transferable_key_t *      dst,
-                      const pgp_transferable_key_t *src,
+transferable_key_copy(pgp_transferable_key_t &      dst,
+                      const pgp_transferable_key_t &src,
                       bool                          pubonly)
 {
-    if (!copy_key_pkt(&dst->key, &src->key, pubonly)) {
+    if (!copy_key_pkt(&dst.key, &src.key, pubonly)) {
         RNP_LOG("failed to copy key pkt");
         return false;
     }
 
     try {
-        dst->userids = src->userids;
-        dst->subkeys = src->subkeys;
+        dst.userids = src.userids;
+        dst.subkeys = src.subkeys;
+        dst.signatures = src.signatures;
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
-        return false;
-    }
-
-    if (!copy_signatures(&dst->signatures, &src->signatures)) {
-        RNP_LOG("failed to copy key signatures");
         return false;
     }
     return true;
 }
 
 rnp_result_t
-transferable_key_from_key(pgp_transferable_key_t *dst, const pgp_key_t *key)
+transferable_key_from_key(pgp_transferable_key_t &dst, const pgp_key_t &key)
 {
     pgp_source_t memsrc = {};
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
-    if (!rnp_key_to_src(key, &memsrc)) {
+    if (!rnp_key_to_src(&key, &memsrc)) {
         return RNP_ERROR_BAD_STATE;
     }
 
-    ret = process_pgp_key(&memsrc, *dst, false);
+    ret = process_pgp_key(&memsrc, dst, false);
     src_close(&memsrc);
     return ret;
 }
 
 static pgp_transferable_userid_t *
-transferable_key_has_userid(pgp_transferable_key_t *src, const pgp_userid_pkt_t *userid)
+transferable_key_has_userid(pgp_transferable_key_t &src, const pgp_userid_pkt_t &userid)
 {
-    for (auto &uid : src->userids) {
-        if (userid_pkt_equal(&uid.uid, userid)) {
+    for (auto &uid : src.userids) {
+        if (userid_pkt_equal(&uid.uid, &userid)) {
             return &uid;
         }
     }
@@ -227,24 +187,24 @@ transferable_key_has_subkey(pgp_transferable_key_t &src, const pgp_key_pkt_t &su
 }
 
 rnp_result_t
-transferable_key_merge(pgp_transferable_key_t *dst, const pgp_transferable_key_t *src)
+transferable_key_merge(pgp_transferable_key_t &dst, const pgp_transferable_key_t &src)
 {
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
-    if (!key_pkt_equal(&dst->key, &src->key, true)) {
+    if (!key_pkt_equal(&dst.key, &src.key, true)) {
         RNP_LOG("wrong key merge call");
         return RNP_ERROR_BAD_PARAMETERS;
     }
     /* direct-key signatures */
-    if ((ret = merge_signatures(&dst->signatures, &src->signatures))) {
+    if ((ret = merge_signatures(dst.signatures, src.signatures))) {
         RNP_LOG("failed to merge signatures");
         return ret;
     }
     /* userids */
-    for (auto &srcuid : src->userids) {
-        pgp_transferable_userid_t *dstuid = transferable_key_has_userid(dst, &srcuid.uid);
+    for (auto &srcuid : src.userids) {
+        pgp_transferable_userid_t *dstuid = transferable_key_has_userid(dst, srcuid.uid);
         if (dstuid) {
-            if ((ret = transferable_userid_merge(dstuid, &srcuid))) {
+            if ((ret = transferable_userid_merge(*dstuid, srcuid))) {
                 RNP_LOG("failed to merge userid");
                 return ret;
             }
@@ -252,7 +212,7 @@ transferable_key_merge(pgp_transferable_key_t *dst, const pgp_transferable_key_t
         }
         /* add userid */
         try {
-            dst->userids.emplace_back(srcuid);
+            dst.userids.emplace_back(srcuid);
         } catch (const std::exception &e) {
             RNP_LOG("%s", e.what());
             return RNP_ERROR_OUT_OF_MEMORY;
@@ -260,21 +220,21 @@ transferable_key_merge(pgp_transferable_key_t *dst, const pgp_transferable_key_t
     }
 
     /* subkeys */
-    for (auto &srcsub : src->subkeys) {
-        pgp_transferable_subkey_t *dstsub = transferable_key_has_subkey(*dst, srcsub.subkey);
+    for (auto &srcsub : src.subkeys) {
+        pgp_transferable_subkey_t *dstsub = transferable_key_has_subkey(dst, srcsub.subkey);
         if (dstsub) {
-            if ((ret = transferable_subkey_merge(dstsub, &srcsub))) {
+            if ((ret = transferable_subkey_merge(*dstsub, srcsub))) {
                 RNP_LOG("failed to merge subkey");
                 return ret;
             }
             continue;
         }
         /* add subkey */
-        if (is_public_key_pkt(dst->key.tag) != is_public_key_pkt(srcsub.subkey.tag)) {
+        if (is_public_key_pkt(dst.key.tag) != is_public_key_pkt(srcsub.subkey.tag)) {
             RNP_LOG("warning: adding public/secret subkey to secret/public key");
         }
         try {
-            dst->subkeys.emplace_back(srcsub);
+            dst.subkeys.emplace_back(srcsub);
         } catch (const std::exception &e) {
             RNP_LOG("%s", e.what());
             return RNP_ERROR_OUT_OF_MEMORY;
@@ -284,20 +244,20 @@ transferable_key_merge(pgp_transferable_key_t *dst, const pgp_transferable_key_t
 }
 
 pgp_transferable_userid_t *
-transferable_key_add_userid(pgp_transferable_key_t *key, const char *userid)
+transferable_key_add_userid(pgp_transferable_key_t &key, const char *userid)
 {
     try {
-        key->userids.emplace_back();
+        key.userids.emplace_back();
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
         return NULL;
     }
 
-    pgp_transferable_userid_t &uid = key->userids.back();
+    pgp_transferable_userid_t &uid = key.userids.back();
     uid.uid.tag = PGP_PKT_USER_ID;
     uid.uid.uid_len = strlen(userid);
     if (!(uid.uid.uid = (uint8_t *) malloc(uid.uid.uid_len))) {
-        key->userids.pop_back();
+        key.userids.pop_back();
         return NULL;
     }
     memcpy(uid.uid.uid, userid, uid.uid.uid_len);
@@ -353,34 +313,29 @@ signature_calculate_direct(const pgp_key_pkt_t *key,
 }
 
 pgp_signature_t *
-transferable_userid_certify(const pgp_key_pkt_t *          key,
-                            pgp_transferable_userid_t *    userid,
-                            const pgp_key_pkt_t *          signer,
+transferable_userid_certify(const pgp_key_pkt_t &          key,
+                            pgp_transferable_userid_t &    userid,
+                            const pgp_key_pkt_t &          signer,
                             pgp_hash_alg_t                 hash_alg,
-                            const rnp_selfsig_cert_info_t *cert)
+                            const rnp_selfsig_cert_info_t &cert)
 {
     pgp_signature_t   sig = {};
     pgp_key_id_t      keyid = {};
     pgp_fingerprint_t keyfp;
 
-    if (!key || !userid || !signer || !cert) {
-        RNP_LOG("invalid parameters");
-        return NULL;
-    }
-
-    if (pgp_keyid(keyid, signer)) {
+    if (pgp_keyid(keyid, &signer)) {
         RNP_LOG("failed to calculate keyid");
         return NULL;
     }
 
-    if (pgp_fingerprint(keyfp, signer)) {
+    if (pgp_fingerprint(keyfp, &signer)) {
         RNP_LOG("failed to calculate keyfp");
         return NULL;
     }
 
     sig.version = PGP_V4;
-    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, signer);
-    sig.palg = signer->alg;
+    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, &signer);
+    sig.palg = signer.alg;
     sig.type = PGP_CERT_POSITIVE;
 
     if (!signature_set_keyfp(&sig, keyfp)) {
@@ -391,19 +346,19 @@ transferable_userid_certify(const pgp_key_pkt_t *          key,
         RNP_LOG("failed to set creation time");
         return NULL;
     }
-    if (cert->key_expiration && !signature_set_key_expiration(&sig, cert->key_expiration)) {
+    if (cert.key_expiration && !signature_set_key_expiration(&sig, cert.key_expiration)) {
         RNP_LOG("failed to set key expiration time");
         return NULL;
     }
-    if (cert->key_flags && !signature_set_key_flags(&sig, cert->key_flags)) {
+    if (cert.key_flags && !signature_set_key_flags(&sig, cert.key_flags)) {
         RNP_LOG("failed to set key flags");
         return NULL;
     }
-    if (cert->primary && !signature_set_primary_uid(&sig, true)) {
+    if (cert.primary && !signature_set_primary_uid(&sig, true)) {
         RNP_LOG("failed to set primary userid");
         return NULL;
     }
-    const pgp_user_prefs_t *prefs = &cert->prefs;
+    const pgp_user_prefs_t *prefs = &cert.prefs;
     if (prefs->symm_alg_count &&
         !signature_set_preferred_symm_algs(
           &sig, (uint8_t *) prefs->symm_algs, prefs->symm_alg_count)) {
@@ -436,14 +391,17 @@ transferable_userid_certify(const pgp_key_pkt_t *          key,
         return NULL;
     }
 
-    if (!signature_calculate_certification(key, &userid->uid, &sig, signer)) {
+    if (!signature_calculate_certification(&key, &userid.uid, &sig, &signer)) {
         RNP_LOG("failed to calculate signature");
         return NULL;
     }
-    pgp_signature_t *res =
-      (pgp_signature_t *) list_append(&userid->signatures, NULL, sizeof(sig));
-    *res = std::move(sig);
-    return res;
+    try {
+        userid.signatures.emplace_back(std::move(sig));
+        return &userid.signatures.back();
+    } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
+        return NULL;
+    }
 }
 
 static bool
@@ -551,18 +509,13 @@ end:
 }
 
 pgp_signature_t *
-transferable_subkey_bind(const pgp_key_pkt_t *             key,
-                         pgp_transferable_subkey_t *       subkey,
+transferable_subkey_bind(const pgp_key_pkt_t &             key,
+                         pgp_transferable_subkey_t &       subkey,
                          pgp_hash_alg_t                    hash_alg,
-                         const rnp_selfsig_binding_info_t *binding)
+                         const rnp_selfsig_binding_info_t &binding)
 {
-    if (!key || !subkey || !binding) {
-        RNP_LOG("invalid parameters");
-        return NULL;
-    }
-
     pgp_fingerprint_t keyfp;
-    if (pgp_fingerprint(keyfp, key)) {
+    if (pgp_fingerprint(keyfp, &key)) {
         RNP_LOG("failed to calculate keyfp");
         return NULL;
     }
@@ -571,8 +524,8 @@ transferable_subkey_bind(const pgp_key_pkt_t *             key,
     pgp_key_flags_t realkf = (pgp_key_flags_t) 0;
 
     sig.version = PGP_V4;
-    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, key);
-    sig.palg = key->alg;
+    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, &key);
+    sig.palg = key.alg;
     sig.type = PGP_SIG_SUBKEY;
 
     if (!signature_set_keyfp(&sig, keyfp)) {
@@ -583,59 +536,57 @@ transferable_subkey_bind(const pgp_key_pkt_t *             key,
         RNP_LOG("failed to set creation time");
         return NULL;
     }
-    if (binding->key_expiration &&
-        !signature_set_key_expiration(&sig, binding->key_expiration)) {
+    if (binding.key_expiration &&
+        !signature_set_key_expiration(&sig, binding.key_expiration)) {
         RNP_LOG("failed to set key expiration time");
         return NULL;
     }
-    if (binding->key_flags && !signature_set_key_flags(&sig, binding->key_flags)) {
+    if (binding.key_flags && !signature_set_key_flags(&sig, binding.key_flags)) {
         RNP_LOG("failed to set key flags");
         return NULL;
     }
 
-    realkf = (pgp_key_flags_t) binding->key_flags;
+    realkf = (pgp_key_flags_t) binding.key_flags;
     if (!realkf) {
-        realkf = pgp_pk_alg_capabilities(subkey->subkey.alg);
+        realkf = pgp_pk_alg_capabilities(subkey.subkey.alg);
     }
 
-    if (!signature_calculate_binding(key, &subkey->subkey, &sig, realkf & PGP_KF_SIGN)) {
+    if (!signature_calculate_binding(&key, &subkey.subkey, &sig, realkf & PGP_KF_SIGN)) {
         return NULL;
     }
-
-    pgp_signature_t *res =
-      (pgp_signature_t *) list_append(&subkey->signatures, NULL, sizeof(sig));
-    *res = std::move(sig);
-    return res;
+    try {
+        subkey.signatures.emplace_back(std::move(sig));
+        return &subkey.signatures.back();
+    } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
+        return NULL;
+    }
 }
 
 pgp_signature_t *
-transferable_key_revoke(const pgp_key_pkt_t *key,
-                        const pgp_key_pkt_t *signer,
+transferable_key_revoke(const pgp_key_pkt_t &key,
+                        const pgp_key_pkt_t &signer,
                         pgp_hash_alg_t       hash_alg,
-                        const pgp_revoke_t * revoke)
+                        const pgp_revoke_t & revoke)
 {
     pgp_signature_t   sig;
     bool              res = false;
     pgp_key_id_t      keyid;
     pgp_fingerprint_t keyfp;
 
-    if (!key || !signer || !revoke) {
-        RNP_LOG("invalid parameters");
-        return NULL;
-    }
-    if (pgp_keyid(keyid, signer)) {
+    if (pgp_keyid(keyid, &signer)) {
         RNP_LOG("failed to calculate keyid");
         return NULL;
     }
-    if (pgp_fingerprint(keyfp, signer)) {
+    if (pgp_fingerprint(keyfp, &signer)) {
         RNP_LOG("failed to calculate keyfp");
         return NULL;
     }
 
     sig.version = PGP_V4;
-    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, signer);
-    sig.palg = signer->alg;
-    sig.type = is_primary_key_pkt(key->tag) ? PGP_SIG_REV_KEY : PGP_SIG_REV_SUBKEY;
+    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, &signer);
+    sig.palg = signer.alg;
+    sig.type = is_primary_key_pkt(key.tag) ? PGP_SIG_REV_KEY : PGP_SIG_REV_SUBKEY;
 
     if (!signature_set_keyfp(&sig, keyfp)) {
         RNP_LOG("failed to set issuer fingerprint");
@@ -645,7 +596,7 @@ transferable_key_revoke(const pgp_key_pkt_t *key,
         RNP_LOG("failed to set creation time");
         return NULL;
     }
-    if (!signature_set_revocation_reason(&sig, revoke->code, revoke->reason.c_str())) {
+    if (!signature_set_revocation_reason(&sig, revoke.code, revoke.reason.c_str())) {
         RNP_LOG("failed to set revocation reason");
         return NULL;
     }
@@ -654,10 +605,10 @@ transferable_key_revoke(const pgp_key_pkt_t *key,
         return NULL;
     }
 
-    if (is_primary_key_pkt(key->tag)) {
-        res = signature_calculate_direct(key, &sig, signer);
+    if (is_primary_key_pkt(key.tag)) {
+        res = signature_calculate_direct(&key, &sig, &signer);
     } else {
-        res = signature_calculate_binding(signer, key, &sig, false);
+        res = signature_calculate_binding(&signer, &key, &sig, false);
     }
     if (!res) {
         RNP_LOG("failed to calculate signature");
@@ -694,49 +645,46 @@ skip_pgp_packets(pgp_source_t *src, const std::set<pgp_pkt_type_t> &pkts)
 }
 
 static rnp_result_t
-process_pgp_key_signatures(pgp_source_t *src, list *sigs, bool skiperrors)
+process_pgp_key_signatures(pgp_source_t *src, pgp_signature_list_t &sigs, bool skiperrors)
 {
-    int          ptag;
-    rnp_result_t ret = RNP_ERROR_BAD_FORMAT;
-
+    int ptag;
     while ((ptag = stream_pkt_type(src)) == PGP_PKT_SIGNATURE) {
-        pgp_signature_t *sig = (pgp_signature_t *) list_append(sigs, NULL, sizeof(*sig));
-        if (!sig) {
-            RNP_LOG("sig alloc failed");
-            return RNP_ERROR_OUT_OF_MEMORY;
-        }
-
-        uint64_t sigpos = src->readb;
-        if ((ret = stream_parse_signature(src, sig))) {
+        pgp_signature_t sig = {};
+        uint64_t        sigpos = src->readb;
+        rnp_result_t    ret = stream_parse_signature(src, &sig);
+        if (ret) {
             RNP_LOG("failed to parse signature at %" PRIu64, sigpos);
-            sig->~pgp_signature_t();
-            list_remove((list_item *) sig);
             if (!skiperrors) {
                 return ret;
             }
+        } else {
+            try {
+                sigs.emplace_back(std::move(sig));
+            } catch (const std::exception &e) {
+                RNP_LOG("%s", e.what());
+                return RNP_ERROR_OUT_OF_MEMORY;
+            }
         }
-
         if (!skip_pgp_packets(src, {PGP_PKT_TRUST})) {
             return RNP_ERROR_READ;
         }
     }
-
     return ptag < 0 ? RNP_ERROR_BAD_FORMAT : RNP_SUCCESS;
 }
 
 static rnp_result_t
-process_pgp_userid(pgp_source_t *src, pgp_transferable_userid_t *uid, bool skiperrors)
+process_pgp_userid(pgp_source_t *src, pgp_transferable_userid_t &uid, bool skiperrors)
 {
     rnp_result_t ret;
     uint64_t     uidpos = src->readb;
-    if ((ret = stream_parse_userid(src, &uid->uid))) {
+    if ((ret = stream_parse_userid(src, &uid.uid))) {
         RNP_LOG("failed to parse userid at %" PRIu64, uidpos);
         return ret;
     }
     if (!skip_pgp_packets(src, {PGP_PKT_TRUST})) {
         return RNP_ERROR_READ;
     }
-    return process_pgp_key_signatures(src, &uid->signatures, skiperrors);
+    return process_pgp_key_signatures(src, uid.signatures, skiperrors);
 }
 
 rnp_result_t
@@ -762,7 +710,7 @@ process_pgp_subkey(pgp_source_t &src, pgp_transferable_subkey_t &subkey, bool sk
         goto done;
     }
 
-    ret = process_pgp_key_signatures(&src, &subkey.signatures, skiperrors);
+    ret = process_pgp_key_signatures(&src, subkey.signatures, skiperrors);
 done:
     return ret;
 }
@@ -887,7 +835,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t &key, bool skiperrors)
     }
 
     /* direct-key signatures */
-    if ((ret = process_pgp_key_signatures(src, &key.signatures, skiperrors))) {
+    if ((ret = process_pgp_key_signatures(src, key.signatures, skiperrors))) {
         goto finish;
     }
 
@@ -904,7 +852,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t &key, bool skiperrors)
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto finish;
         }
-        ret = process_pgp_userid(src, &key.userids.back(), skiperrors);
+        ret = process_pgp_userid(src, key.userids.back(), skiperrors);
         if ((ret == RNP_ERROR_BAD_FORMAT) && skiperrors &&
             skip_pgp_packets(src, {PGP_PKT_TRUST, PGP_PKT_SIGNATURE})) {
             key.userids.pop_back();
@@ -948,14 +896,13 @@ finish:
 }
 
 static bool
-write_pgp_signatures(list signatures, pgp_dest_t *dst)
+write_pgp_signatures(pgp_signature_list_t &signatures, pgp_dest_t *dst)
 {
-    for (list_item *sig = list_front(signatures); sig; sig = list_next(sig)) {
-        if (!stream_write_signature((pgp_signature_t *) sig, dst)) {
+    for (auto &sig : signatures) {
+        if (!stream_write_signature(&sig, dst)) {
             return false;
         }
     }
-
     return true;
 }
 
@@ -1014,7 +961,7 @@ finish:
 }
 
 rnp_result_t
-write_pgp_key(pgp_transferable_key_t *key, pgp_dest_t *dst, bool armor)
+write_pgp_key(pgp_transferable_key_t &key, pgp_dest_t *dst, bool armor)
 {
     pgp_key_sequence_t keys;
 
@@ -1026,7 +973,7 @@ write_pgp_key(pgp_transferable_key_t *key, pgp_dest_t *dst, bool armor)
     }
     /* temporary solution to not implement copy constructor */
     pgp_transferable_key_t &front = keys.keys.front();
-    memcpy(&front, key, sizeof(*key));
+    memcpy(&front, &key, sizeof(key));
     rnp_result_t res = write_pgp_keys(keys, dst, armor);
     memset(&front, 0, sizeof(front));
     return res;
@@ -1459,10 +1406,7 @@ pgp_transferable_userid_t::pgp_transferable_userid_t(const pgp_transferable_user
     if (!copy_userid_pkt(&uid, &src.uid)) {
         throw std::bad_alloc();
     }
-    signatures = NULL;
-    if (!copy_signatures(&signatures, &src.signatures)) {
-        throw std::bad_alloc();
-    }
+    signatures = src.signatures;
 }
 
 pgp_transferable_userid_t &
@@ -1475,34 +1419,26 @@ pgp_transferable_userid_t::operator=(const pgp_transferable_userid_t &src)
     if (!copy_userid_pkt(&uid, &src.uid)) {
         throw std::bad_alloc();
     }
-    signature_list_destroy(&signatures);
-    if (!copy_signatures(&signatures, &src.signatures)) {
-        throw std::bad_alloc();
-    }
+    signatures = src.signatures;
     return *this;
 }
 
 pgp_transferable_userid_t::~pgp_transferable_userid_t()
 {
     free_userid_pkt(&uid);
-    signature_list_destroy(&signatures);
 }
 
 pgp_transferable_subkey_t::pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src)
 {
     copy_key_pkt(&subkey, &src.subkey, false);
-    signatures = NULL;
-    if (!copy_signatures(&signatures, &src.signatures)) {
-        throw std::bad_alloc();
-    }
+    signatures = src.signatures;
 }
 
 pgp_transferable_subkey_t::pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src)
 {
     subkey = src.subkey;
     src.subkey = {};
-    signatures = src.signatures;
-    src.signatures = NULL;
+    signatures = std::move(src.signatures);
 }
 
 pgp_transferable_subkey_t &
@@ -1513,10 +1449,7 @@ pgp_transferable_subkey_t::operator=(const pgp_transferable_subkey_t &src)
     }
     free_key_pkt(&subkey);
     copy_key_pkt(&subkey, &src.subkey, false);
-    signature_list_destroy(&signatures);
-    if (!copy_signatures(&signatures, &src.signatures)) {
-        throw std::bad_alloc();
-    }
+    signatures = src.signatures;
     return *this;
 }
 
@@ -1529,9 +1462,7 @@ pgp_transferable_subkey_t::operator=(pgp_transferable_subkey_t &&src)
     free_key_pkt(&subkey);
     subkey = src.subkey;
     src.subkey = {};
-    signature_list_destroy(&signatures);
-    signatures = src.signatures;
-    src.signatures = NULL;
+    signatures = std::move(src.signatures);
     return *this;
 }
 
@@ -1539,7 +1470,6 @@ pgp_transferable_subkey_t::~pgp_transferable_subkey_t()
 {
     forget_secret_key_fields(&subkey.material);
     free_key_pkt(&subkey);
-    signature_list_destroy(&signatures);
 }
 
 pgp_transferable_key_t::pgp_transferable_key_t(pgp_transferable_key_t &&src)
@@ -1548,8 +1478,7 @@ pgp_transferable_key_t::pgp_transferable_key_t(pgp_transferable_key_t &&src)
     src.key = {};
     userids = std::move(src.userids);
     subkeys = std::move(src.subkeys);
-    signatures = src.signatures;
-    src.signatures = NULL;
+    signatures = std::move(src.signatures);
 }
 
 pgp_transferable_key_t &
@@ -1565,10 +1494,7 @@ pgp_transferable_key_t::operator=(pgp_transferable_key_t &&src)
 
     userids = std::move(src.userids);
     subkeys = std::move(src.subkeys);
-
-    signature_list_destroy(&signatures);
-    signatures = src.signatures;
-    src.signatures = NULL;
+    signatures = std::move(src.signatures);
     return *this;
 }
 
@@ -1576,5 +1502,4 @@ pgp_transferable_key_t::~pgp_transferable_key_t()
 {
     forget_secret_key_fields(&key.material);
     free_key_pkt(&key);
-    signature_list_destroy(&signatures);
 }

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -47,14 +47,6 @@
 #include <set>
 
 void
-transferable_subkey_destroy(pgp_transferable_subkey_t *subkey)
-{
-    forget_secret_key_fields(&subkey->subkey.material);
-    free_key_pkt(&subkey->subkey);
-    signature_list_destroy(&subkey->signatures);
-}
-
-void
 transferable_userid_destroy(pgp_transferable_userid_t *userid)
 {
     free_userid_pkt(&userid->uid);
@@ -151,21 +143,16 @@ transferable_subkey_copy(pgp_transferable_subkey_t *      dst,
                          const pgp_transferable_subkey_t *src,
                          bool                             pubonly)
 {
-    memset(dst, 0, sizeof(*dst));
-
     if (!copy_key_pkt(&dst->subkey, &src->subkey, pubonly)) {
         RNP_LOG("failed to copy subkey pkt");
-        goto error;
+        return false;
     }
 
     if (!copy_signatures(&dst->signatures, &src->signatures)) {
         RNP_LOG("failed to copy subkey signatures");
-        goto error;
+        return false;
     }
     return true;
-error:
-    transferable_subkey_destroy(dst);
-    return false;
 }
 
 rnp_result_t
@@ -178,7 +165,7 @@ transferable_subkey_from_key(pgp_transferable_subkey_t *dst, const pgp_key_t *ke
         return RNP_ERROR_BAD_STATE;
     }
 
-    ret = process_pgp_subkey(&memsrc, dst, false);
+    ret = process_pgp_subkey(memsrc, *dst, false);
     src_close(&memsrc);
     return ret;
 }
@@ -204,11 +191,9 @@ transferable_key_copy(pgp_transferable_key_t *      dst,
                       const pgp_transferable_key_t *src,
                       bool                          pubonly)
 {
-    memset(dst, 0, sizeof(*dst));
-
     if (!copy_key_pkt(&dst->key, &src->key, pubonly)) {
         RNP_LOG("failed to copy key pkt");
-        goto error;
+        return false;
     }
 
     for (list_item *uid = list_front(src->userids); uid; uid = list_next(uid)) {
@@ -216,7 +201,7 @@ transferable_key_copy(pgp_transferable_key_t *      dst,
           (pgp_transferable_userid_t *) list_append(&dst->userids, NULL, sizeof(*tuid));
         if (!tuid || !transferable_userid_copy(tuid, (pgp_transferable_userid_t *) uid)) {
             RNP_LOG("failed to copy uid");
-            goto error;
+            return false;
         }
     }
 
@@ -226,18 +211,15 @@ transferable_key_copy(pgp_transferable_key_t *      dst,
         if (!tskey ||
             !transferable_subkey_copy(tskey, (pgp_transferable_subkey_t *) skey, pubonly)) {
             RNP_LOG("failed to copy subkey");
-            goto error;
+            return false;
         }
     }
 
     if (!copy_signatures(&dst->signatures, &src->signatures)) {
         RNP_LOG("failed to copy key signatures");
-        goto error;
+        return false;
     }
     return true;
-error:
-    transferable_key_destroy(dst);
-    return false;
 }
 
 rnp_result_t
@@ -250,7 +232,7 @@ transferable_key_from_key(pgp_transferable_key_t *dst, const pgp_key_t *key)
         return RNP_ERROR_BAD_STATE;
     }
 
-    ret = process_pgp_key(&memsrc, dst, false);
+    ret = process_pgp_key(&memsrc, *dst, false);
     src_close(&memsrc);
     return ret;
 }
@@ -732,34 +714,6 @@ transferable_key_revoke(const pgp_key_pkt_t *key,
     }
 }
 
-void
-transferable_key_destroy(pgp_transferable_key_t *key)
-{
-    forget_secret_key_fields(&key->key.material);
-
-    for (list_item *li = list_front(key->userids); li; li = list_next(li)) {
-        transferable_userid_destroy((pgp_transferable_userid_t *) li);
-    }
-    list_destroy(&key->userids);
-
-    for (list_item *li = list_front(key->subkeys); li; li = list_next(li)) {
-        transferable_subkey_destroy((pgp_transferable_subkey_t *) li);
-    }
-    list_destroy(&key->subkeys);
-
-    signature_list_destroy(&key->signatures);
-    free_key_pkt(&key->key);
-}
-
-void
-key_sequence_destroy(pgp_key_sequence_t *keys)
-{
-    for (list_item *li = list_front(keys->keys); li; li = list_next(li)) {
-        transferable_key_destroy((pgp_transferable_key_t *) li);
-    }
-    list_destroy(&keys->keys);
-}
-
 static bool
 skip_pgp_packets(pgp_source_t *src, const std::set<pgp_pkt_type_t> &pkts)
 {
@@ -842,39 +796,35 @@ done:
 }
 
 rnp_result_t
-process_pgp_subkey(pgp_source_t *src, pgp_transferable_subkey_t *subkey, bool skiperrors)
+process_pgp_subkey(pgp_source_t &src, pgp_transferable_subkey_t &subkey, bool skiperrors)
 {
     int          ptag;
     rnp_result_t ret = RNP_ERROR_BAD_FORMAT;
 
-    memset(subkey, 0, sizeof(*subkey));
-    uint64_t keypos = src->readb;
-    if (!is_subkey_pkt(ptag = stream_pkt_type(src))) {
+    subkey = {};
+    uint64_t keypos = src.readb;
+    if (!is_subkey_pkt(ptag = stream_pkt_type(&src))) {
         RNP_LOG("wrong subkey ptag: %d at %" PRIu64, ptag, keypos);
         return RNP_ERROR_BAD_FORMAT;
     }
 
-    if ((ret = stream_parse_key(src, &subkey->subkey))) {
+    if ((ret = stream_parse_key(&src, &subkey.subkey))) {
         RNP_LOG("failed to parse subkey at %" PRIu64, keypos);
         goto done;
     }
 
-    if (!skip_pgp_packets(src, {PGP_PKT_TRUST})) {
+    if (!skip_pgp_packets(&src, {PGP_PKT_TRUST})) {
         ret = RNP_ERROR_READ;
         goto done;
     }
 
-    ret = process_pgp_key_signatures(src, &subkey->signatures, skiperrors);
+    ret = process_pgp_key_signatures(&src, &subkey.signatures, skiperrors);
 done:
-    if (ret) {
-        transferable_subkey_destroy(subkey);
-        memset(subkey, 0, sizeof(*subkey));
-    }
     return ret;
 }
 
 rnp_result_t
-process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t *keys, bool skiperrors)
+process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t &keys, bool skiperrors)
 {
     int                     ptag;
     bool                    armored = false;
@@ -885,8 +835,7 @@ process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t *keys, bool skiperrors)
     pgp_transferable_key_t *curkey = NULL;
     rnp_result_t            ret = RNP_ERROR_GENERIC;
 
-    memset(keys, 0, sizeof(*keys));
-
+    keys = {};
     /* check whether keys are armored */
 armoredpass:
     if (is_armored_source(src)) {
@@ -908,13 +857,17 @@ armoredpass:
         }
 
         if (!(curkey =
-                (pgp_transferable_key_t *) list_append(&keys->keys, NULL, sizeof(*curkey)))) {
+                (pgp_transferable_key_t *) list_append(&keys.keys, NULL, sizeof(*curkey)))) {
             RNP_LOG("key alloc failed");
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto finish;
         }
 
-        ret = process_pgp_key(src, curkey, skiperrors);
+        ret = process_pgp_key(src, *curkey, skiperrors);
+        if (ret) {
+            curkey->~pgp_transferable_key_t();
+            list_remove((list_item *) curkey);
+        }
         if ((ret == RNP_ERROR_BAD_FORMAT) && skiperrors &&
             skip_pgp_packets(src,
                              {PGP_PKT_TRUST,
@@ -923,7 +876,6 @@ armoredpass:
                               PGP_PKT_USER_ATTR,
                               PGP_PKT_PUBLIC_SUBKEY,
                               PGP_PKT_SECRET_SUBKEY})) {
-            list_remove((list_item *) curkey);
             continue;
         }
         if (ret) {
@@ -952,21 +904,20 @@ finish:
         src_close(&armorsrc);
     }
     if (ret) {
-        key_sequence_destroy(keys);
+        keys = {};
     }
     return ret;
 }
 
 rnp_result_t
-process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors)
+process_pgp_key(pgp_source_t *src, pgp_transferable_key_t &key, bool skiperrors)
 {
     pgp_source_t armorsrc = {0};
     bool         armored = false;
     int          ptag;
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
-    memset(key, 0, sizeof(*key));
-
+    key = {};
     /* check whether keys are armored */
     if (is_armored_source(src)) {
         if ((ret = init_armored_src(&armorsrc, src))) {
@@ -986,7 +937,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors)
         goto finish;
     }
 
-    if ((ret = stream_parse_key(src, &key->key))) {
+    if ((ret = stream_parse_key(src, &key.key))) {
         RNP_LOG("failed to parse key pkt at %" PRIu64, keypos);
         goto finish;
     }
@@ -997,7 +948,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors)
     }
 
     /* direct-key signatures */
-    if ((ret = process_pgp_key_signatures(src, &key->signatures, skiperrors))) {
+    if ((ret = process_pgp_key_signatures(src, &key.signatures, skiperrors))) {
         goto finish;
     }
 
@@ -1008,7 +959,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors)
         }
 
         pgp_transferable_userid_t *uid =
-          (pgp_transferable_userid_t *) list_append(&key->userids, NULL, sizeof(*uid));
+          (pgp_transferable_userid_t *) list_append(&key.userids, NULL, sizeof(*uid));
         if (!uid) {
             RNP_LOG("uid alloc failed");
             ret = RNP_ERROR_OUT_OF_MEMORY;
@@ -1033,16 +984,17 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors)
         }
 
         pgp_transferable_subkey_t *subkey =
-          (pgp_transferable_subkey_t *) list_append(&key->subkeys, NULL, sizeof(*subkey));
+          (pgp_transferable_subkey_t *) list_append(&key.subkeys, NULL, sizeof(*subkey));
         if (!subkey) {
             RNP_LOG("subkey alloc failed");
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto finish;
         }
 
-        ret = process_pgp_subkey(src, subkey, skiperrors);
+        ret = process_pgp_subkey(*src, *subkey, skiperrors);
         if ((ret == RNP_ERROR_BAD_FORMAT) && skiperrors &&
             skip_pgp_packets(src, {PGP_PKT_TRUST, PGP_PKT_SIGNATURE})) {
+            subkey->~pgp_transferable_subkey_t();
             list_remove((list_item *) subkey);
             /* skip malformed subkey */
             continue;
@@ -1056,9 +1008,6 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors)
 finish:
     if (armored) {
         src_close(&armorsrc);
-    }
-    if (ret) {
-        transferable_key_destroy(key);
     }
     return ret;
 }
@@ -1142,7 +1091,7 @@ finish:
 rnp_result_t
 write_pgp_key(pgp_transferable_key_t *key, pgp_dest_t *dst, bool armor)
 {
-    pgp_key_sequence_t keys = {0};
+    pgp_key_sequence_t keys = {};
     rnp_result_t       ret = RNP_ERROR_GENERIC;
 
     if (!list_append(&keys.keys, key, sizeof(*key))) {
@@ -1574,4 +1523,97 @@ forget_secret_key_fields(pgp_key_material_t *key)
     }
 
     key->secret = false;
+}
+
+pgp_transferable_subkey_t &
+pgp_transferable_subkey_t::operator=(pgp_transferable_subkey_t &&src)
+{
+    if (this == &src) {
+        return *this;
+    }
+    free_key_pkt(&subkey);
+    subkey = src.subkey;
+    src.subkey = {};
+    signature_list_destroy(&signatures);
+    signatures = src.signatures;
+    src.signatures = NULL;
+    return *this;
+}
+
+pgp_transferable_subkey_t::~pgp_transferable_subkey_t()
+{
+    forget_secret_key_fields(&subkey.material);
+    free_key_pkt(&subkey);
+    signature_list_destroy(&signatures);
+}
+
+pgp_transferable_key_t &
+pgp_transferable_key_t::operator=(pgp_transferable_key_t &&src)
+{
+    if (this == &src) {
+        return *this;
+    }
+    forget_secret_key_fields(&key.material);
+    free_key_pkt(&key);
+    key = src.key;
+    src.key = {};
+
+    for (list_item *li = list_front(userids); li; li = list_next(li)) {
+        transferable_userid_destroy((pgp_transferable_userid_t *) li);
+    }
+    list_destroy(&userids);
+    userids = src.userids;
+    src.userids = NULL;
+
+    for (list_item *li = list_front(subkeys); li; li = list_next(li)) {
+        ((pgp_transferable_subkey_t *) li)->~pgp_transferable_subkey_t();
+    }
+    list_destroy(&subkeys);
+    subkeys = src.subkeys;
+    src.subkeys = NULL;
+
+    signature_list_destroy(&signatures);
+    signatures = src.signatures;
+    src.signatures = NULL;
+    return *this;
+}
+
+pgp_transferable_key_t::~pgp_transferable_key_t()
+{
+    forget_secret_key_fields(&key.material);
+    free_key_pkt(&key);
+
+    for (list_item *li = list_front(userids); li; li = list_next(li)) {
+        transferable_userid_destroy((pgp_transferable_userid_t *) li);
+    }
+    list_destroy(&userids);
+
+    for (list_item *li = list_front(subkeys); li; li = list_next(li)) {
+        ((pgp_transferable_subkey_t *) li)->~pgp_transferable_subkey_t();
+    }
+    list_destroy(&subkeys);
+    signature_list_destroy(&signatures);
+}
+
+pgp_key_sequence_t &
+pgp_key_sequence_t::operator=(pgp_key_sequence_t &&src)
+{
+    if (this == &src) {
+        return *this;
+    }
+    for (list_item *li = list_front(keys); li; li = list_next(li)) {
+        ((pgp_transferable_key_t *) li)->~pgp_transferable_key_t();
+    }
+    list_destroy(&keys);
+    keys = src.keys;
+    src.keys = NULL;
+    return *this;
+}
+
+pgp_key_sequence_t::~pgp_key_sequence_t()
+{
+    for (list_item *li = list_front(keys); li; li = list_next(li)) {
+        ((pgp_transferable_key_t *) li)->~pgp_transferable_key_t();
+    }
+    list_destroy(&keys);
 }

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -66,8 +66,14 @@ copy_signatures(list *dst, const list *src)
 {
     for (list_item *sig = list_front(*src); sig; sig = list_next(sig)) {
         pgp_signature_t *newsig = (pgp_signature_t *) list_append(dst, NULL, sizeof(*newsig));
-        if (!newsig || !copy_signature_packet(newsig, (pgp_signature_t *) sig)) {
+        if (!newsig) {
             signature_list_destroy(dst);
+            return false;
+        }
+        try {
+            *newsig = *((pgp_signature_t *) sig);
+        } catch (const std::exception &e) {
+            RNP_LOG("%s", e.what());
             return false;
         }
     }
@@ -103,7 +109,10 @@ merge_signatures(list *dst, const list *src)
         if (!newsig) {
             return RNP_ERROR_OUT_OF_MEMORY;
         }
-        if (!copy_signature_packet(newsig, (pgp_signature_t *) sig)) {
+        try {
+            *newsig = *((pgp_signature_t *) sig);
+        } catch (const std::exception &e) {
+            RNP_LOG("%s", e.what());
             list_remove((list_item *) newsig);
             return RNP_ERROR_OUT_OF_MEMORY;
         }
@@ -410,11 +419,9 @@ transferable_userid_certify(const pgp_key_pkt_t *          key,
                             pgp_hash_alg_t                 hash_alg,
                             const rnp_selfsig_cert_info_t *cert)
 {
-    pgp_signature_t         sig = {};
-    pgp_signature_t *       res = NULL;
-    pgp_key_id_t            keyid = {};
-    pgp_fingerprint_t       keyfp;
-    const pgp_user_prefs_t *prefs = NULL;
+    pgp_signature_t   sig = {};
+    pgp_key_id_t      keyid = {};
+    pgp_fingerprint_t keyfp;
 
     if (!key || !userid || !signer || !cert) {
         RNP_LOG("invalid parameters");
@@ -423,12 +430,12 @@ transferable_userid_certify(const pgp_key_pkt_t *          key,
 
     if (pgp_keyid(keyid, signer)) {
         RNP_LOG("failed to calculate keyid");
-        goto end;
+        return NULL;
     }
 
     if (pgp_fingerprint(keyfp, signer)) {
         RNP_LOG("failed to calculate keyfp");
-        goto end;
+        return NULL;
     }
 
     sig.version = PGP_V4;
@@ -438,66 +445,64 @@ transferable_userid_certify(const pgp_key_pkt_t *          key,
 
     if (!signature_set_keyfp(&sig, keyfp)) {
         RNP_LOG("failed to set issuer fingerprint");
-        goto end;
+        return NULL;
     }
     if (!signature_set_creation(&sig, time(NULL))) {
         RNP_LOG("failed to set creation time");
-        goto end;
+        return NULL;
     }
     if (cert->key_expiration && !signature_set_key_expiration(&sig, cert->key_expiration)) {
         RNP_LOG("failed to set key expiration time");
-        goto end;
+        return NULL;
     }
     if (cert->key_flags && !signature_set_key_flags(&sig, cert->key_flags)) {
         RNP_LOG("failed to set key flags");
-        goto end;
+        return NULL;
     }
     if (cert->primary && !signature_set_primary_uid(&sig, true)) {
         RNP_LOG("failed to set primary userid");
-        goto end;
+        return NULL;
     }
-    prefs = &cert->prefs;
+    const pgp_user_prefs_t *prefs = &cert->prefs;
     if (prefs->symm_alg_count &&
         !signature_set_preferred_symm_algs(
           &sig, (uint8_t *) prefs->symm_algs, prefs->symm_alg_count)) {
         RNP_LOG("failed to set symm alg prefs");
-        goto end;
+        return NULL;
     }
     if (prefs->hash_alg_count &&
         !signature_set_preferred_hash_algs(
           &sig, (uint8_t *) prefs->hash_algs, prefs->hash_alg_count)) {
         RNP_LOG("failed to set hash alg prefs");
-        goto end;
+        return NULL;
     }
     if (prefs->z_alg_count &&
         !signature_set_preferred_z_algs(&sig, (uint8_t *) prefs->z_algs, prefs->z_alg_count)) {
         RNP_LOG("failed to set compress alg prefs");
-        goto end;
+        return NULL;
     }
     if (prefs->ks_pref_count &&
         !signature_set_key_server_prefs(&sig, (uint8_t) prefs->ks_prefs[0])) {
         RNP_LOG("failed to set key server prefs");
-        goto end;
+        return NULL;
     }
     if (prefs->key_server &&
         !signature_set_preferred_key_server(&sig, (char *) prefs->key_server)) {
         RNP_LOG("failed to set preferred key server");
-        goto end;
+        return NULL;
     }
     if (!signature_set_keyid(&sig, keyid)) {
         RNP_LOG("failed to set issuer key id");
-        goto end;
+        return NULL;
     }
 
     if (!signature_calculate_certification(key, &userid->uid, &sig, signer)) {
         RNP_LOG("failed to calculate signature");
-        goto end;
+        return NULL;
     }
-    res = (pgp_signature_t *) list_append(&userid->signatures, &sig, sizeof(sig));
-end:
-    if (!res) {
-        free_signature(&sig);
-    }
+    pgp_signature_t *res =
+      (pgp_signature_t *) list_append(&userid->signatures, NULL, sizeof(sig));
+    *res = std::move(sig);
     return res;
 }
 
@@ -512,7 +517,6 @@ signature_calculate_primary_binding(const pgp_key_pkt_t *key,
     pgp_hash_t   hash = {};
     bool         res = false;
 
-    memset(sig, 0, sizeof(*sig));
     sig->version = PGP_V4;
     sig->halg = pgp_hash_adjust_alg_to_key(halg, subkey);
     sig->palg = subkey->alg;
@@ -520,15 +524,15 @@ signature_calculate_primary_binding(const pgp_key_pkt_t *key,
 
     if (pgp_keyid(keyid, subkey)) {
         RNP_LOG("failed to calculate keyid");
-        goto end;
+        return false;
     }
     if (!signature_set_creation(sig, time(NULL))) {
         RNP_LOG("failed to set embedded sig creation time");
-        goto end;
+        return false;
     }
     if (!signature_set_keyid(sig, keyid)) {
         RNP_LOG("failed to set issuer key id");
-        goto end;
+        return false;
     }
     if (!signature_hash_binding(sig, key, subkey, &hash)) {
         RNP_LOG("failed to hash key and subkey");
@@ -545,7 +549,6 @@ signature_calculate_primary_binding(const pgp_key_pkt_t *key,
     res = true;
 end:
     if (!res) {
-        free_signature(sig);
         pgp_hash_finish(&hash, NULL);
     }
     return res;
@@ -585,15 +588,12 @@ signature_calculate_binding(const pgp_key_pkt_t *key,
     /* unhashed subpackets. Primary key binding signature and issuer key id */
     if (subsign) {
         pgp_signature_t embsig = {};
-        bool            embres;
 
         if (!signature_calculate_primary_binding(key, sub, sig->halg, &embsig, &rng)) {
             RNP_LOG("failed to calculate primary key binding signature");
             goto end;
         }
-        embres = signature_set_embedded_sig(sig, &embsig);
-        free_signature(&embsig);
-        if (!embres) {
+        if (!signature_set_embedded_sig(sig, &embsig)) {
             RNP_LOG("failed to add primary key binding signature");
             goto end;
         }
@@ -604,7 +604,6 @@ signature_calculate_binding(const pgp_key_pkt_t *key,
         RNP_LOG("failed to set issuer key id");
         goto end;
     }
-
     res = true;
 end:
     rng_destroy(&rng);
@@ -628,9 +627,8 @@ transferable_subkey_bind(const pgp_key_pkt_t *             key,
         return NULL;
     }
 
-    pgp_signature_t  sig = {};
-    pgp_signature_t *res = NULL;
-    pgp_key_flags_t  realkf = (pgp_key_flags_t) 0;
+    pgp_signature_t sig = {};
+    pgp_key_flags_t realkf = (pgp_key_flags_t) 0;
 
     sig.version = PGP_V4;
     sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, key);
@@ -639,20 +637,20 @@ transferable_subkey_bind(const pgp_key_pkt_t *             key,
 
     if (!signature_set_keyfp(&sig, keyfp)) {
         RNP_LOG("failed to set issuer fingerprint");
-        goto end;
+        return NULL;
     }
     if (!signature_set_creation(&sig, time(NULL))) {
         RNP_LOG("failed to set creation time");
-        goto end;
+        return NULL;
     }
     if (binding->key_expiration &&
         !signature_set_key_expiration(&sig, binding->key_expiration)) {
         RNP_LOG("failed to set key expiration time");
-        goto end;
+        return NULL;
     }
     if (binding->key_flags && !signature_set_key_flags(&sig, binding->key_flags)) {
         RNP_LOG("failed to set key flags");
-        goto end;
+        return NULL;
     }
 
     realkf = (pgp_key_flags_t) binding->key_flags;
@@ -661,14 +659,12 @@ transferable_subkey_bind(const pgp_key_pkt_t *             key,
     }
 
     if (!signature_calculate_binding(key, &subkey->subkey, &sig, realkf & PGP_KF_SIGN)) {
-        goto end;
+        return NULL;
     }
 
-    res = (pgp_signature_t *) list_append(&subkey->signatures, &sig, sizeof(sig));
-end:
-    if (!res) {
-        free_signature(&sig);
-    }
+    pgp_signature_t *res =
+      (pgp_signature_t *) list_append(&subkey->signatures, NULL, sizeof(sig));
+    *res = std::move(sig);
     return res;
 }
 
@@ -678,7 +674,7 @@ transferable_key_revoke(const pgp_key_pkt_t *key,
                         pgp_hash_alg_t       hash_alg,
                         const pgp_revoke_t * revoke)
 {
-    pgp_signature_t * sig = NULL;
+    pgp_signature_t   sig;
     bool              res = false;
     pgp_key_id_t      keyid;
     pgp_fingerprint_t keyfp;
@@ -687,57 +683,53 @@ transferable_key_revoke(const pgp_key_pkt_t *key,
         RNP_LOG("invalid parameters");
         return NULL;
     }
-    sig = (pgp_signature_t *) calloc(1, sizeof(*sig));
-    if (!sig) {
-        RNP_LOG("allocation failed");
-        goto end;
-    }
     if (pgp_keyid(keyid, signer)) {
         RNP_LOG("failed to calculate keyid");
-        goto end;
+        return NULL;
     }
     if (pgp_fingerprint(keyfp, signer)) {
         RNP_LOG("failed to calculate keyfp");
-        goto end;
+        return NULL;
     }
 
-    sig->version = PGP_V4;
-    sig->halg = pgp_hash_adjust_alg_to_key(hash_alg, signer);
-    sig->palg = signer->alg;
-    sig->type = is_primary_key_pkt(key->tag) ? PGP_SIG_REV_KEY : PGP_SIG_REV_SUBKEY;
+    sig.version = PGP_V4;
+    sig.halg = pgp_hash_adjust_alg_to_key(hash_alg, signer);
+    sig.palg = signer->alg;
+    sig.type = is_primary_key_pkt(key->tag) ? PGP_SIG_REV_KEY : PGP_SIG_REV_SUBKEY;
 
-    if (!signature_set_keyfp(sig, keyfp)) {
+    if (!signature_set_keyfp(&sig, keyfp)) {
         RNP_LOG("failed to set issuer fingerprint");
-        goto end;
+        return NULL;
     }
-    if (!signature_set_creation(sig, time(NULL))) {
+    if (!signature_set_creation(&sig, time(NULL))) {
         RNP_LOG("failed to set creation time");
-        goto end;
+        return NULL;
     }
-    if (!signature_set_revocation_reason(sig, revoke->code, revoke->reason.c_str())) {
+    if (!signature_set_revocation_reason(&sig, revoke->code, revoke->reason.c_str())) {
         RNP_LOG("failed to set revocation reason");
-        goto end;
+        return NULL;
     }
-    if (!signature_set_keyid(sig, keyid)) {
+    if (!signature_set_keyid(&sig, keyid)) {
         RNP_LOG("failed to set issuer key id");
-        goto end;
+        return NULL;
     }
 
     if (is_primary_key_pkt(key->tag)) {
-        res = signature_calculate_direct(key, sig, signer);
+        res = signature_calculate_direct(key, &sig, signer);
     } else {
-        res = signature_calculate_binding(signer, key, sig, false);
+        res = signature_calculate_binding(signer, key, &sig, false);
     }
     if (!res) {
         RNP_LOG("failed to calculate signature");
+        return NULL;
     }
-end:
-    if (!res && sig) {
-        free_signature(sig);
-        free(sig);
-        sig = NULL;
+
+    try {
+        return new pgp_signature_t(std::move(sig));
+    } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
+        return NULL;
     }
-    return sig;
 }
 
 void
@@ -805,6 +797,7 @@ process_pgp_key_signatures(pgp_source_t *src, list *sigs, bool skiperrors)
         uint64_t sigpos = src->readb;
         if ((ret = stream_parse_signature(src, sig))) {
             RNP_LOG("failed to parse signature at %" PRIu64, sigpos);
+            sig->~pgp_signature_t();
             list_remove((list_item *) sig);
             if (!skiperrors) {
                 return ret;

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -53,10 +53,10 @@ typedef struct pgp_transferable_subkey_t {
     list          signatures;
 
     pgp_transferable_subkey_t() : subkey({}), signatures(NULL){};
-    pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src) = delete;
-    pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src) = delete;
+    pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src);
+    pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src);
     pgp_transferable_subkey_t &operator=(pgp_transferable_subkey_t &&src);
-    pgp_transferable_subkey_t &operator=(const pgp_transferable_subkey_t &src) = delete;
+    pgp_transferable_subkey_t &operator=(const pgp_transferable_subkey_t &src);
     ~pgp_transferable_subkey_t();
 } pgp_transferable_subkey_t;
 
@@ -64,10 +64,10 @@ typedef struct pgp_transferable_subkey_t {
 typedef struct pgp_transferable_key_t {
     pgp_key_pkt_t                          key; /* main key packet */
     std::vector<pgp_transferable_userid_t> userids;
-    list                                   subkeys;
+    std::vector<pgp_transferable_subkey_t> subkeys;
     list                                   signatures;
 
-    pgp_transferable_key_t() : key({}), subkeys(NULL), signatures(NULL){};
+    pgp_transferable_key_t() : key({}), signatures(NULL){};
     pgp_transferable_key_t(const pgp_transferable_key_t &src) = delete;
     pgp_transferable_key_t(pgp_transferable_key_t &&src);
     pgp_transferable_key_t &operator=(pgp_transferable_key_t &&src);

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -62,7 +62,7 @@ typedef struct pgp_transferable_key_t {
 
     pgp_transferable_key_t() : key({}), userids(NULL), subkeys(NULL), signatures(NULL){};
     pgp_transferable_key_t(const pgp_transferable_key_t &src) = delete;
-    pgp_transferable_key_t(pgp_transferable_key_t &&src) = delete;
+    pgp_transferable_key_t(pgp_transferable_key_t &&src);
     pgp_transferable_key_t &operator=(pgp_transferable_key_t &&src);
     pgp_transferable_key_t &operator=(const pgp_transferable_key_t &src) = delete;
     ~pgp_transferable_key_t();
@@ -70,14 +70,7 @@ typedef struct pgp_transferable_key_t {
 
 /* sequence of OpenPGP transferable keys */
 typedef struct pgp_key_sequence_t {
-    list keys; /* list of pgp_transferable_key_t records */
-
-    pgp_key_sequence_t() : keys(NULL){};
-    pgp_key_sequence_t(const pgp_key_sequence_t &src) = delete;
-    pgp_key_sequence_t(pgp_key_sequence_t &&src) = delete;
-    pgp_key_sequence_t &operator=(pgp_key_sequence_t &&src);
-    pgp_key_sequence_t &operator=(const pgp_key_sequence_t &src) = delete;
-    ~pgp_key_sequence_t();
+    std::vector<pgp_transferable_key_t> keys;
 } pgp_key_sequence_t;
 
 void transferable_userid_destroy(pgp_transferable_userid_t *userid);
@@ -130,7 +123,7 @@ rnp_result_t process_pgp_subkey(pgp_source_t &             src,
 
 rnp_result_t write_pgp_key(pgp_transferable_key_t *key, pgp_dest_t *dst, bool armor);
 
-rnp_result_t write_pgp_keys(pgp_key_sequence_t *keys, pgp_dest_t *dst, bool armor);
+rnp_result_t write_pgp_keys(pgp_key_sequence_t &keys, pgp_dest_t *dst, bool armor);
 
 rnp_result_t decrypt_secret_key(pgp_key_pkt_t *key, const char *password);
 

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -38,6 +38,13 @@
 typedef struct pgp_transferable_userid_t {
     pgp_userid_pkt_t uid;
     list             signatures;
+
+    pgp_transferable_userid_t() : uid({}), signatures(NULL){};
+    pgp_transferable_userid_t(const pgp_transferable_userid_t &src) = delete;
+    pgp_transferable_userid_t(pgp_transferable_userid_t &&src) = delete;
+    pgp_transferable_userid_t &operator=(pgp_transferable_userid_t &&src);
+    pgp_transferable_userid_t &operator=(const pgp_transferable_userid_t &src);
+    ~pgp_transferable_userid_t();
 } pgp_transferable_userid_t;
 
 /* subkey with all corresponding signatures */
@@ -72,8 +79,6 @@ typedef struct pgp_transferable_key_t {
 typedef struct pgp_key_sequence_t {
     std::vector<pgp_transferable_key_t> keys;
 } pgp_key_sequence_t;
-
-void transferable_userid_destroy(pgp_transferable_userid_t *userid);
 
 bool transferable_key_copy(pgp_transferable_key_t *      dst,
                            const pgp_transferable_key_t *src,

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -40,7 +40,7 @@ typedef struct pgp_transferable_userid_t {
     list             signatures;
 
     pgp_transferable_userid_t() : uid({}), signatures(NULL){};
-    pgp_transferable_userid_t(const pgp_transferable_userid_t &src) = delete;
+    pgp_transferable_userid_t(const pgp_transferable_userid_t &src);
     pgp_transferable_userid_t(pgp_transferable_userid_t &&src) = delete;
     pgp_transferable_userid_t &operator=(pgp_transferable_userid_t &&src);
     pgp_transferable_userid_t &operator=(const pgp_transferable_userid_t &src);
@@ -62,12 +62,12 @@ typedef struct pgp_transferable_subkey_t {
 
 /* transferable key with userids, subkeys and revocation signatures */
 typedef struct pgp_transferable_key_t {
-    pgp_key_pkt_t key; /* main key packet */
-    list          userids;
-    list          subkeys;
-    list          signatures;
+    pgp_key_pkt_t                          key; /* main key packet */
+    std::vector<pgp_transferable_userid_t> userids;
+    list                                   subkeys;
+    list                                   signatures;
 
-    pgp_transferable_key_t() : key({}), userids(NULL), subkeys(NULL), signatures(NULL){};
+    pgp_transferable_key_t() : key({}), subkeys(NULL), signatures(NULL){};
     pgp_transferable_key_t(const pgp_transferable_key_t &src) = delete;
     pgp_transferable_key_t(pgp_transferable_key_t &&src);
     pgp_transferable_key_t &operator=(pgp_transferable_key_t &&src);

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -44,6 +44,13 @@ typedef struct pgp_transferable_userid_t {
 typedef struct pgp_transferable_subkey_t {
     pgp_key_pkt_t subkey;
     list          signatures;
+
+    pgp_transferable_subkey_t() : subkey({}), signatures(NULL){};
+    pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src) = delete;
+    pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src) = delete;
+    pgp_transferable_subkey_t &operator=(pgp_transferable_subkey_t &&src);
+    pgp_transferable_subkey_t &operator=(const pgp_transferable_subkey_t &src) = delete;
+    ~pgp_transferable_subkey_t();
 } pgp_transferable_subkey_t;
 
 /* transferable key with userids, subkeys and revocation signatures */
@@ -52,16 +59,26 @@ typedef struct pgp_transferable_key_t {
     list          userids;
     list          subkeys;
     list          signatures;
+
+    pgp_transferable_key_t() : key({}), userids(NULL), subkeys(NULL), signatures(NULL){};
+    pgp_transferable_key_t(const pgp_transferable_key_t &src) = delete;
+    pgp_transferable_key_t(pgp_transferable_key_t &&src) = delete;
+    pgp_transferable_key_t &operator=(pgp_transferable_key_t &&src);
+    pgp_transferable_key_t &operator=(const pgp_transferable_key_t &src) = delete;
+    ~pgp_transferable_key_t();
 } pgp_transferable_key_t;
 
 /* sequence of OpenPGP transferable keys */
 typedef struct pgp_key_sequence_t {
     list keys; /* list of pgp_transferable_key_t records */
+
+    pgp_key_sequence_t() : keys(NULL){};
+    pgp_key_sequence_t(const pgp_key_sequence_t &src) = delete;
+    pgp_key_sequence_t(pgp_key_sequence_t &&src) = delete;
+    pgp_key_sequence_t &operator=(pgp_key_sequence_t &&src);
+    pgp_key_sequence_t &operator=(const pgp_key_sequence_t &src) = delete;
+    ~pgp_key_sequence_t();
 } pgp_key_sequence_t;
-
-void transferable_subkey_destroy(pgp_transferable_subkey_t *subkey);
-
-void transferable_key_destroy(pgp_transferable_key_t *key);
 
 void transferable_userid_destroy(pgp_transferable_userid_t *userid);
 
@@ -103,14 +120,12 @@ pgp_signature_t *transferable_key_revoke(const pgp_key_pkt_t *key,
                                          pgp_hash_alg_t       hash_alg,
                                          const pgp_revoke_t * revoke);
 
-void key_sequence_destroy(pgp_key_sequence_t *keys);
+rnp_result_t process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t &keys, bool skiperrors);
 
-rnp_result_t process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t *keys, bool skiperrors);
+rnp_result_t process_pgp_key(pgp_source_t *src, pgp_transferable_key_t &key, bool skiperrors);
 
-rnp_result_t process_pgp_key(pgp_source_t *src, pgp_transferable_key_t *key, bool skiperrors);
-
-rnp_result_t process_pgp_subkey(pgp_source_t *             src,
-                                pgp_transferable_subkey_t *subkey,
+rnp_result_t process_pgp_subkey(pgp_source_t &             src,
+                                pgp_transferable_subkey_t &subkey,
                                 bool                       skiperrors);
 
 rnp_result_t write_pgp_key(pgp_transferable_key_t *key, pgp_dest_t *dst, bool armor);

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -36,10 +36,10 @@
 
 /* userid/userattr with all the corresponding signatures */
 typedef struct pgp_transferable_userid_t {
-    pgp_userid_pkt_t uid;
-    list             signatures;
+    pgp_userid_pkt_t     uid;
+    pgp_signature_list_t signatures;
 
-    pgp_transferable_userid_t() : uid({}), signatures(NULL){};
+    pgp_transferable_userid_t() : uid({}){};
     pgp_transferable_userid_t(const pgp_transferable_userid_t &src);
     pgp_transferable_userid_t(pgp_transferable_userid_t &&src) = delete;
     pgp_transferable_userid_t &operator=(pgp_transferable_userid_t &&src);
@@ -49,10 +49,10 @@ typedef struct pgp_transferable_userid_t {
 
 /* subkey with all corresponding signatures */
 typedef struct pgp_transferable_subkey_t {
-    pgp_key_pkt_t subkey;
-    list          signatures;
+    pgp_key_pkt_t        subkey;
+    pgp_signature_list_t signatures;
 
-    pgp_transferable_subkey_t() : subkey({}), signatures(NULL){};
+    pgp_transferable_subkey_t() : subkey({}){};
     pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src);
     pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src);
     pgp_transferable_subkey_t &operator=(pgp_transferable_subkey_t &&src);
@@ -65,9 +65,9 @@ typedef struct pgp_transferable_key_t {
     pgp_key_pkt_t                          key; /* main key packet */
     std::vector<pgp_transferable_userid_t> userids;
     std::vector<pgp_transferable_subkey_t> subkeys;
-    list                                   signatures;
+    pgp_signature_list_t                   signatures;
 
-    pgp_transferable_key_t() : key({}), signatures(NULL){};
+    pgp_transferable_key_t() : key({}){};
     pgp_transferable_key_t(const pgp_transferable_key_t &src) = delete;
     pgp_transferable_key_t(pgp_transferable_key_t &&src);
     pgp_transferable_key_t &operator=(pgp_transferable_key_t &&src);
@@ -80,43 +80,43 @@ typedef struct pgp_key_sequence_t {
     std::vector<pgp_transferable_key_t> keys;
 } pgp_key_sequence_t;
 
-bool transferable_key_copy(pgp_transferable_key_t *      dst,
-                           const pgp_transferable_key_t *src,
+bool transferable_key_copy(pgp_transferable_key_t &      dst,
+                           const pgp_transferable_key_t &src,
                            bool                          pubonly);
 
-rnp_result_t transferable_key_from_key(pgp_transferable_key_t *dst, const pgp_key_t *key);
+rnp_result_t transferable_key_from_key(pgp_transferable_key_t &dst, const pgp_key_t &key);
 
-rnp_result_t transferable_key_merge(pgp_transferable_key_t *      dst,
-                                    const pgp_transferable_key_t *src);
+rnp_result_t transferable_key_merge(pgp_transferable_key_t &      dst,
+                                    const pgp_transferable_key_t &src);
 
-bool transferable_subkey_copy(pgp_transferable_subkey_t *      dst,
-                              const pgp_transferable_subkey_t *src,
+bool transferable_subkey_copy(pgp_transferable_subkey_t &      dst,
+                              const pgp_transferable_subkey_t &src,
                               bool                             pubonly);
 
-rnp_result_t transferable_subkey_from_key(pgp_transferable_subkey_t *dst,
-                                          const pgp_key_t *          key);
+rnp_result_t transferable_subkey_from_key(pgp_transferable_subkey_t &dst,
+                                          const pgp_key_t &          key);
 
-rnp_result_t transferable_subkey_merge(pgp_transferable_subkey_t *      dst,
-                                       const pgp_transferable_subkey_t *src);
+rnp_result_t transferable_subkey_merge(pgp_transferable_subkey_t &      dst,
+                                       const pgp_transferable_subkey_t &src);
 
-pgp_transferable_userid_t *transferable_key_add_userid(pgp_transferable_key_t *key,
+pgp_transferable_userid_t *transferable_key_add_userid(pgp_transferable_key_t &key,
                                                        const char *            userid);
 
-pgp_signature_t *transferable_userid_certify(const pgp_key_pkt_t *          key,
-                                             pgp_transferable_userid_t *    userid,
-                                             const pgp_key_pkt_t *          signer,
+pgp_signature_t *transferable_userid_certify(const pgp_key_pkt_t &          key,
+                                             pgp_transferable_userid_t &    userid,
+                                             const pgp_key_pkt_t &          signer,
                                              pgp_hash_alg_t                 hash_alg,
-                                             const rnp_selfsig_cert_info_t *cert);
+                                             const rnp_selfsig_cert_info_t &cert);
 
-pgp_signature_t *transferable_subkey_bind(const pgp_key_pkt_t *             primary_key,
-                                          pgp_transferable_subkey_t *       subkey,
+pgp_signature_t *transferable_subkey_bind(const pgp_key_pkt_t &             primary_key,
+                                          pgp_transferable_subkey_t &       subkey,
                                           pgp_hash_alg_t                    hash_alg,
-                                          const rnp_selfsig_binding_info_t *binding);
+                                          const rnp_selfsig_binding_info_t &binding);
 
-pgp_signature_t *transferable_key_revoke(const pgp_key_pkt_t *key,
-                                         const pgp_key_pkt_t *signer,
+pgp_signature_t *transferable_key_revoke(const pgp_key_pkt_t &key,
+                                         const pgp_key_pkt_t &signer,
                                          pgp_hash_alg_t       hash_alg,
-                                         const pgp_revoke_t * revoke);
+                                         const pgp_revoke_t & revoke);
 
 rnp_result_t process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t &keys, bool skiperrors);
 
@@ -126,7 +126,7 @@ rnp_result_t process_pgp_subkey(pgp_source_t &             src,
                                 pgp_transferable_subkey_t &subkey,
                                 bool                       skiperrors);
 
-rnp_result_t write_pgp_key(pgp_transferable_key_t *key, pgp_dest_t *dst, bool armor);
+rnp_result_t write_pgp_key(pgp_transferable_key_t &key, pgp_dest_t *dst, bool armor);
 
 rnp_result_t write_pgp_keys(pgp_key_sequence_t &keys, pgp_dest_t *dst, bool armor);
 

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -1819,20 +1819,6 @@ stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig)
 }
 
 bool
-signature_pkt_equal(const pgp_signature_t *sig1, const pgp_signature_t *sig2)
-{
-    if (memcmp(sig1->lbits, sig2->lbits, 2)) {
-        return false;
-    }
-    if ((sig1->hashed_len != sig2->hashed_len) ||
-        memcmp(sig1->hashed_data, sig2->hashed_data, sig1->hashed_len)) {
-        return false;
-    }
-    return (sig1->material_len == sig2->material_len) &&
-           !memcmp(sig1->material_buf, sig2->material_buf, sig1->material_len);
-}
-
-bool
 is_key_pkt(int tag)
 {
     switch (tag) {

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -1471,7 +1471,12 @@ signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
         /* parse signature */
         pgp_packet_body_t pkt = {};
         packet_body_part_from_mem(&pkt, subpkt->data, subpkt->len);
-        oklen = checked = !stream_parse_signature_body(&pkt, &subpkt->fields.sig);
+        subpkt->fields.sig = (pgp_signature_t *) calloc(1, sizeof(*subpkt->fields.sig));
+        if (!subpkt->fields.sig) {
+            RNP_LOG("allocation faield");
+            return false;
+        }
+        oklen = checked = !stream_parse_signature_body(&pkt, subpkt->fields.sig);
         break;
     }
     case PGP_SIG_SUBPKT_ISSUER_FPR:
@@ -1867,7 +1872,9 @@ free_signature_subpkt(pgp_sig_subpkt_t *subpkt)
         return;
     }
     if (subpkt->parsed && (subpkt->type == PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE)) {
-        free_signature(&subpkt->fields.sig);
+        free_signature(subpkt->fields.sig);
+        free(subpkt->fields.sig);
+        subpkt->fields.sig = NULL;
     }
     free(subpkt->data);
 }

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -424,7 +424,6 @@ bool
 add_packet_body_subpackets(pgp_packet_body_t *body, const pgp_signature_t *sig, bool hashed)
 {
     pgp_packet_body_t spbody;
-    pgp_sig_subpkt_t *subpkt;
     size_t            lenlen;
     uint8_t           splen[6];
     bool              res;
@@ -436,17 +435,15 @@ add_packet_body_subpackets(pgp_packet_body_t *body, const pgp_signature_t *sig, 
     /* add space for subpackets length */
     res = add_packet_body_uint16(&spbody, 0);
 
-    for (list_item *sp = list_front(sig->subpkts); sp; sp = list_next(sp)) {
-        subpkt = (pgp_sig_subpkt_t *) sp;
-
-        if (subpkt->hashed != hashed) {
+    for (auto &subpkt : sig->subpkts) {
+        if (subpkt.hashed != hashed) {
             continue;
         }
 
-        lenlen = write_packet_len(splen, subpkt->len + 1);
+        lenlen = write_packet_len(splen, subpkt.len + 1);
         res &= add_packet_body(&spbody, splen, lenlen) &&
-               add_packet_body_byte(&spbody, subpkt->type | (subpkt->critical << 7)) &&
-               add_packet_body(&spbody, subpkt->data, subpkt->len);
+               add_packet_body_byte(&spbody, subpkt.type | (subpkt.critical << 7)) &&
+               add_packet_body(&spbody, subpkt.data, subpkt.len);
     }
 
     if (res) {
@@ -1363,155 +1360,158 @@ signature_read_v3(pgp_packet_body_t *pkt, pgp_signature_t *sig)
 
 /* check the signature's subpacket for validity */
 bool
-signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
+signature_parse_subpacket(pgp_sig_subpkt_t &subpkt)
 {
     bool oklen = true;
     bool checked = true;
 
-    switch (subpkt->type) {
+    switch (subpkt.type) {
     case PGP_SIG_SUBPKT_CREATION_TIME:
-        if (!subpkt->hashed) {
+        if (!subpkt.hashed) {
             RNP_LOG("creation time subpacket must be hashed");
             checked = false;
         }
-        if ((oklen = subpkt->len == 4)) {
-            subpkt->fields.create = read_uint32(subpkt->data);
+        if ((oklen = subpkt.len == 4)) {
+            subpkt.fields.create = read_uint32(subpkt.data);
         }
         break;
     case PGP_SIG_SUBPKT_EXPIRATION_TIME:
     case PGP_SIG_SUBPKT_KEY_EXPIRY:
-        if ((oklen = subpkt->len == 4)) {
-            subpkt->fields.expiry = read_uint32(subpkt->data);
+        if ((oklen = subpkt.len == 4)) {
+            subpkt.fields.expiry = read_uint32(subpkt.data);
         }
         break;
     case PGP_SIG_SUBPKT_EXPORT_CERT:
-        if ((oklen = subpkt->len == 1)) {
-            subpkt->fields.exportable = subpkt->data[0] != 0;
+        if ((oklen = subpkt.len == 1)) {
+            subpkt.fields.exportable = subpkt.data[0] != 0;
         }
         break;
     case PGP_SIG_SUBPKT_TRUST:
-        if ((oklen = subpkt->len == 2)) {
-            subpkt->fields.trust.level = subpkt->data[0];
-            subpkt->fields.trust.amount = subpkt->data[1];
+        if ((oklen = subpkt.len == 2)) {
+            subpkt.fields.trust.level = subpkt.data[0];
+            subpkt.fields.trust.amount = subpkt.data[1];
         }
         break;
     case PGP_SIG_SUBPKT_REGEXP:
-        subpkt->fields.regexp.str = (const char *) subpkt->data;
-        subpkt->fields.regexp.len = subpkt->len;
+        subpkt.fields.regexp.str = (const char *) subpkt.data;
+        subpkt.fields.regexp.len = subpkt.len;
         break;
     case PGP_SIG_SUBPKT_REVOCABLE:
-        if ((oklen = subpkt->len == 1)) {
-            subpkt->fields.revocable = subpkt->data[0] != 0;
+        if ((oklen = subpkt.len == 1)) {
+            subpkt.fields.revocable = subpkt.data[0] != 0;
         }
         break;
     case PGP_SIG_SUBPKT_PREFERRED_SKA:
     case PGP_SIG_SUBPKT_PREFERRED_HASH:
     case PGP_SIG_SUBPKT_PREF_COMPRESS:
     case PGP_SIG_SUBPKT_PREFERRED_AEAD:
-        subpkt->fields.preferred.arr = subpkt->data;
-        subpkt->fields.preferred.len = subpkt->len;
+        subpkt.fields.preferred.arr = subpkt.data;
+        subpkt.fields.preferred.len = subpkt.len;
         break;
     case PGP_SIG_SUBPKT_REVOCATION_KEY:
-        if ((oklen = subpkt->len == 22)) {
-            subpkt->fields.revocation_key.klass = subpkt->data[0];
-            subpkt->fields.revocation_key.pkalg = (pgp_pubkey_alg_t) subpkt->data[1];
-            subpkt->fields.revocation_key.fp = &subpkt->data[2];
+        if ((oklen = subpkt.len == 22)) {
+            subpkt.fields.revocation_key.klass = subpkt.data[0];
+            subpkt.fields.revocation_key.pkalg = (pgp_pubkey_alg_t) subpkt.data[1];
+            subpkt.fields.revocation_key.fp = &subpkt.data[2];
         }
         break;
     case PGP_SIG_SUBPKT_ISSUER_KEY_ID:
-        if ((oklen = subpkt->len == 8)) {
-            subpkt->fields.issuer = subpkt->data;
+        if ((oklen = subpkt.len == 8)) {
+            subpkt.fields.issuer = subpkt.data;
         }
         break;
     case PGP_SIG_SUBPKT_NOTATION_DATA:
-        if ((oklen = subpkt->len >= 8)) {
-            memcpy(subpkt->fields.notation.flags, subpkt->data, 4);
-            subpkt->fields.notation.nlen = read_uint16(&subpkt->data[4]);
-            subpkt->fields.notation.vlen = read_uint16(&subpkt->data[6]);
+        if ((oklen = subpkt.len >= 8)) {
+            memcpy(subpkt.fields.notation.flags, subpkt.data, 4);
+            subpkt.fields.notation.nlen = read_uint16(&subpkt.data[4]);
+            subpkt.fields.notation.vlen = read_uint16(&subpkt.data[6]);
 
-            if (subpkt->len !=
-                8 + subpkt->fields.notation.nlen + subpkt->fields.notation.vlen) {
+            if (subpkt.len != 8 + subpkt.fields.notation.nlen + subpkt.fields.notation.vlen) {
                 oklen = false;
             } else {
-                subpkt->fields.notation.name = (const char *) &subpkt->data[8];
-                subpkt->fields.notation.value =
-                  (const char *) &subpkt->data[8 + subpkt->fields.notation.nlen];
+                subpkt.fields.notation.name = (const char *) &subpkt.data[8];
+                subpkt.fields.notation.value =
+                  (const char *) &subpkt.data[8 + subpkt.fields.notation.nlen];
             }
         }
         break;
     case PGP_SIG_SUBPKT_KEYSERV_PREFS:
-        if ((oklen = subpkt->len >= 1)) {
-            subpkt->fields.ks_prefs.no_modify = (subpkt->data[0] & 0x80) != 0;
+        if ((oklen = subpkt.len >= 1)) {
+            subpkt.fields.ks_prefs.no_modify = (subpkt.data[0] & 0x80) != 0;
         }
         break;
     case PGP_SIG_SUBPKT_PREF_KEYSERV:
-        subpkt->fields.preferred_ks.uri = (const char *) subpkt->data;
-        subpkt->fields.preferred_ks.len = subpkt->len;
+        subpkt.fields.preferred_ks.uri = (const char *) subpkt.data;
+        subpkt.fields.preferred_ks.len = subpkt.len;
         break;
     case PGP_SIG_SUBPKT_PRIMARY_USER_ID:
-        if ((oklen = subpkt->len == 1)) {
-            subpkt->fields.primary_uid = subpkt->data[0] != 0;
+        if ((oklen = subpkt.len == 1)) {
+            subpkt.fields.primary_uid = subpkt.data[0] != 0;
         }
         break;
     case PGP_SIG_SUBPKT_POLICY_URI:
-        subpkt->fields.policy.uri = (const char *) subpkt->data;
-        subpkt->fields.policy.len = subpkt->len;
+        subpkt.fields.policy.uri = (const char *) subpkt.data;
+        subpkt.fields.policy.len = subpkt.len;
         break;
     case PGP_SIG_SUBPKT_KEY_FLAGS:
-        if ((oklen = subpkt->len >= 1)) {
-            subpkt->fields.key_flags = subpkt->data[0];
+        if ((oklen = subpkt.len >= 1)) {
+            subpkt.fields.key_flags = subpkt.data[0];
         }
         break;
     case PGP_SIG_SUBPKT_SIGNERS_USER_ID:
-        subpkt->fields.signer.uid = (const char *) subpkt->data;
-        subpkt->fields.signer.len = subpkt->len;
+        subpkt.fields.signer.uid = (const char *) subpkt.data;
+        subpkt.fields.signer.len = subpkt.len;
         break;
     case PGP_SIG_SUBPKT_REVOCATION_REASON:
-        if ((oklen = subpkt->len >= 1)) {
-            subpkt->fields.revocation_reason.code = (pgp_revocation_type_t) subpkt->data[0];
-            subpkt->fields.revocation_reason.str = (const char *) &subpkt->data[1];
-            subpkt->fields.revocation_reason.len = subpkt->len - 1;
+        if ((oklen = subpkt.len >= 1)) {
+            subpkt.fields.revocation_reason.code = (pgp_revocation_type_t) subpkt.data[0];
+            subpkt.fields.revocation_reason.str = (const char *) &subpkt.data[1];
+            subpkt.fields.revocation_reason.len = subpkt.len - 1;
         }
         break;
     case PGP_SIG_SUBPKT_FEATURES:
-        if ((oklen = subpkt->len >= 1)) {
-            subpkt->fields.features.mdc = subpkt->data[0] & 0x01;
-            subpkt->fields.features.aead = subpkt->data[0] & 0x02;
-            subpkt->fields.features.key_v5 = subpkt->data[0] & 0x04;
+        if ((oklen = subpkt.len >= 1)) {
+            subpkt.fields.features.mdc = subpkt.data[0] & 0x01;
+            subpkt.fields.features.aead = subpkt.data[0] & 0x02;
+            subpkt.fields.features.key_v5 = subpkt.data[0] & 0x04;
         }
         break;
     case PGP_SIG_SUBPKT_SIGNATURE_TARGET:
-        if ((oklen = subpkt->len >= 18)) {
-            subpkt->fields.sig_target.pkalg = (pgp_pubkey_alg_t) subpkt->data[0];
-            subpkt->fields.sig_target.halg = (pgp_hash_alg_t) subpkt->data[1];
-            subpkt->fields.sig_target.hash = &subpkt->data[2];
-            subpkt->fields.sig_target.hlen = subpkt->len - 2;
+        if ((oklen = subpkt.len >= 18)) {
+            subpkt.fields.sig_target.pkalg = (pgp_pubkey_alg_t) subpkt.data[0];
+            subpkt.fields.sig_target.halg = (pgp_hash_alg_t) subpkt.data[1];
+            subpkt.fields.sig_target.hash = &subpkt.data[2];
+            subpkt.fields.sig_target.hlen = subpkt.len - 2;
         }
         break;
     case PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE: {
         /* parse signature */
         pgp_packet_body_t pkt = {};
-        packet_body_part_from_mem(&pkt, subpkt->data, subpkt->len);
-        subpkt->fields.sig = (pgp_signature_t *) calloc(1, sizeof(*subpkt->fields.sig));
-        if (!subpkt->fields.sig) {
-            RNP_LOG("allocation faield");
-            return false;
+        packet_body_part_from_mem(&pkt, subpkt.data, subpkt.len);
+        pgp_signature_t sig;
+        oklen = checked = !stream_parse_signature_body(&pkt, &sig);
+        if (checked) {
+            try {
+                subpkt.fields.sig = new pgp_signature_t(std::move(sig));
+            } catch (const std::exception &e) {
+                RNP_LOG("%s", e.what());
+                return false;
+            }
         }
-        oklen = checked = !stream_parse_signature_body(&pkt, subpkt->fields.sig);
         break;
     }
     case PGP_SIG_SUBPKT_ISSUER_FPR:
-        if ((oklen = subpkt->len >= 21)) {
-            subpkt->fields.issuer_fp.version = subpkt->data[0];
-            subpkt->fields.issuer_fp.fp = &subpkt->data[1];
-            subpkt->fields.issuer_fp.len = subpkt->len - 1;
+        if ((oklen = subpkt.len >= 21)) {
+            subpkt.fields.issuer_fp.version = subpkt.data[0];
+            subpkt.fields.issuer_fp.fp = &subpkt.data[1];
+            subpkt.fields.issuer_fp.len = subpkt.len - 1;
         }
         break;
     case PGP_SIG_SUBPKT_PRIVATE_FIRST ... PGP_SIG_SUBPKT_PRIVATE_LAST:
         oklen = true;
-        checked = !subpkt->critical;
+        checked = !subpkt.critical;
         if (!checked) {
-            RNP_LOG("unknown critical private subpacket %d", (int) subpkt->type);
+            RNP_LOG("unknown critical private subpacket %d", (int) subpkt.type);
         }
         break;
     case PGP_SIG_SUBPKT_RESERVED_1:
@@ -1524,18 +1524,16 @@ signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
     case PGP_SIG_SUBPKT_RESERVED_18:
     case PGP_SIG_SUBPKT_RESERVED_19:
         /* do not report reserved/placeholder subpacket */
-        return !subpkt->critical;
+        return !subpkt.critical;
     default:
-        RNP_LOG("unknown subpacket : %d", (int) subpkt->type);
-        return !subpkt->critical;
+        RNP_LOG("unknown subpacket : %d", (int) subpkt.type);
+        return !subpkt.critical;
     }
 
     if (!oklen) {
-        RNP_LOG("wrong len %d of subpacket type %d", (int) subpkt->len, (int) subpkt->type);
-    }
-
-    if (oklen) {
-        subpkt->parsed = 1;
+        RNP_LOG("wrong len %d of subpacket type %d", (int) subpkt.len, (int) subpkt.type);
+    } else {
+        subpkt.parsed = 1;
     }
 
     return oklen && checked;
@@ -1545,9 +1543,7 @@ signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
 static bool
 signature_parse_subpackets(pgp_signature_t *sig, uint8_t *buf, size_t len, bool hashed)
 {
-    pgp_sig_subpkt_t subpkt;
-    size_t           splen;
-    bool             res = true;
+    bool res = true;
 
     while (len > 0) {
         if (len < 2) {
@@ -1556,6 +1552,7 @@ signature_parse_subpackets(pgp_signature_t *sig, uint8_t *buf, size_t len, bool 
         }
 
         /* subpacket length */
+        size_t splen;
         if (*buf < 192) {
             splen = *buf;
             buf++;
@@ -1585,9 +1582,8 @@ signature_parse_subpackets(pgp_signature_t *sig, uint8_t *buf, size_t len, bool 
             return false;
         }
 
-        memset(&subpkt, 0, sizeof(subpkt));
-
-        if ((subpkt.data = (uint8_t *) malloc(splen - 1)) == NULL) {
+        pgp_sig_subpkt_t subpkt;
+        if (!(subpkt.data = (uint8_t *) malloc(splen - 1))) {
             RNP_LOG("subpacket data allocation failed");
             return false;
         }
@@ -1599,13 +1595,13 @@ signature_parse_subpackets(pgp_signature_t *sig, uint8_t *buf, size_t len, bool 
         memcpy(subpkt.data, buf + 1, splen - 1);
         subpkt.len = splen - 1;
 
-        res = res && signature_parse_subpacket(&subpkt);
-
-        if (!list_append(&sig->subpkts, &subpkt, sizeof(subpkt))) {
-            RNP_LOG("allocation failed");
+        res = res && signature_parse_subpacket(subpkt);
+        try {
+            sig->subpkts.emplace_back(subpkt);
+        } catch (const std::exception &e) {
+            RNP_LOG("%s", e.what());
             return false;
         }
-
         len -= splen;
         buf += splen;
     }
@@ -1834,20 +1830,6 @@ signature_pkt_equal(const pgp_signature_t *sig1, const pgp_signature_t *sig2)
     }
     return (sig1->material_len == sig2->material_len) &&
            !memcmp(sig1->material_buf, sig2->material_buf, sig1->material_len);
-}
-
-void
-free_signature_subpkt(pgp_sig_subpkt_t *subpkt)
-{
-    if (!subpkt) {
-        return;
-    }
-    if (subpkt->parsed && (subpkt->type == PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE)) {
-        (*subpkt->fields.sig).~pgp_signature_t();
-        free(subpkt->fields.sig);
-        subpkt->fields.sig = NULL;
-    }
-    free(subpkt->data);
 }
 
 bool

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -291,13 +291,9 @@ rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
 
 bool parse_signature_material(const pgp_signature_t &sig, pgp_signature_material_t &material);
 
-bool copy_signature_packet(pgp_signature_t *dst, const pgp_signature_t *src);
-
 bool signature_pkt_equal(const pgp_signature_t *sig1, const pgp_signature_t *sig2);
 
 void free_signature_subpkt(pgp_sig_subpkt_t *subpkt);
-
-void free_signature(pgp_signature_t *sig);
 
 /* Public/Private key or Subkey */
 

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -283,7 +283,7 @@ bool stream_write_signature(const pgp_signature_t *sig, pgp_dest_t *dst);
 
 bool write_signature_material(pgp_signature_t &sig, const pgp_signature_material_t &material);
 
-bool signature_parse_subpacket(pgp_sig_subpkt_t *subpkt);
+bool signature_parse_subpacket(pgp_sig_subpkt_t &subpkt);
 
 rnp_result_t stream_parse_signature_body(pgp_packet_body_t *pkt, pgp_signature_t *sig);
 
@@ -292,8 +292,6 @@ rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
 bool parse_signature_material(const pgp_signature_t &sig, pgp_signature_material_t &material);
 
 bool signature_pkt_equal(const pgp_signature_t *sig1, const pgp_signature_t *sig2);
-
-void free_signature_subpkt(pgp_sig_subpkt_t *subpkt);
 
 /* Public/Private key or Subkey */
 

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -291,8 +291,6 @@ rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
 
 bool parse_signature_material(const pgp_signature_t &sig, pgp_signature_material_t &material);
 
-bool signature_pkt_equal(const pgp_signature_t *sig1, const pgp_signature_t *sig2);
-
 /* Public/Private key or Subkey */
 
 bool is_key_pkt(int tag);

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -281,11 +281,15 @@ rnp_result_t stream_parse_one_pass(pgp_source_t *src, pgp_one_pass_sig_t *onepas
 
 bool stream_write_signature(const pgp_signature_t *sig, pgp_dest_t *dst);
 
+bool write_signature_material(pgp_signature_t &sig, const pgp_signature_material_t &material);
+
 bool signature_parse_subpacket(pgp_sig_subpkt_t *subpkt);
 
 rnp_result_t stream_parse_signature_body(pgp_packet_body_t *pkt, pgp_signature_t *sig);
 
 rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
+
+bool parse_signature_material(const pgp_signature_t &sig, pgp_signature_material_t &material);
 
 bool copy_signature_packet(pgp_signature_t *dst, const pgp_signature_t *src);
 

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -823,7 +823,7 @@ signed_read_single_signature(pgp_source_signed_param_t *param,
     }
 
     try {
-        param->sigs.push_back(readsig);
+        param->sigs.push_back(std::move(readsig));
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
         return RNP_ERROR_OUT_OF_MEMORY;
@@ -2030,9 +2030,6 @@ pgp_source_signed_param_t::~pgp_source_signed_param_t()
 {
     for (auto &hash : hashes) {
         pgp_hash_finish(&hash, NULL);
-    }
-    for (auto &sig : sigs) {
-        free_signature(&sig);
     }
 }
 

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1314,12 +1314,6 @@ pgp_sig_subpkt_t::~pgp_sig_subpkt_t()
     free(data);
 }
 
-pgp_signature_t::pgp_signature_t()
-{
-    hashed_data = NULL;
-    material_buf = NULL;
-}
-
 pgp_signature_t::pgp_signature_t(const pgp_signature_t &src)
 {
     version = src.version;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1161,18 +1161,8 @@ signature_check_subkey_revocation(pgp_signature_info_t *sinfo,
     return signature_check(sinfo, &hash);
 }
 
-void
-signature_list_destroy(list *sigs)
-{
-    for (list_item *li = list_front(*sigs); li; li = list_next(li)) {
-        pgp_signature_t *sig = (pgp_signature_t *) li;
-        (*sig).~pgp_signature_t();
-    }
-    list_destroy(sigs);
-}
-
 rnp_result_t
-process_pgp_signatures(pgp_source_t *src, std::vector<pgp_signature_t> &sigs)
+process_pgp_signatures(pgp_source_t *src, pgp_signature_list_t &sigs)
 {
     bool          armored = false;
     pgp_source_t  armorsrc = {0};
@@ -1440,6 +1430,25 @@ pgp_signature_t::operator=(const pgp_signature_t &src)
     subpkts = src.subpkts;
 
     return *this;
+}
+
+bool
+pgp_signature_t::operator==(const pgp_signature_t &src) const
+{
+    if ((lbits[0] != src.lbits[0]) || (lbits[1] != src.lbits[1])) {
+        return false;
+    }
+    if ((hashed_len != src.hashed_len) || memcmp(hashed_data, src.hashed_data, hashed_len)) {
+        return false;
+    }
+    return (material_len == src.material_len) &&
+           !memcmp(material_buf, src.material_buf, material_len);
+}
+
+bool
+pgp_signature_t::operator!=(const pgp_signature_t &src) const
+{
+    return !(*this == src);
 }
 
 pgp_signature_t::~pgp_signature_t()

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -57,22 +57,31 @@ signature_matches_onepass(pgp_signature_t *sig, pgp_one_pass_sig_t *onepass)
 }
 
 pgp_sig_subpkt_t *
-signature_get_subpkt(const pgp_signature_t *sig, pgp_sig_subpacket_type_t type)
+signature_get_subpkt(pgp_signature_t *sig, pgp_sig_subpacket_type_t type)
 {
-    pgp_sig_subpkt_t *res = NULL;
-
     if (!sig || (sig->version < PGP_V4)) {
         return NULL;
     }
-
-    for (list_item *sp = list_front(sig->subpkts); sp; sp = list_next(sp)) {
-        pgp_sig_subpkt_t *subpkt = (pgp_sig_subpkt_t *) sp;
-        if (subpkt->type == type) {
-            return subpkt;
+    for (auto &subpkt : sig->subpkts) {
+        if (subpkt.type == type) {
+            return &subpkt;
         }
     }
+    return NULL;
+}
 
-    return res;
+const pgp_sig_subpkt_t *
+signature_get_subpkt(const pgp_signature_t *sig, pgp_sig_subpacket_type_t type)
+{
+    if (!sig || (sig->version < PGP_V4)) {
+        return NULL;
+    }
+    for (auto &subpkt : sig->subpkts) {
+        if (subpkt.type == type) {
+            return &subpkt;
+        }
+    }
+    return NULL;
 }
 
 pgp_sig_subpkt_t *
@@ -82,32 +91,34 @@ signature_add_subpkt(pgp_signature_t *        sig,
                      bool                     reuse)
 {
     pgp_sig_subpkt_t *subpkt = NULL;
-
     if (!sig) {
         return NULL;
     }
-
     if (sig->version < PGP_V4) {
         RNP_LOG("wrong signature version");
         return NULL;
     }
 
-    if (reuse && (subpkt = signature_get_subpkt(sig, type))) {
-        free_signature_subpkt(subpkt);
-        memset(subpkt, 0, sizeof(*subpkt));
-    }
-
-    if (!subpkt) {
-        pgp_sig_subpkt_t s = {(pgp_sig_subpacket_type_t) 0};
-        subpkt = (pgp_sig_subpkt_t *) list_append(&sig->subpkts, &s, sizeof(s));
-    }
-
-    if (!subpkt || ((datalen > 0) && !(subpkt->data = (uint8_t *) calloc(1, datalen)))) {
-        RNP_LOG("data allocation failed");
-        list_remove((list_item *) subpkt);
+    uint8_t *newdata = (uint8_t *) calloc(1, datalen);
+    if (!newdata) {
+        RNP_LOG("Allocation failed");
         return NULL;
     }
 
+    if (reuse && (subpkt = signature_get_subpkt(sig, type))) {
+        *subpkt = {};
+    } else {
+        try {
+            sig->subpkts.push_back({});
+            subpkt = &sig->subpkts.back();
+        } catch (const std::exception &e) {
+            RNP_LOG("%s", e.what());
+            free(newdata);
+            return NULL;
+        }
+    }
+
+    subpkt->data = newdata;
     subpkt->type = type;
     subpkt->len = datalen;
     return subpkt;
@@ -116,9 +127,11 @@ signature_add_subpkt(pgp_signature_t *        sig,
 void
 signature_remove_subpkt(pgp_signature_t *sig, pgp_sig_subpkt_t *subpkt)
 {
-    if (list_is_member(sig->subpkts, (list_item *) subpkt)) {
-        free_signature_subpkt(subpkt);
-        list_remove((list_item *) subpkt);
+    for (auto it = sig->subpkts.begin(); it < sig->subpkts.end(); it++) {
+        if (&*it == subpkt) {
+            sig->subpkts.erase(it);
+            return;
+        }
     }
 }
 
@@ -137,14 +150,12 @@ signature_has_keyfp(const pgp_signature_t *sig)
 bool
 signature_get_keyfp(const pgp_signature_t *sig, pgp_fingerprint_t &fp)
 {
-    pgp_sig_subpkt_t *subpkt;
-
     if (!sig || (sig->version < PGP_V4)) {
         return false;
     }
 
-    fp.length = 0;
-    if (!(subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_ISSUER_FPR))) {
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_ISSUER_FPR);
+    if (!subpkt) {
         return false;
     }
     fp.length = subpkt->fields.issuer_fp.len;
@@ -152,7 +163,6 @@ signature_get_keyfp(const pgp_signature_t *sig, pgp_fingerprint_t &fp)
         memcpy(fp.fingerprint, subpkt->fields.issuer_fp.fp, subpkt->fields.issuer_fp.len);
         return true;
     }
-
     return false;
 }
 
@@ -206,7 +216,7 @@ signature_get_keyid(const pgp_signature_t *sig, pgp_key_id_t &id)
     }
 
     /* version 4 and up use subpackets */
-    pgp_sig_subpkt_t *subpkt;
+    const pgp_sig_subpkt_t *subpkt;
     static_assert(std::tuple_size<std::remove_reference<decltype(id)>::type>::value ==
                     PGP_KEY_ID_SIZE,
                   "pgp_key_id_t size mismatch");
@@ -220,7 +230,6 @@ signature_get_keyid(const pgp_signature_t *sig, pgp_key_id_t &id)
                PGP_KEY_ID_SIZE);
         return true;
     }
-
     return false;
 }
 
@@ -255,14 +264,13 @@ signature_set_keyid(pgp_signature_t *sig, const pgp_key_id_t &id)
 uint32_t
 signature_get_creation(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
     if (!sig) {
         return 0;
     }
     if (sig->version < PGP_V4) {
         return sig->creation_time;
     }
+    const pgp_sig_subpkt_t *subpkt;
     if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_CREATION_TIME))) {
         return subpkt->fields.create;
     }
@@ -298,13 +306,8 @@ signature_set_creation(pgp_signature_t *sig, uint32_t ctime)
 uint32_t
 signature_get_expiration(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_EXPIRATION_TIME))) {
-        return subpkt->fields.expiry;
-    }
-
-    return 0;
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_EXPIRATION_TIME);
+    return subpkt ? subpkt->fields.expiry : 0;
 }
 
 bool
@@ -337,13 +340,8 @@ signature_has_key_expiration(const pgp_signature_t *sig)
 uint32_t
 signature_get_key_expiration(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_KEY_EXPIRY))) {
-        return subpkt->fields.expiry;
-    }
-
-    return 0;
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_KEY_EXPIRY);
+    return subpkt ? subpkt->fields.expiry : 0;
 }
 
 bool
@@ -372,13 +370,8 @@ signature_has_key_flags(const pgp_signature_t *sig)
 uint8_t
 signature_get_key_flags(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_KEY_FLAGS))) {
-        return subpkt->fields.key_flags;
-    }
-
-    return 0;
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_KEY_FLAGS);
+    return subpkt ? subpkt->fields.key_flags : 0;
 }
 
 bool
@@ -454,18 +447,16 @@ signature_get_preferred_algs(const pgp_signature_t *  sig,
                              size_t *                 len,
                              pgp_sig_subpacket_type_t type)
 {
-    pgp_sig_subpkt_t *subpkt;
-
     if (!algs || !len) {
         return false;
     }
 
-    if ((subpkt = signature_get_subpkt(sig, type))) {
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, type);
+    if (subpkt) {
         *algs = subpkt->fields.preferred.arr;
         *len = subpkt->fields.preferred.len;
         return true;
     }
-
     return false;
 }
 
@@ -532,13 +523,8 @@ signature_has_key_server_prefs(const pgp_signature_t *sig)
 uint8_t
 signature_get_key_server_prefs(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_KEYSERV_PREFS))) {
-        return subpkt->data[0];
-    }
-
-    return 0;
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_KEYSERV_PREFS);
+    return subpkt ? subpkt->data[0] : 0;
 }
 
 bool
@@ -586,9 +572,8 @@ signature_has_trust(const pgp_signature_t *sig)
 bool
 signature_get_trust(const pgp_signature_t *sig, uint8_t *level, uint8_t *amount)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_TRUST))) {
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_TRUST);
+    if (subpkt) {
         if (level) {
             *level = subpkt->fields.trust.level;
         }
@@ -597,7 +582,6 @@ signature_get_trust(const pgp_signature_t *sig, uint8_t *level, uint8_t *amount)
         }
         return true;
     }
-
     return false;
 }
 
@@ -623,13 +607,8 @@ signature_set_trust(pgp_signature_t *sig, uint8_t level, uint8_t amount)
 bool
 signature_get_revocable(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_REVOCABLE))) {
-        return subpkt->fields.revocable;
-    }
-
-    return true;
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_REVOCABLE);
+    return subpkt ? subpkt->fields.revocable : true;
 }
 
 bool
@@ -661,7 +640,7 @@ signature_set_features(pgp_signature_t *sig, uint8_t features)
 
     subpkt->hashed = 1;
     subpkt->data[0] = features;
-    return signature_parse_subpacket(subpkt);
+    return signature_parse_subpacket(*subpkt);
 }
 
 bool
@@ -676,7 +655,7 @@ signature_set_signer_uid(pgp_signature_t *sig, uint8_t *uid, size_t len)
 
     subpkt->hashed = 1;
     memcpy(subpkt->data, uid, len);
-    return signature_parse_subpacket(subpkt);
+    return signature_parse_subpacket(*subpkt);
 }
 
 bool
@@ -716,17 +695,10 @@ signature_set_embedded_sig(pgp_signature_t *sig, pgp_signature_t *esig)
         RNP_LOG("failed to read back signature");
         goto finish;
     }
-    subpkt->fields.sig = (pgp_signature_t *) calloc(1, sizeof(*subpkt->fields.sig));
-    if (!subpkt->fields.sig) {
-        RNP_LOG("Allocation failed");
-        goto finish;
-    }
     try {
-        *subpkt->fields.sig = *esig;
+        subpkt->fields.sig = new pgp_signature_t(*esig);
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
-        free(subpkt->fields.sig);
-        subpkt->fields.sig = NULL;
         goto finish;
     }
     subpkt->parsed = 1;
@@ -771,7 +743,7 @@ signature_add_notation_data(pgp_signature_t *sig,
     memcpy(subpkt->data + 6, name, nlen);
     write_uint16(subpkt->data + 6 + nlen, vlen);
     memcpy(subpkt->data + 8 + nlen, value, vlen);
-    return signature_parse_subpacket(subpkt);
+    return signature_parse_subpacket(*subpkt);
 }
 
 bool
@@ -783,9 +755,8 @@ signature_has_key_server(const pgp_signature_t *sig)
 char *
 signature_get_key_server(const pgp_signature_t *sig)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_PREF_KEYSERV))) {
+    const pgp_sig_subpkt_t *subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_PREF_KEYSERV);
+    if (subpkt) {
         char *res = (char *) malloc(subpkt->len + 1);
         if (res) {
             memcpy(res, subpkt->data, subpkt->len);
@@ -793,7 +764,6 @@ signature_get_key_server(const pgp_signature_t *sig)
         }
         return res;
     }
-
     return NULL;
 }
 
@@ -808,9 +778,9 @@ signature_get_revocation_reason(const pgp_signature_t *sig,
                                 pgp_revocation_type_t *code,
                                 char **                reason)
 {
-    pgp_sig_subpkt_t *subpkt;
-
-    if ((subpkt = signature_get_subpkt(sig, PGP_SIG_SUBPKT_REVOCATION_REASON))) {
+    const pgp_sig_subpkt_t *subpkt =
+      signature_get_subpkt(sig, PGP_SIG_SUBPKT_REVOCATION_REASON);
+    if (subpkt) {
         if (code) {
             *code = subpkt->fields.revocation_reason.code;
         }
@@ -826,7 +796,6 @@ signature_get_revocation_reason(const pgp_signature_t *sig,
         }
         return true;
     }
-
     return false;
 }
 
@@ -847,7 +816,7 @@ signature_set_revocation_reason(pgp_signature_t *     sig,
     if (reason) {
         memcpy(subpkt->data + 1, reason, strlen(reason));
     }
-    return signature_parse_subpacket(subpkt);
+    return signature_parse_subpacket(*subpkt);
 }
 
 bool
@@ -1263,11 +1232,102 @@ finish:
     return ret;
 }
 
+pgp_sig_subpkt_t::pgp_sig_subpkt_t()
+{
+    type = PGP_SIG_SUBPKT_UNKNOWN;
+    data = NULL;
+    fields = {};
+}
+
+pgp_sig_subpkt_t::pgp_sig_subpkt_t(const pgp_sig_subpkt_t &src)
+{
+    type = src.type;
+    len = src.len;
+    data = (uint8_t *) malloc(len);
+    if (!data) {
+        throw std::bad_alloc();
+    }
+    memcpy(data, src.data, len);
+    critical = src.critical;
+    hashed = src.hashed;
+    parsed = false;
+    signature_parse_subpacket(*this);
+}
+
+pgp_sig_subpkt_t::pgp_sig_subpkt_t(pgp_sig_subpkt_t &&src)
+{
+    type = src.type;
+    len = src.len;
+    data = src.data;
+    src.data = NULL;
+    critical = src.critical;
+    hashed = src.hashed;
+    parsed = src.parsed;
+    memcpy(&fields, &src.fields, sizeof(fields));
+    src.fields = {};
+}
+
+pgp_sig_subpkt_t &
+pgp_sig_subpkt_t::operator=(pgp_sig_subpkt_t &&src)
+{
+    if (&src == this) {
+        return *this;
+    }
+
+    if (parsed && (type == PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE)) {
+        delete fields.sig;
+    }
+    type = src.type;
+    len = src.len;
+    free(data);
+    data = src.data;
+    src.data = NULL;
+    critical = src.critical;
+    hashed = src.hashed;
+    parsed = src.parsed;
+    fields = src.fields;
+    src.fields = {};
+    return *this;
+}
+
+pgp_sig_subpkt_t &
+pgp_sig_subpkt_t::operator=(const pgp_sig_subpkt_t &src)
+{
+    if (&src == this) {
+        return *this;
+    }
+
+    if (parsed && (type == PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE)) {
+        delete fields.sig;
+    }
+    type = src.type;
+    len = src.len;
+    free(data);
+    data = (uint8_t *) malloc(len);
+    if (!data) {
+        throw std::bad_alloc();
+    }
+    memcpy(data, src.data, len);
+    critical = src.critical;
+    hashed = src.hashed;
+    parsed = false;
+    fields = {};
+    signature_parse_subpacket(*this);
+    return *this;
+}
+
+pgp_sig_subpkt_t::~pgp_sig_subpkt_t()
+{
+    if (parsed && (type == PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE)) {
+        delete fields.sig;
+    }
+    free(data);
+}
+
 pgp_signature_t::pgp_signature_t()
 {
     hashed_data = NULL;
     material_buf = NULL;
-    subpkts = NULL;
 }
 
 pgp_signature_t::pgp_signature_t(const pgp_signature_t &src)
@@ -1296,24 +1356,7 @@ pgp_signature_t::pgp_signature_t(const pgp_signature_t &src)
         }
         memcpy(material_buf, src.material_buf, material_len);
     }
-
-    subpkts = NULL;
-    for (list_item *sp = list_front(src.subpkts); sp; sp = list_next(sp)) {
-        pgp_sig_subpkt_t *dstsp;
-        pgp_sig_subpkt_t *srcsp = (pgp_sig_subpkt_t *) sp;
-        /* subpacket may have internal pointers to the subpkt->data ! */
-        dstsp = (pgp_sig_subpkt_t *) list_append(&subpkts, srcsp, sizeof(*dstsp));
-        if (!dstsp) {
-            throw std::bad_alloc();
-        }
-        if (!(dstsp->data = (uint8_t *) malloc(dstsp->len))) {
-            throw std::bad_alloc();
-        }
-        memcpy(dstsp->data, srcsp->data, srcsp->len);
-        dstsp->len = srcsp->len;
-        memset(&dstsp->fields, 0, sizeof(dstsp->fields));
-        signature_parse_subpacket(dstsp);
-    }
+    subpkts = src.subpkts;
 }
 
 pgp_signature_t::pgp_signature_t(pgp_signature_t &&src)
@@ -1331,8 +1374,7 @@ pgp_signature_t::pgp_signature_t(pgp_signature_t &&src)
     material_len = src.material_len;
     material_buf = src.material_buf;
     src.material_buf = NULL;
-    subpkts = src.subpkts;
-    src.subpkts = NULL;
+    subpkts = std::move(src.subpkts);
 }
 
 pgp_signature_t &
@@ -1357,12 +1399,7 @@ pgp_signature_t::operator=(pgp_signature_t &&src)
     free(material_buf);
     material_buf = src.material_buf;
     src.material_buf = NULL;
-    for (list_item *sp = list_front(subpkts); sp; sp = list_next(sp)) {
-        free_signature_subpkt((pgp_sig_subpkt_t *) sp);
-    }
-    list_destroy(&subpkts);
-    subpkts = src.subpkts;
-    src.subpkts = NULL;
+    subpkts = std::move(src.subpkts);
 
     return *this;
 }
@@ -1400,28 +1437,7 @@ pgp_signature_t::operator=(const pgp_signature_t &src)
         }
         memcpy(material_buf, src.material_buf, material_len);
     }
-
-    for (list_item *sp = list_front(subpkts); sp; sp = list_next(sp)) {
-        free_signature_subpkt((pgp_sig_subpkt_t *) sp);
-    }
-    list_destroy(&subpkts);
-    subpkts = NULL;
-    for (list_item *sp = list_front(src.subpkts); sp; sp = list_next(sp)) {
-        pgp_sig_subpkt_t *dstsp;
-        pgp_sig_subpkt_t *srcsp = (pgp_sig_subpkt_t *) sp;
-        /* subpacket may have internal pointers to the subpkt->data ! */
-        dstsp = (pgp_sig_subpkt_t *) list_append(&subpkts, srcsp, sizeof(*dstsp));
-        if (!dstsp) {
-            throw std::bad_alloc();
-        }
-        if (!(dstsp->data = (uint8_t *) malloc(dstsp->len))) {
-            throw std::bad_alloc();
-        }
-        memcpy(dstsp->data, srcsp->data, srcsp->len);
-        dstsp->len = srcsp->len;
-        memset(&dstsp->fields, 0, sizeof(dstsp->fields));
-        signature_parse_subpacket(dstsp);
-    }
+    subpkts = src.subpkts;
 
     return *this;
 }
@@ -1430,9 +1446,4 @@ pgp_signature_t::~pgp_signature_t()
 {
     free(hashed_data);
     free(material_buf);
-
-    for (list_item *sp = list_front(subpkts); sp; sp = list_next(sp)) {
-        free_signature_subpkt((pgp_sig_subpkt_t *) sp);
-    }
-    list_destroy(&subpkts);
 }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -721,8 +721,10 @@ signature_set_embedded_sig(pgp_signature_t *sig, pgp_signature_t *esig)
         RNP_LOG("Allocation failed");
         goto finish;
     }
-    if (!copy_signature_packet(subpkt->fields.sig, esig)) {
-        RNP_LOG("failed to copy signature");
+    try {
+        *subpkt->fields.sig = *esig;
+    } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
         free(subpkt->fields.sig);
         subpkt->fields.sig = NULL;
         goto finish;
@@ -1194,21 +1196,21 @@ void
 signature_list_destroy(list *sigs)
 {
     for (list_item *li = list_front(*sigs); li; li = list_next(li)) {
-        free_signature((pgp_signature_t *) li);
+        pgp_signature_t *sig = (pgp_signature_t *) li;
+        (*sig).~pgp_signature_t();
     }
     list_destroy(sigs);
 }
 
 rnp_result_t
-process_pgp_signatures(pgp_source_t *src, list *sigs)
+process_pgp_signatures(pgp_source_t *src, std::vector<pgp_signature_t> &sigs)
 {
-    bool             armored = false;
-    pgp_source_t     armorsrc = {0};
-    pgp_source_t *   origsrc = src;
-    pgp_signature_t *cursig = NULL;
-    rnp_result_t     ret = RNP_ERROR_GENERIC;
+    bool          armored = false;
+    pgp_source_t  armorsrc = {0};
+    pgp_source_t *origsrc = src;
+    rnp_result_t  ret = RNP_ERROR_GENERIC;
 
-    *sigs = NULL;
+    sigs.clear();
     /* check whether signatures are armored */
 armoredpass:
     if (is_armored_source(src)) {
@@ -1230,14 +1232,15 @@ armoredpass:
             goto finish;
         }
 
-        if (!(cursig = (pgp_signature_t *) list_append(sigs, NULL, sizeof(*cursig)))) {
-            RNP_LOG("sig alloc failed");
+        try {
+            sigs.emplace_back();
+        } catch (const std::exception &e) {
+            RNP_LOG("%s", e.what());
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto finish;
         }
-
-        if ((ret = stream_parse_signature(src, cursig))) {
-            list_remove((list_item *) cursig);
+        if ((ret = stream_parse_signature(src, &sigs.back()))) {
+            sigs.pop_back();
             goto finish;
         }
     }
@@ -1255,7 +1258,181 @@ finish:
         src_close(&armorsrc);
     }
     if (ret) {
-        signature_list_destroy(sigs);
+        sigs.clear();
     }
     return ret;
+}
+
+pgp_signature_t::pgp_signature_t()
+{
+    hashed_data = NULL;
+    material_buf = NULL;
+    subpkts = NULL;
+}
+
+pgp_signature_t::pgp_signature_t(const pgp_signature_t &src)
+{
+    version = src.version;
+    type = src.type;
+    palg = src.palg;
+    halg = src.halg;
+    memcpy(lbits, src.lbits, sizeof(src.lbits));
+    creation_time = src.creation_time;
+    signer = src.signer;
+
+    hashed_len = src.hashed_len;
+    hashed_data = NULL;
+    if (src.hashed_data) {
+        if (!(hashed_data = (uint8_t *) malloc(hashed_len))) {
+            throw std::bad_alloc();
+        }
+        memcpy(hashed_data, src.hashed_data, hashed_len);
+    }
+    material_len = src.material_len;
+    material_buf = NULL;
+    if (src.material_buf) {
+        if (!(material_buf = (uint8_t *) malloc(material_len))) {
+            throw std::bad_alloc();
+        }
+        memcpy(material_buf, src.material_buf, material_len);
+    }
+
+    subpkts = NULL;
+    for (list_item *sp = list_front(src.subpkts); sp; sp = list_next(sp)) {
+        pgp_sig_subpkt_t *dstsp;
+        pgp_sig_subpkt_t *srcsp = (pgp_sig_subpkt_t *) sp;
+        /* subpacket may have internal pointers to the subpkt->data ! */
+        dstsp = (pgp_sig_subpkt_t *) list_append(&subpkts, srcsp, sizeof(*dstsp));
+        if (!dstsp) {
+            throw std::bad_alloc();
+        }
+        if (!(dstsp->data = (uint8_t *) malloc(dstsp->len))) {
+            throw std::bad_alloc();
+        }
+        memcpy(dstsp->data, srcsp->data, srcsp->len);
+        dstsp->len = srcsp->len;
+        memset(&dstsp->fields, 0, sizeof(dstsp->fields));
+        signature_parse_subpacket(dstsp);
+    }
+}
+
+pgp_signature_t::pgp_signature_t(pgp_signature_t &&src)
+{
+    version = src.version;
+    type = src.type;
+    palg = src.palg;
+    halg = src.halg;
+    memcpy(lbits, src.lbits, sizeof(src.lbits));
+    creation_time = src.creation_time;
+    signer = src.signer;
+    hashed_len = src.hashed_len;
+    hashed_data = src.hashed_data;
+    src.hashed_data = NULL;
+    material_len = src.material_len;
+    material_buf = src.material_buf;
+    src.material_buf = NULL;
+    subpkts = src.subpkts;
+    src.subpkts = NULL;
+}
+
+pgp_signature_t &
+pgp_signature_t::operator=(pgp_signature_t &&src)
+{
+    if (this == &src) {
+        return *this;
+    }
+
+    version = src.version;
+    type = src.type;
+    palg = src.palg;
+    halg = src.halg;
+    memcpy(lbits, src.lbits, sizeof(src.lbits));
+    creation_time = src.creation_time;
+    signer = src.signer;
+    hashed_len = src.hashed_len;
+    free(hashed_data);
+    hashed_data = src.hashed_data;
+    src.hashed_data = NULL;
+    material_len = src.material_len;
+    free(material_buf);
+    material_buf = src.material_buf;
+    src.material_buf = NULL;
+    for (list_item *sp = list_front(subpkts); sp; sp = list_next(sp)) {
+        free_signature_subpkt((pgp_sig_subpkt_t *) sp);
+    }
+    list_destroy(&subpkts);
+    subpkts = src.subpkts;
+    src.subpkts = NULL;
+
+    return *this;
+}
+
+pgp_signature_t &
+pgp_signature_t::operator=(const pgp_signature_t &src)
+{
+    if (this == &src) {
+        return *this;
+    }
+
+    version = src.version;
+    type = src.type;
+    palg = src.palg;
+    halg = src.halg;
+    memcpy(lbits, src.lbits, sizeof(src.lbits));
+    creation_time = src.creation_time;
+    signer = src.signer;
+
+    hashed_len = src.hashed_len;
+    free(hashed_data);
+    hashed_data = NULL;
+    if (src.hashed_data) {
+        if (!(hashed_data = (uint8_t *) malloc(hashed_len))) {
+            throw std::bad_alloc();
+        }
+        memcpy(hashed_data, src.hashed_data, hashed_len);
+    }
+    material_len = src.material_len;
+    free(material_buf);
+    material_buf = NULL;
+    if (src.material_buf) {
+        if (!(material_buf = (uint8_t *) malloc(material_len))) {
+            throw std::bad_alloc();
+        }
+        memcpy(material_buf, src.material_buf, material_len);
+    }
+
+    for (list_item *sp = list_front(subpkts); sp; sp = list_next(sp)) {
+        free_signature_subpkt((pgp_sig_subpkt_t *) sp);
+    }
+    list_destroy(&subpkts);
+    subpkts = NULL;
+    for (list_item *sp = list_front(src.subpkts); sp; sp = list_next(sp)) {
+        pgp_sig_subpkt_t *dstsp;
+        pgp_sig_subpkt_t *srcsp = (pgp_sig_subpkt_t *) sp;
+        /* subpacket may have internal pointers to the subpkt->data ! */
+        dstsp = (pgp_sig_subpkt_t *) list_append(&subpkts, srcsp, sizeof(*dstsp));
+        if (!dstsp) {
+            throw std::bad_alloc();
+        }
+        if (!(dstsp->data = (uint8_t *) malloc(dstsp->len))) {
+            throw std::bad_alloc();
+        }
+        memcpy(dstsp->data, srcsp->data, srcsp->len);
+        dstsp->len = srcsp->len;
+        memset(&dstsp->fields, 0, sizeof(dstsp->fields));
+        signature_parse_subpacket(dstsp);
+    }
+
+    return *this;
+}
+
+pgp_signature_t::~pgp_signature_t()
+{
+    free(hashed_data);
+    free(material_buf);
+
+    for (list_item *sp = list_front(subpkts); sp; sp = list_next(sp)) {
+        free_signature_subpkt((pgp_sig_subpkt_t *) sp);
+    }
+    list_destroy(&subpkts);
 }

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -45,6 +45,8 @@ typedef struct pgp_signature_info_t {
     bool             ignore_expiry; /* ignore signer's key expiration time */
 } pgp_signature_info_t;
 
+typedef std::vector<pgp_signature_t> pgp_signature_list_t;
+
 /**
  * @brief Check whether signature packet matches one-pass signature packet.
  * @param sig pointer to the read signature packet
@@ -354,13 +356,6 @@ rnp_result_t signature_check_subkey_revocation(pgp_signature_info_t *sinfo,
                                                const pgp_key_pkt_t * subkey);
 
 /**
- * @brief Destroy list of pgp_signature_t structures.
- *
- * @param sigs list of signatures, can be NULL.
- */
-void signature_list_destroy(list *sigs);
-
-/**
  * @brief Parse stream with signatures to the signatures list.
  *        Can handle binary or armored stream with signatures, including stream with multiple
  * armored signatures.
@@ -369,6 +364,6 @@ void signature_list_destroy(list *sigs);
  * @param sigs on success parsed signature structures will be put here.
  * @return RNP_SUCCESS or error code otherwise.
  */
-rnp_result_t process_pgp_signatures(pgp_source_t *src, std::vector<pgp_signature_t> &sigs);
+rnp_result_t process_pgp_signatures(pgp_source_t *src, pgp_signature_list_t &sigs);
 
 #endif

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -368,6 +368,6 @@ void signature_list_destroy(list *sigs);
  * @param sigs on success parsed signature structures will be put here.
  * @return RNP_SUCCESS or error code otherwise.
  */
-rnp_result_t process_pgp_signatures(pgp_source_t *src, list *sigs);
+rnp_result_t process_pgp_signatures(pgp_source_t *src, std::vector<pgp_signature_t> &sigs);
 
 #endif

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -59,8 +59,9 @@ bool signature_matches_onepass(pgp_signature_t *sig, pgp_one_pass_sig_t *onepass
  * @param type type of the subpacket to lookup for
  * @return pointer to the subpacket structure or NULL if it was not found or error occurred
  */
-pgp_sig_subpkt_t *signature_get_subpkt(const pgp_signature_t *  sig,
-                                       pgp_sig_subpacket_type_t type);
+pgp_sig_subpkt_t *signature_get_subpkt(pgp_signature_t *sig, pgp_sig_subpacket_type_t type);
+const pgp_sig_subpkt_t *signature_get_subpkt(const pgp_signature_t *  sig,
+                                             pgp_sig_subpacket_type_t type);
 
 /**
  * @brief Add subpacket of the specified type to v4 signature

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1114,7 +1114,7 @@ signed_write_signature(pgp_dest_signed_param_t *param,
                        pgp_dest_signer_info_t * signer,
                        pgp_dest_t *             writedst)
 {
-    pgp_signature_t sig = {(pgp_version_t) 0};
+    pgp_signature_t sig = {};
     rnp_result_t    ret;
 
     sig.version = (pgp_version_t) 4;
@@ -1131,8 +1131,6 @@ signed_write_signature(pgp_dest_signed_param_t *param,
     if (!(ret = signed_fill_signature(param, &sig, signer))) {
         ret = stream_write_signature(&sig, writedst) ? RNP_SUCCESS : RNP_ERROR_WRITE;
     }
-
-    free_signature(&sig);
     return ret;
 }
 

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -8341,7 +8341,6 @@ TEST_F(rnp_tests, test_ffi_export_revocation)
     assert_int_equal(code, PGP_REVOCATION_SUPERSEDED);
     assert_int_equal(strcmp(reason, "test key revocation"), 0);
     free(reason);
-    free_signature(&sig);
     assert_int_equal(unlink("alice-revocation.pgp"), 0);
 
     assert_rnp_success(rnp_ffi_destroy(ffi));

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -949,8 +949,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         psig = &pgp_key_get_subsig(&pub, 0)->sig;
         ssig = &pgp_key_get_subsig(&sec, 0)->sig;
         // make sure our sig MPI is not NULL
-        assert_int_not_equal(psig->material.rsa.s.len, 0);
-        assert_int_not_equal(ssig->material.rsa.s.len, 0);
+        assert_int_not_equal(psig->material_len, 0);
+        assert_int_not_equal(ssig->material_len, 0);
         // make sure we're targeting the right packet
         assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_subsig(&pub, 0)->rawpkt.tag);
         assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_subsig(&sec, 0)->rawpkt.tag);
@@ -1077,8 +1077,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         psig = &pgp_key_get_subsig(&pub, 0)->sig;
         ssig = &pgp_key_get_subsig(&sec, 0)->sig;
         // make sure our sig MPI is not NULL
-        assert_int_not_equal(psig->material.rsa.s.len, 0);
-        assert_int_not_equal(ssig->material.rsa.s.len, 0);
+        assert_int_not_equal(psig->material_len, 0);
+        assert_int_not_equal(ssig->material_len, 0);
         // make sure we're targeting the right packet
         assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_subsig(&pub, 0)->rawpkt.tag);
         assert_int_equal(PGP_PKT_SIGNATURE, pgp_key_get_subsig(&sec, 0)->rawpkt.tag);

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -78,7 +78,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
         // steal this key from the store
         key = new pgp_key_t();
         assert_non_null(key);
-        pgp_key_copy(key, tmp, false);
+        pgp_key_copy(*key, *tmp, false);
         delete ks;
     }
 

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -125,9 +125,8 @@ key_store_add(rnp_key_store_t *keyring, const char *keypath)
     pgp_transferable_key_t tkey = {};
 
     assert_rnp_success(init_file_src(&keysrc, keypath));
-    assert_rnp_success(process_pgp_key(&keysrc, &tkey, false));
+    assert_rnp_success(process_pgp_key(&keysrc, tkey, false));
     assert_true(rnp_key_store_add_transferable_key(keyring, &tkey));
-    transferable_key_destroy(&tkey);
     src_close(&keysrc);
 }
 

--- a/src/tests/large-mpi.cpp
+++ b/src/tests/large-mpi.cpp
@@ -40,7 +40,7 @@ TEST_F(rnp_tests, test_large_mpi_rsa_pub)
     /* Load RSA pubkey packet with 65535 bit modulus MPI. Must fail. */
     assert_rnp_success(init_file_src(&keysrc, "data/test_large_MPIs/rsa-pub-65535bits.pgp"));
     assert_rnp_failure(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 0);
+    assert_true(keyseq.keys.empty());
     src_close(&keysrc);
 
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));

--- a/src/tests/large-mpi.cpp
+++ b/src/tests/large-mpi.cpp
@@ -39,9 +39,8 @@ TEST_F(rnp_tests, test_large_mpi_rsa_pub)
 
     /* Load RSA pubkey packet with 65535 bit modulus MPI. Must fail. */
     assert_rnp_success(init_file_src(&keysrc, "data/test_large_MPIs/rsa-pub-65535bits.pgp"));
-    assert_rnp_failure(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_failure(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 0);
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -798,7 +798,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 0);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 0);
+    assert_true(tkey.userids.empty());
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
 
     /* import public key + 1 userid */
@@ -813,8 +813,8 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 0);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 1);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_int_equal(tkey.userids.size(), 1);
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 0);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
@@ -832,9 +832,9 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 0);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 1);
+    assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
@@ -851,9 +851,9 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 1);
+    assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
@@ -873,9 +873,9 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 1);
+    assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
@@ -886,10 +886,10 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 1);
+    assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
     assert_rnp_success(decrypt_secret_key(&tkey.key, "password"));
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
@@ -910,13 +910,13 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 2);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 2);
+    assert_int_equal(tkey.userids.size(), 2);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_next((list_item *) tuid));
+    assert_non_null(tuid = &tkey.userids[1]);
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
@@ -930,14 +930,14 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 2);
     assert_int_equal(list_length(tkey.signatures), 0);
-    assert_int_equal(list_length(tkey.userids), 2);
+    assert_int_equal(tkey.userids.size(), 2);
     assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
     assert_rnp_success(decrypt_secret_key(&tkey.key, "password"));
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_front(tkey.userids));
+    assert_non_null(tuid = &tkey.userids.front());
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tuid = (pgp_transferable_userid_t *) list_next((list_item *) tuid));
+    assert_non_null(tuid = &tkey.userids[1]);
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -797,7 +797,7 @@ TEST_F(rnp_tests, test_key_import)
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_true(tkey.subkeys.empty());
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_true(tkey.userids.empty());
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
 
@@ -812,10 +812,10 @@ TEST_F(rnp_tests, test_key_import)
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_true(tkey.subkeys.empty());
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 1);
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 0);
+    assert_true(tuid->signatures.empty());
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
@@ -831,11 +831,11 @@ TEST_F(rnp_tests, test_key_import)
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_true(tkey.subkeys.empty());
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
 
@@ -850,15 +850,15 @@ TEST_F(rnp_tests, test_key_import)
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(tkey.subkeys.size(), 1);
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = &tkey.subkeys.front());
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
 
     /* import secret key with 1 uid and 1 subkey */
@@ -872,29 +872,29 @@ TEST_F(rnp_tests, test_key_import)
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(tkey.subkeys.size(), 1);
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = &tkey.subkeys.front());
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
 
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
     assert_int_equal(tkey.subkeys.size(), 1);
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
     assert_rnp_success(decrypt_secret_key(&tkey.key, "password"));
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = &tkey.subkeys.front());
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
 
@@ -909,44 +909,44 @@ TEST_F(rnp_tests, test_key_import)
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(tkey.subkeys.size(), 2);
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 2);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tuid = &tkey.userids[1]);
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = &tkey.subkeys.front());
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_non_null(tskey = &tkey.subkeys[1]);
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
 
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
     assert_int_equal(tkey.subkeys.size(), 2);
-    assert_int_equal(list_length(tkey.signatures), 0);
+    assert_true(tkey.signatures.empty());
     assert_int_equal(tkey.userids.size(), 2);
     assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
     assert_rnp_success(decrypt_secret_key(&tkey.key, "password"));
     assert_non_null(tuid = &tkey.userids.front());
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tuid = &tkey.userids[1]);
-    assert_int_equal(list_length(tuid->signatures), 1);
+    assert_int_equal(tuid->signatures.size(), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
     assert_non_null(tskey = &tkey.subkeys.front());
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
     assert_non_null(tskey = &tkey.subkeys[1]);
-    assert_int_equal(list_length(tskey->signatures), 1);
+    assert_int_equal(tskey->signatures.size(), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
 

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -796,7 +796,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(keycount, 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 0);
+    assert_true(tkey.subkeys.empty());
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_true(tkey.userids.empty());
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
@@ -811,7 +811,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(keycount, 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 0);
+    assert_true(tkey.subkeys.empty());
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 1);
     assert_non_null(tuid = &tkey.userids.front());
@@ -830,7 +830,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(keycount, 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 0);
+    assert_true(tkey.subkeys.empty());
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
@@ -849,7 +849,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(keycount, 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 1);
+    assert_int_equal(tkey.subkeys.size(), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
@@ -857,7 +857,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
+    assert_non_null(tskey = &tkey.subkeys.front());
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
 
@@ -871,7 +871,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(keycount, 2);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 1);
+    assert_int_equal(tkey.subkeys.size(), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
@@ -879,12 +879,12 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
+    assert_non_null(tskey = &tkey.subkeys.front());
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
 
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 1);
+    assert_int_equal(tkey.subkeys.size(), 1);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 1);
     assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
@@ -893,7 +893,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-1", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
+    assert_non_null(tskey = &tkey.subkeys.front());
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
@@ -908,7 +908,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(keycount, 3);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 2);
+    assert_int_equal(tkey.subkeys.size(), 2);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 2);
     assert_int_equal(tkey.key.tag, PGP_PKT_PUBLIC_KEY);
@@ -920,15 +920,15 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
+    assert_non_null(tskey = &tkey.subkeys.front());
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_next((list_item *) tskey));
+    assert_non_null(tskey = &tkey.subkeys[1]);
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_PUBLIC_SUBKEY);
 
     assert_true(load_transferable_key(&tkey, ".rnp/secring.gpg"));
-    assert_int_equal(list_length(tkey.subkeys), 2);
+    assert_int_equal(tkey.subkeys.size(), 2);
     assert_int_equal(list_length(tkey.signatures), 0);
     assert_int_equal(tkey.userids.size(), 2);
     assert_int_equal(tkey.key.tag, PGP_PKT_SECRET_KEY);
@@ -941,11 +941,11 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(list_length(tuid->signatures), 1);
     assert_false(memcmp(tuid->uid.uid, "key-merge-uid-2", 15));
     assert_int_equal(tuid->uid.tag, PGP_PKT_USER_ID);
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_front(tkey.subkeys));
+    assert_non_null(tskey = &tkey.subkeys.front());
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
-    assert_non_null(tskey = (pgp_transferable_subkey_t *) list_next((list_item *) tskey));
+    assert_non_null(tskey = &tkey.subkeys[1]);
     assert_int_equal(list_length(tskey->signatures), 1);
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -726,7 +726,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_non_null(skey2 = rnp_key_store_get_key_by_id(secstore, sub2id, NULL));
 
     /* copy the secret key */
-    assert_rnp_success(pgp_key_copy(&keycp, key, false));
+    assert_rnp_success(pgp_key_copy(keycp, *key, false));
     assert_true(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(pgp_key_get_subkey_fp(&keycp, 0) == pgp_key_get_fp(skey1));
@@ -735,7 +735,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_SECRET_KEY);
 
     /* copy the public part */
-    assert_rnp_success(pgp_key_copy(&keycp, key, true));
+    assert_rnp_success(pgp_key_copy(keycp, *key, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(check_subkey_fp(&keycp, skey1, 0));
@@ -747,7 +747,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
-    assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
+    assert_rnp_success(pgp_key_copy(keycp, *skey1, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 0));
@@ -759,7 +759,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
-    assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
+    assert_rnp_success(pgp_key_copy(keycp, *skey2, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 1));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -452,11 +452,11 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* public keyring, read-save-read-save armored-read */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_true(list_length(keyseq.keys) > 1);
+    assert_true(keyseq.keys.size() > 1);
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout.gpg", true));
-    assert_rnp_success(write_pgp_keys(&keyseq, &keydst, false));
+    assert_rnp_success(write_pgp_keys(keyseq, &keydst, false));
     dst_close(&keydst, false);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout.gpg"));
@@ -464,7 +464,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout.asc", true));
-    assert_rnp_success(write_pgp_keys(&keyseq, &keydst, true));
+    assert_rnp_success(write_pgp_keys(keyseq, &keydst, true));
     dst_close(&keydst, false);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout.asc"));
@@ -474,11 +474,11 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* secret keyring */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_true(list_length(keyseq.keys) > 1);
+    assert_true(keyseq.keys.size() > 1);
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout-sec.gpg", true));
-    assert_rnp_success(write_pgp_keys(&keyseq, &keydst, false));
+    assert_rnp_success(write_pgp_keys(keyseq, &keydst, false));
     dst_close(&keydst, false);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout-sec.gpg"));
@@ -486,7 +486,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout-sec.asc", true));
-    assert_rnp_success(write_pgp_keys(&keyseq, &keydst, true));
+    assert_rnp_success(write_pgp_keys(keyseq, &keydst, true));
     dst_close(&keydst, false);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout-sec.asc"));
@@ -496,8 +496,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* armored v3 public key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_keyid(keyid, &key->key));
     assert_true(cmp_keyid(keyid, "7D0BC10E933404C9"));
     assert_false(cmp_keyid(keyid, "1D0BC10E933404C9"));
@@ -506,8 +506,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* armored v3 secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-s.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_keyid(keyid, &key->key));
     assert_true(cmp_keyid(keyid, "7D0BC10E933404C9"));
     src_close(&keysrc);
@@ -515,8 +515,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* rsa/rsa public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "6BC04A5A3DDB35766B9A40D82FB9179118898E8B"));
     assert_rnp_success(pgp_keyid(keyid, &key->key));
@@ -528,8 +528,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* rsa/rsa secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "6BC04A5A3DDB35766B9A40D82FB9179118898E8B"));
     assert_rnp_success(pgp_keyid(keyid, &key->key));
@@ -541,8 +541,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* dsa/el-gamal public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "091C44CE9CFBC3FF7EC7A64DC8A10A7D78273E10"));
     assert_int_equal(list_length(key->subkeys), 1);
@@ -554,8 +554,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* dsa/el-gamal secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -563,8 +563,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* curve 25519 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "21FC68274AAE3B5DE39A4277CC786278981B0728"));
     src_close(&keysrc);
@@ -572,8 +572,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* curve 25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 0);
     assert_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -581,8 +581,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* eddsa/x25519 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "4C9738A6F2BE4E1A796C9B7B941822A0FC1B30A5"));
     assert_int_equal(list_length(key->subkeys), 1);
@@ -594,8 +594,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* eddsa/x25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -603,8 +603,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* p-256 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "B54FDEBBB673423A5D0AA54423674F21B2441527"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -615,8 +615,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* p-256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -624,8 +624,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* p-384 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "AB25CBA042DD924C3ACC3ED3242A3AA5EA85F44A"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -636,8 +636,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* p-384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -645,8 +645,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* p-521 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "4FB39FF6FA4857A4BD7EF5B42092CA8324263B6A"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -657,8 +657,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* p-521 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -666,8 +666,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* Brainpool P256 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp256-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "0633C5F72A198F51E650E4ABD0C8A3DAF9E0634A"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -678,8 +678,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* Brainpool P256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp256-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -687,8 +687,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* Brainpool P384 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp384-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "5B8A254C823CED98DECD10ED6CF2DCE85599ADA2"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -699,8 +699,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* Brainpool P384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp384-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -708,8 +708,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* Brainpool P512 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp512-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "4C59AB9272AA6A1F60B85BD0AA5C58D14F7B8F48"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -720,8 +720,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* Brainpool P512 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp512-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -729,8 +729,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* secp256k1 ecc public key, not supported now */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256k1-pub.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "81F772B57D4EBFE7000A66233EA5BB6F9692C1A0"));
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
@@ -741,8 +741,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     /* secp256k1 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256k1-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
     src_close(&keysrc);
@@ -761,9 +761,9 @@ buggy_key_load_single(const void *keydata, size_t keylen)
         assert_rnp_success(init_mem_src(&memsrc, keydata, partlen, false));
         if (!process_pgp_keys(&memsrc, keyseq, false)) {
             /* it may succeed if we accidentally hit some packet boundary */
-            assert_non_null(list_front(keyseq.keys));
+            assert_false(keyseq.keys.empty());
         } else {
-            assert_null(list_front(keyseq.keys));
+            assert_true(keyseq.keys.empty());
         }
         src_close(&memsrc);
     }
@@ -775,9 +775,9 @@ buggy_key_load_single(const void *keydata, size_t keylen)
         assert_rnp_success(init_mem_src(&memsrc, keydata, keylen, false));
         if (!process_pgp_keys(&memsrc, keyseq, false)) {
             /* it may succeed if we accidentally hit some packet boundary */
-            assert_non_null(list_front(keyseq.keys));
+            assert_false(keyseq.keys.empty());
         } else {
-            assert_null(list_front(keyseq.keys));
+            assert_true(keyseq.keys.empty());
         }
         src_close(&memsrc);
         dataptr[partlen] ^= 0xff;
@@ -841,12 +841,11 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* load and decrypt secret keyring */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    for (list_item *li = list_front(keyseq.keys); li; li = list_next(li)) {
-        key = (pgp_transferable_key_t *) li;
-        assert_rnp_failure(decrypt_secret_key(&key->key, "passw0rd"));
-        assert_rnp_success(decrypt_secret_key(&key->key, "password"));
+    for (auto &key : keyseq.keys) {
+        assert_rnp_failure(decrypt_secret_key(&key.key, "passw0rd"));
+        assert_rnp_success(decrypt_secret_key(&key.key, "password"));
 
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
+        for (list_item *sli = list_front(key.subkeys); sli; sli = list_next(sli)) {
             subkey = (pgp_transferable_subkey_t *) sli;
             assert_rnp_failure(decrypt_secret_key(&subkey->subkey, "passw0rd"));
             assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -857,7 +856,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* armored v3 secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-s.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_failure(decrypt_secret_key(&key->key, "passw0rd"));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     src_close(&keysrc);
@@ -865,7 +864,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* rsa/rsa secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -874,7 +873,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* dsa/el-gamal secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -883,14 +882,14 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* curve 25519 eddsa ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     src_close(&keysrc);
 
     /* x25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -899,7 +898,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* p-256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -908,7 +907,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* p-384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -917,7 +916,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     /* p-521 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-sec.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
@@ -932,7 +931,6 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
     size_t                     keylen;
     pgp_key_sequence_t         keyseq;
     pgp_key_sequence_t         keyseq2;
-    pgp_transferable_key_t *   key = NULL;
     pgp_transferable_subkey_t *subkey = NULL;
     rng_t                      rng;
 
@@ -943,63 +941,64 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
-    for (list_item *li = list_front(keyseq.keys); li; li = list_next(li)) {
-        key = (pgp_transferable_key_t *) li;
-        assert_rnp_success(decrypt_secret_key(&key->key, "password"));
+    for (auto &key : keyseq.keys) {
+        assert_rnp_success(decrypt_secret_key(&key.key, "password"));
 
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
+        for (list_item *sli = list_front(key.subkeys); sli; sli = list_next(sli)) {
             subkey = (pgp_transferable_subkey_t *) sli;
             assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
         }
 
         /* change password and encryption algorithm */
-        key->key.sec_protection.symm_alg = PGP_SA_CAMELLIA_192;
-        assert_rnp_success(encrypt_secret_key(&key->key, "passw0rd", &rng));
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
+        key.key.sec_protection.symm_alg = PGP_SA_CAMELLIA_192;
+        assert_rnp_success(encrypt_secret_key(&key.key, "passw0rd", &rng));
+        for (list_item *sli = list_front(key.subkeys); sli; sli = list_next(sli)) {
             subkey = (pgp_transferable_subkey_t *) sli;
             subkey->subkey.sec_protection.symm_alg = PGP_SA_CAMELLIA_256;
             assert_rnp_success(encrypt_secret_key(&subkey->subkey, "passw0rd", &rng));
         }
         /* write changed key */
         assert_rnp_success(init_mem_dest(&keydst, keybuf, sizeof(keybuf)));
-        assert_rnp_success(write_pgp_key(key, &keydst, false));
+        assert_rnp_success(write_pgp_key(&key, &keydst, false));
         keylen = keydst.writeb;
         dst_close(&keydst, false);
         /* load and decrypt changed key */
         assert_rnp_success(init_mem_src(&keysrc, keybuf, keylen, false));
         assert_rnp_success(process_pgp_keys(&keysrc, keyseq2, false));
         src_close(&keysrc);
-        assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq2.keys));
-        assert_int_equal(key->key.sec_protection.symm_alg, PGP_SA_CAMELLIA_192);
-        assert_rnp_success(decrypt_secret_key(&key->key, "passw0rd"));
+        assert_false(keyseq2.keys.empty());
+        auto &key2 = keyseq2.keys.front();
+        assert_int_equal(key2.key.sec_protection.symm_alg, PGP_SA_CAMELLIA_192);
+        assert_rnp_success(decrypt_secret_key(&key2.key, "passw0rd"));
 
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
+        for (list_item *sli = list_front(key2.subkeys); sli; sli = list_next(sli)) {
             subkey = (pgp_transferable_subkey_t *) sli;
             assert_int_equal(subkey->subkey.sec_protection.symm_alg, PGP_SA_CAMELLIA_256);
             assert_rnp_success(decrypt_secret_key(&subkey->subkey, "passw0rd"));
         }
         /* write key without the password */
-        key->key.sec_protection.s2k.usage = PGP_S2KU_NONE;
-        assert_rnp_success(encrypt_secret_key(&key->key, NULL, NULL));
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
+        key2.key.sec_protection.s2k.usage = PGP_S2KU_NONE;
+        assert_rnp_success(encrypt_secret_key(&key2.key, NULL, NULL));
+        for (list_item *sli = list_front(key2.subkeys); sli; sli = list_next(sli)) {
             subkey = (pgp_transferable_subkey_t *) sli;
             subkey->subkey.sec_protection.s2k.usage = PGP_S2KU_NONE;
             assert_rnp_success(encrypt_secret_key(&subkey->subkey, NULL, NULL));
         }
         /* write changed key */
         assert_rnp_success(init_mem_dest(&keydst, keybuf, sizeof(keybuf)));
-        assert_rnp_success(write_pgp_key(key, &keydst, false));
+        assert_rnp_success(write_pgp_key(&key2, &keydst, false));
         keylen = keydst.writeb;
         dst_close(&keydst, false);
         /* load non-encrypted key */
         assert_rnp_success(init_mem_src(&keysrc, keybuf, keylen, false));
         assert_rnp_success(process_pgp_keys(&keysrc, keyseq2, false));
         src_close(&keysrc);
-        assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq2.keys));
-        assert_int_equal(key->key.sec_protection.s2k.usage, PGP_S2KU_NONE);
-        assert_rnp_success(decrypt_secret_key(&key->key, NULL));
+        assert_false(keyseq2.keys.empty());
+        auto &key3 = keyseq2.keys.front();
+        assert_int_equal(key3.key.sec_protection.s2k.usage, PGP_S2KU_NONE);
+        assert_rnp_success(decrypt_secret_key(&key3.key, NULL));
 
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
+        for (list_item *sli = list_front(key3.subkeys); sli; sli = list_next(sli)) {
             subkey = (pgp_transferable_subkey_t *) sli;
             assert_int_equal(subkey->subkey.sec_protection.s2k.usage, PGP_S2KU_NONE);
             assert_rnp_success(decrypt_secret_key(&subkey->subkey, NULL));
@@ -1032,8 +1031,8 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
-    assert_int_equal(list_length(keyseq.keys), 1);
-    assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
+    assert_int_equal(keyseq.keys.size(), 1);
+    assert_non_null(key = &keyseq.keys.front());
     assert_non_null(uid = (pgp_transferable_userid_t *) list_front(key->userids));
     assert_non_null(sig = (pgp_signature_t *) list_front(uid->signatures));
     assert_true(signature_get_keyid(sig, keyid));
@@ -1055,8 +1054,8 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     src_close(&keysrc);
 
     /* check key signatures */
-    for (list_item *li = list_front(keyseq.keys); li; li = list_next(li)) {
-        key = (pgp_transferable_key_t *) li;
+    for (auto &keyref : keyseq.keys) {
+        key = &keyref;
 
         for (list_item *uli = list_front(key->userids); uli; uli = list_next(uli)) {
             uid = (pgp_transferable_userid_t *) uli;

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -451,78 +451,70 @@ TEST_F(rnp_tests, test_stream_key_load)
 
     /* public keyring, read-save-read-save armored-read */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_true(list_length(keyseq.keys) > 1);
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout.gpg", true));
     assert_rnp_success(write_pgp_keys(&keyseq, &keydst, false));
     dst_close(&keydst, false);
-    key_sequence_destroy(&keyseq);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout.asc", true));
     assert_rnp_success(write_pgp_keys(&keyseq, &keydst, true));
     dst_close(&keydst, false);
-    key_sequence_destroy(&keyseq);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
-    key_sequence_destroy(&keyseq);
 
     /* secret keyring */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_true(list_length(keyseq.keys) > 1);
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout-sec.gpg", true));
     assert_rnp_success(write_pgp_keys(&keyseq, &keydst, false));
     dst_close(&keydst, false);
-    key_sequence_destroy(&keyseq);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout-sec.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
 
     assert_rnp_success(init_file_dest(&keydst, "keyout-sec.asc", true));
     assert_rnp_success(write_pgp_keys(&keyseq, &keydst, true));
     dst_close(&keydst, false);
-    key_sequence_destroy(&keyseq);
 
     assert_rnp_success(init_file_src(&keysrc, "keyout-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
-    key_sequence_destroy(&keyseq);
 
     /* armored v3 public key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_keyid(keyid, &key->key));
     assert_true(cmp_keyid(keyid, "7D0BC10E933404C9"));
     assert_false(cmp_keyid(keyid, "1D0BC10E933404C9"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* armored v3 secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-s.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_keyid(keyid, &key->key));
     assert_true(cmp_keyid(keyid, "7D0BC10E933404C9"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* rsa/rsa public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -531,12 +523,11 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyid(keyid, "2FB9179118898E8B"));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* rsa/rsa secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -545,12 +536,11 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyid(keyid, "2FB9179118898E8B"));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* dsa/el-gamal public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -559,42 +549,38 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "02A5715C3537717E"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* dsa/el-gamal secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* curve 25519 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "21FC68274AAE3B5DE39A4277CC786278981B0728"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* curve 25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 0);
     assert_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* eddsa/x25519 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -603,22 +589,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "C711187E594376AF"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* eddsa/x25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-256 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -626,22 +610,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "37E285E9E9851491"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-384 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -649,22 +631,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "E210E3D554A4FAD9"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-521 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -672,22 +652,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "9853DF2F6D297442"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-521 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* Brainpool P256 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp256-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -695,22 +673,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "2EDABB94D3055F76"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* Brainpool P256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp256-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* Brainpool P384 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp384-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -718,22 +694,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "CFF1BB6F16D28191"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* Brainpool P384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp384-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* Brainpool P512 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp512-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -741,22 +715,20 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "20CDAA1482BA79CE"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* Brainpool P512 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp512-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* secp256k1 ecc public key, not supported now */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256k1-pub.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
@@ -764,17 +736,15 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "7635401F90D3E533"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* secp256k1 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256k1-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_int_equal(list_length(key->subkeys), 1);
     assert_non_null(list_front(key->subkeys));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 }
 
@@ -789,10 +759,9 @@ buggy_key_load_single(const void *keydata, size_t keylen)
     /* try truncated load */
     for (partlen = 1; partlen < keylen; partlen += 15) {
         assert_rnp_success(init_mem_src(&memsrc, keydata, partlen, false));
-        if (!process_pgp_keys(&memsrc, &keyseq, false)) {
+        if (!process_pgp_keys(&memsrc, keyseq, false)) {
             /* it may succeed if we accidentally hit some packet boundary */
             assert_non_null(list_front(keyseq.keys));
-            key_sequence_destroy(&keyseq);
         } else {
             assert_null(list_front(keyseq.keys));
         }
@@ -804,10 +773,9 @@ buggy_key_load_single(const void *keydata, size_t keylen)
     for (partlen = 1; partlen < keylen; partlen++) {
         dataptr[partlen] ^= 0xff;
         assert_rnp_success(init_mem_src(&memsrc, keydata, keylen, false));
-        if (!process_pgp_keys(&memsrc, &keyseq, false)) {
+        if (!process_pgp_keys(&memsrc, keyseq, false)) {
             /* it may succeed if we accidentally hit some packet boundary */
             assert_non_null(list_front(keyseq.keys));
-            key_sequence_destroy(&keyseq);
         } else {
             assert_null(list_front(keyseq.keys));
         }
@@ -872,7 +840,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
 
     /* load and decrypt secret keyring */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     for (list_item *li = list_front(keyseq.keys); li; li = list_next(li)) {
         key = (pgp_transferable_key_t *) li;
         assert_rnp_failure(decrypt_secret_key(&key->key, "passw0rd"));
@@ -884,84 +852,75 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
             assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
         }
     }
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* armored v3 secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-s.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_failure(decrypt_secret_key(&key->key, "passw0rd"));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* rsa/rsa secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* dsa/el-gamal secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* curve 25519 eddsa ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* x25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 
     /* p-521 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-sec.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    key_sequence_destroy(&keyseq);
     src_close(&keysrc);
 }
 
@@ -982,7 +941,7 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
 
     /* load and decrypt secret keyring, then re-encrypt and reload keys */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
     for (list_item *li = list_front(keyseq.keys); li; li = list_next(li)) {
         key = (pgp_transferable_key_t *) li;
@@ -1008,7 +967,7 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
         dst_close(&keydst, false);
         /* load and decrypt changed key */
         assert_rnp_success(init_mem_src(&keysrc, keybuf, keylen, false));
-        assert_rnp_success(process_pgp_keys(&keysrc, &keyseq2, false));
+        assert_rnp_success(process_pgp_keys(&keysrc, keyseq2, false));
         src_close(&keysrc);
         assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq2.keys));
         assert_int_equal(key->key.sec_protection.symm_alg, PGP_SA_CAMELLIA_192);
@@ -1032,10 +991,9 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
         assert_rnp_success(write_pgp_key(key, &keydst, false));
         keylen = keydst.writeb;
         dst_close(&keydst, false);
-        key_sequence_destroy(&keyseq2);
         /* load non-encrypted key */
         assert_rnp_success(init_mem_src(&keysrc, keybuf, keylen, false));
-        assert_rnp_success(process_pgp_keys(&keysrc, &keyseq2, false));
+        assert_rnp_success(process_pgp_keys(&keysrc, keyseq2, false));
         src_close(&keysrc);
         assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq2.keys));
         assert_int_equal(key->key.sec_protection.s2k.usage, PGP_S2KU_NONE);
@@ -1046,9 +1004,7 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
             assert_int_equal(subkey->subkey.sec_protection.s2k.usage, PGP_S2KU_NONE);
             assert_rnp_success(decrypt_secret_key(&subkey->subkey, NULL));
         }
-        key_sequence_destroy(&keyseq2);
     }
-    key_sequence_destroy(&keyseq);
     rng_destroy(&rng);
 }
 
@@ -1074,7 +1030,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     pubring = new rnp_key_store_t(PGP_KEY_STORE_GPG, "data/keyrings/4/rsav3-p.asc");
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
     assert_int_equal(list_length(keyseq.keys), 1);
     assert_non_null(key = (pgp_transferable_key_t *) list_front(keyseq.keys));
@@ -1090,13 +1046,12 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     assert_true(signature_hash_certification(sig, &key->key, &uid->uid, &hash));
     assert_rnp_failure(signature_validate(sig, pgp_key_get_material(pkey), &hash));
     delete pubring;
-    key_sequence_destroy(&keyseq);
 
     /* keyring */
     pubring = new rnp_key_store_t(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
-    assert_rnp_success(process_pgp_keys(&keysrc, &keyseq, false));
+    assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     src_close(&keysrc);
 
     /* check key signatures */
@@ -1147,7 +1102,6 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     }
 
     delete pubring;
-    key_sequence_destroy(&keyseq);
     rng_destroy(&rng);
 }
 

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -521,8 +521,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyfp(keyfp, "6BC04A5A3DDB35766B9A40D82FB9179118898E8B"));
     assert_rnp_success(pgp_keyid(keyid, &key->key));
     assert_true(cmp_keyid(keyid, "2FB9179118898E8B"));
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* rsa/rsa secret key */
@@ -534,8 +534,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyfp(keyfp, "6BC04A5A3DDB35766B9A40D82FB9179118898E8B"));
     assert_rnp_success(pgp_keyid(keyid, &key->key));
     assert_true(cmp_keyid(keyid, "2FB9179118898E8B"));
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* dsa/el-gamal public key */
@@ -545,8 +545,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "091C44CE9CFBC3FF7EC7A64DC8A10A7D78273E10"));
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "02A5715C3537717E"));
     src_close(&keysrc);
@@ -556,8 +556,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* curve 25519 ecc public key */
@@ -574,8 +574,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 0);
-    assert_null(list_front(key->subkeys));
+    assert_true(key->subkeys.empty());
     src_close(&keysrc);
 
     /* eddsa/x25519 ecc public key */
@@ -585,8 +584,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "4C9738A6F2BE4E1A796C9B7B941822A0FC1B30A5"));
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "C711187E594376AF"));
     src_close(&keysrc);
@@ -596,8 +595,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* p-256 ecc public key */
@@ -607,7 +606,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "B54FDEBBB673423A5D0AA54423674F21B2441527"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "37E285E9E9851491"));
     src_close(&keysrc);
@@ -617,8 +616,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* p-384 ecc public key */
@@ -628,7 +627,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "AB25CBA042DD924C3ACC3ED3242A3AA5EA85F44A"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "E210E3D554A4FAD9"));
     src_close(&keysrc);
@@ -638,8 +637,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* p-521 ecc public key */
@@ -649,7 +648,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "4FB39FF6FA4857A4BD7EF5B42092CA8324263B6A"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "9853DF2F6D297442"));
     src_close(&keysrc);
@@ -659,8 +658,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* Brainpool P256 ecc public key */
@@ -670,7 +669,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "0633C5F72A198F51E650E4ABD0C8A3DAF9E0634A"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "2EDABB94D3055F76"));
     src_close(&keysrc);
@@ -680,8 +679,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* Brainpool P384 ecc public key */
@@ -691,7 +690,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "5B8A254C823CED98DECD10ED6CF2DCE85599ADA2"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "CFF1BB6F16D28191"));
     src_close(&keysrc);
@@ -701,8 +700,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* Brainpool P512 ecc public key */
@@ -712,7 +711,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "4C59AB9272AA6A1F60B85BD0AA5C58D14F7B8F48"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "20CDAA1482BA79CE"));
     src_close(&keysrc);
@@ -722,8 +721,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 
     /* secp256k1 ecc public key, not supported now */
@@ -733,7 +732,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, &key->key));
     assert_true(cmp_keyfp(keyfp, "81F772B57D4EBFE7000A66233EA5BB6F9692C1A0"));
-    assert_non_null(skey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, &skey->subkey));
     assert_true(cmp_keyid(keyid, "7635401F90D3E533"));
     src_close(&keysrc);
@@ -743,8 +742,8 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
-    assert_int_equal(list_length(key->subkeys), 1);
-    assert_non_null(list_front(key->subkeys));
+    assert_int_equal(key->subkeys.size(), 1);
+    assert_non_null(key->subkeys[0].subkey.hashed_data);
     src_close(&keysrc);
 }
 
@@ -845,10 +844,9 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
         assert_rnp_failure(decrypt_secret_key(&key.key, "passw0rd"));
         assert_rnp_success(decrypt_secret_key(&key.key, "password"));
 
-        for (list_item *sli = list_front(key.subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            assert_rnp_failure(decrypt_secret_key(&subkey->subkey, "passw0rd"));
-            assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
+        for (auto &subkey : key.subkeys) {
+            assert_rnp_failure(decrypt_secret_key(&subkey.subkey, "passw0rd"));
+            assert_rnp_success(decrypt_secret_key(&subkey.subkey, "password"));
         }
     }
     src_close(&keysrc);
@@ -866,7 +864,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
     src_close(&keysrc);
 
@@ -875,7 +873,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
     src_close(&keysrc);
 
@@ -891,7 +889,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
     src_close(&keysrc);
 
@@ -900,7 +898,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
     src_close(&keysrc);
 
@@ -909,7 +907,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
     src_close(&keysrc);
 
@@ -918,7 +916,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(process_pgp_keys(&keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    assert_non_null(subkey = (pgp_transferable_subkey_t *) list_front(key->subkeys));
+    assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
     src_close(&keysrc);
 }
@@ -931,7 +929,6 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
     size_t                     keylen;
     pgp_key_sequence_t         keyseq;
     pgp_key_sequence_t         keyseq2;
-    pgp_transferable_subkey_t *subkey = NULL;
     rng_t                      rng;
 
     /* we need rng for key encryption */
@@ -944,18 +941,16 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
     for (auto &key : keyseq.keys) {
         assert_rnp_success(decrypt_secret_key(&key.key, "password"));
 
-        for (list_item *sli = list_front(key.subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
+        for (auto &subkey : key.subkeys) {
+            assert_rnp_success(decrypt_secret_key(&subkey.subkey, "password"));
         }
 
         /* change password and encryption algorithm */
         key.key.sec_protection.symm_alg = PGP_SA_CAMELLIA_192;
         assert_rnp_success(encrypt_secret_key(&key.key, "passw0rd", &rng));
-        for (list_item *sli = list_front(key.subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            subkey->subkey.sec_protection.symm_alg = PGP_SA_CAMELLIA_256;
-            assert_rnp_success(encrypt_secret_key(&subkey->subkey, "passw0rd", &rng));
+        for (auto &subkey : key.subkeys) {
+            subkey.subkey.sec_protection.symm_alg = PGP_SA_CAMELLIA_256;
+            assert_rnp_success(encrypt_secret_key(&subkey.subkey, "passw0rd", &rng));
         }
         /* write changed key */
         assert_rnp_success(init_mem_dest(&keydst, keybuf, sizeof(keybuf)));
@@ -971,18 +966,16 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
         assert_int_equal(key2.key.sec_protection.symm_alg, PGP_SA_CAMELLIA_192);
         assert_rnp_success(decrypt_secret_key(&key2.key, "passw0rd"));
 
-        for (list_item *sli = list_front(key2.subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            assert_int_equal(subkey->subkey.sec_protection.symm_alg, PGP_SA_CAMELLIA_256);
-            assert_rnp_success(decrypt_secret_key(&subkey->subkey, "passw0rd"));
+        for (auto &subkey : key2.subkeys) {
+            assert_int_equal(subkey.subkey.sec_protection.symm_alg, PGP_SA_CAMELLIA_256);
+            assert_rnp_success(decrypt_secret_key(&subkey.subkey, "passw0rd"));
         }
         /* write key without the password */
         key2.key.sec_protection.s2k.usage = PGP_S2KU_NONE;
         assert_rnp_success(encrypt_secret_key(&key2.key, NULL, NULL));
-        for (list_item *sli = list_front(key2.subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            subkey->subkey.sec_protection.s2k.usage = PGP_S2KU_NONE;
-            assert_rnp_success(encrypt_secret_key(&subkey->subkey, NULL, NULL));
+        for (auto &subkey : key2.subkeys) {
+            subkey.subkey.sec_protection.s2k.usage = PGP_S2KU_NONE;
+            assert_rnp_success(encrypt_secret_key(&subkey.subkey, NULL, NULL));
         }
         /* write changed key */
         assert_rnp_success(init_mem_dest(&keydst, keybuf, sizeof(keybuf)));
@@ -998,10 +991,9 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
         assert_int_equal(key3.key.sec_protection.s2k.usage, PGP_S2KU_NONE);
         assert_rnp_success(decrypt_secret_key(&key3.key, NULL));
 
-        for (list_item *sli = list_front(key3.subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            assert_int_equal(subkey->subkey.sec_protection.s2k.usage, PGP_S2KU_NONE);
-            assert_rnp_success(decrypt_secret_key(&subkey->subkey, NULL));
+        for (auto &subkey : key3.subkeys) {
+            assert_int_equal(subkey.subkey.sec_protection.s2k.usage, PGP_S2KU_NONE);
+            assert_rnp_success(decrypt_secret_key(&subkey.subkey, NULL));
         }
     }
     rng_destroy(&rng);
@@ -1013,7 +1005,6 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     pgp_source_t               keysrc = {0};
     pgp_key_sequence_t         keyseq;
     pgp_transferable_key_t *   key = NULL;
-    pgp_transferable_subkey_t *subkey = NULL;
     pgp_transferable_userid_t *uid = NULL;
     rng_t                      rng;
     pgp_signature_t *          sig;
@@ -1080,18 +1071,17 @@ TEST_F(rnp_tests, test_stream_key_signatures)
         }
 
         /* subkey binding signatures */
-        for (list_item *sli = list_front(key->subkeys); sli; sli = list_next(sli)) {
-            subkey = (pgp_transferable_subkey_t *) sli;
-            sig = (pgp_signature_t *) list_front(subkey->signatures);
+        for (auto &subkey: key->subkeys) {
+            sig = (pgp_signature_t *) list_front(subkey.signatures);
             assert_non_null(sig);
             assert_true(signature_get_keyid(sig, keyid));
             assert_non_null(pkey = rnp_key_store_get_key_by_id(pubring, keyid, NULL));
             /* high level interface */
             sinfo.sig = sig;
             sinfo.signer = pkey;
-            assert_rnp_success(signature_check_binding(&sinfo, &key->key, &subkey->subkey));
+            assert_rnp_success(signature_check_binding(&sinfo, &key->key, &subkey.subkey));
             /* low level check */
-            assert_true(signature_hash_binding(sig, &key->key, &subkey->subkey, &hash));
+            assert_true(signature_hash_binding(sig, &key->key, &subkey.subkey, &hash));
             assert_rnp_success(signature_validate(sig, pgp_key_get_material(pkey), &hash));
         }
     }

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -371,7 +371,6 @@ TEST_F(rnp_tests, test_stream_signatures)
     /* check forged file */
     assert_true(pgp_hash_copy(&hash, &hash_forged));
     assert_rnp_failure(signature_validate(&sig, pgp_key_get_material(key), &hash));
-    free_signature(&sig);
     /* now let's create signature and sign file */
 
     /* load secret key */
@@ -382,7 +381,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     /* fill signature */
     uint32_t create = time(NULL);
     uint32_t expire = 123456;
-    memset(&sig, 0, sizeof(sig));
+    sig = {};
     sig.version = PGP_V4;
     sig.halg = halg;
     sig.palg = pgp_key_get_alg(key);
@@ -410,7 +409,6 @@ TEST_F(rnp_tests, test_stream_signatures)
     assert_true(signature_get_keyfp(&sig, fp));
     assert_true(fp == pgp_key_get_fp(key));
     assert_rnp_success(signature_validate(&sig, pgp_key_get_material(key), &hash));
-    free_signature(&sig);
     /* cleanup */
     delete pubring;
     delete secring;
@@ -421,7 +419,7 @@ TEST_F(rnp_tests, test_stream_signatures)
 
 TEST_F(rnp_tests, test_stream_signatures_revoked_key)
 {
-    pgp_signature_t sig = {(pgp_version_t) 0};
+    pgp_signature_t sig = {};
     pgp_source_t    sigsrc = {0};
 
     /* load signature */
@@ -439,7 +437,6 @@ TEST_F(rnp_tests, test_stream_signatures_revoked_key)
     assert_string_equal(reason, "For testing!");
     /* cleanup */
     free(reason);
-    free_signature(&sig);
 }
 
 TEST_F(rnp_tests, test_stream_key_load)


### PR DESCRIPTION
This PR is aimed to (at least partially) fix issue #1181 
It includes the following changes:
- use pointer to signature instead of static field for embedded signature subpacket (effectively reducing pgp_sig_subpkt_t size).
- parse signature material to corresponding structure only on validation: this would not add much time overhead, but save a bunch of kilobytes for the each signature
- use std::vector instead of list for signatures/signature subpackets, reducing memory allocations and fragmentation