### PR TITLE
When we're compiling for AFL, use C++'s stdlib because AFL's library uses C++ code

### DIFF
--- a/src/fuzzing/CMakeLists.txt
+++ b/src/fuzzing/CMakeLists.txt
@@ -27,7 +27,11 @@ if(NOT DEFINED ENV{LIB_FUZZING_ENGINE})
   add_compile_options(-fsanitize=fuzzer-no-link)
   add_link_options(-fsanitize=fuzzer)
 else()
+  # This section is used by OSS-Fuzz
   add_link_options($ENV{LIB_FUZZING_ENGINE})
+  if($ENV{FUZZING_ENGINE} STREQUAL "afl")
+    link_libraries(-stdlib=libc++)
+  endif()
 endif()
 
 add_executable(fuzz_dump dump.c)


### PR DESCRIPTION
This commit will allow us to use the AFL driver on OSS-Fuzz