### PR TITLE
Memory leak from unknown pk algo

### DIFF
--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -1189,7 +1189,7 @@ stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_t *pkey)
         break;
     default:
         RNP_LOG("unknown pk alg %d", (int) pkey->alg);
-        return RNP_ERROR_BAD_FORMAT;
+        goto finish;
     }
 
     if (pkt.pos < pkt.len) {


### PR DESCRIPTION
```
=================================================================
==1==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 245 byte(s) in 1 object(s) allocated from:
    #0 0x51e1bd in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x7fae0309f210 in stream_read_packet_body(pgp_source_t*, pgp_packet_body_t*) /src/rnp/src/librepgp/stream-packet.cpp:681:36
    #2 0x7fae030a6434 in stream_parse_pk_sesskey(pgp_source_t*, pgp_pk_sesskey_t*) /src/rnp/src/librepgp/stream-packet.cpp:1115:16
    #3 0x7fae03067daa in stream_dump_pk_session_key(rnp_dump_ctx_t*, pgp_source_t*, pgp_dest_t*) /src/rnp/src/librepgp/stream-dump.cpp:918:16
    #4 0x7fae03062cf0 in stream_dump_packets_raw(rnp_dump_ctx_t*, pgp_source_t*, pgp_dest_t*) /src/rnp/src/librepgp/stream-dump.cpp:1215:19
    #5 0x7fae030619a3 in stream_dump_packets(rnp_dump_ctx_t*, pgp_source_t*, pgp_dest_t*) /src/rnp/src/librepgp/stream-dump.cpp:1323:11
    #6 0x7fae0327682d in rnp_dump_packets_to_output /src/rnp/src/lib/rnp.cpp:7217:24
    #7 0x5506f8 in LLVMFuzzerTestOneInput /src/rnp/src/fuzzing/dump.c:53:11
    #8 0x457da1 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:558:15
    #9 0x4574e5 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:470:3
    #10 0x459487 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:770:7
    #11 0x459689 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:799:3
    #12 0x4493c5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:846:6
    #13 0x470f62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19:10
    #14 0x7fae0024082f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/libc-start.c:291

SUMMARY: AddressSanitizer: 245 byte(s) leaked in 1 allocation(s).
```

In [stream_parse_pk_sesskey](https://github.com/rnpgp/rnp/blob/8b47ff7877045b2b209d4a206e01d46b8b3bdf71/src/librepgp/stream-packet.cpp#L1103), we allocate pkt->data in [stream_read_packet_body](https://github.com/rnpgp/rnp/blob/8b47ff7877045b2b209d4a206e01d46b8b3bdf71/src/librepgp/stream-packet.cpp#L681) (called [here](https://github.com/rnpgp/rnp/blob/8b47ff7877045b2b209d4a206e01d46b8b3bdf71/src/librepgp/stream-packet.cpp#L1115).) But when an unknown pk algo is specified, [we do an early return](https://github.com/rnpgp/rnp/blob/8b47ff7877045b2b209d4a206e01d46b8b3bdf71/src/librepgp/stream-packet.cpp#L1192) instead of free-ing the memory.