### PR TITLE
Add missing move constructor for pgp_transferable_userid_t.

### DIFF
--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1391,6 +1391,14 @@ pgp_transferable_userid_t::pgp_transferable_userid_t(const pgp_transferable_user
     signatures = src.signatures;
 }
 
+pgp_transferable_userid_t::pgp_transferable_userid_t(pgp_transferable_userid_t &&src)
+{
+    free_userid_pkt(&uid);
+    uid = src.uid;
+    src.uid = {};
+    signatures = src.signatures;
+}
+
 pgp_transferable_userid_t &
 pgp_transferable_userid_t::operator=(const pgp_transferable_userid_t &src)
 {

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -41,7 +41,7 @@ typedef struct pgp_transferable_userid_t {
 
     pgp_transferable_userid_t() : uid({}){};
     pgp_transferable_userid_t(const pgp_transferable_userid_t &src);
-    pgp_transferable_userid_t(pgp_transferable_userid_t &&src) = delete;
+    pgp_transferable_userid_t(pgp_transferable_userid_t &&src);
     pgp_transferable_userid_t &operator=(pgp_transferable_userid_t &&src);
     pgp_transferable_userid_t &operator=(const pgp_transferable_userid_t &src);
     ~pgp_transferable_userid_t();


### PR DESCRIPTION
This is attempt to fix issues #1249 and #1244.
Since it is not reflected in our CI yet, it needs a confirmation.