### PR TITLE
Refactor packets to c++

### DIFF
--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -555,8 +555,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
          pgp_subkey_refresh_data(subkey_sec, primary_sec);
 end:
     if (decrypted_primary_seckey) {
-        free_key_pkt(decrypted_primary_seckey);
-        free(decrypted_primary_seckey);
+        delete decrypted_primary_seckey;
     }
     return ok;
 }

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -133,7 +133,13 @@ load_generated_g10_key(pgp_key_t *    dst,
     // if a primary key is provided, it should match the sub with regards to type
     assert(!primary_key ||
            (pgp_key_is_secret(primary_key) == pgp_key_is_secret(&key_store->keys.front())));
-    ok = !pgp_key_copy(*dst, key_store->keys.front(), false);
+    try {
+        *dst = pgp_key_t(key_store->keys.front());
+        ok = true;
+    } catch (const std::exception &e) {
+        RNP_LOG("Failed to copy key: %s", e.what());
+        ok = false;
+    }
 end:
     delete key_store;
     src_close(&memsrc);

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -350,8 +350,8 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
                          pgp_key_store_format_t     secformat)
 {
     bool                       ok = false;
-    pgp_transferable_key_t     tkeysec = {};
-    pgp_transferable_key_t     tkeypub = {};
+    pgp_transferable_key_t     tkeysec;
+    pgp_transferable_key_t     tkeypub;
     pgp_transferable_userid_t *uid = NULL;
 
     // validate args
@@ -390,8 +390,10 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
         goto end;
     }
 
-    if (!transferable_key_copy(tkeypub, tkeysec, true)) {
-        RNP_LOG("failed to copy public key part");
+    try {
+        tkeypub = pgp_transferable_key_t(tkeysec, true);
+    } catch (const std::exception &e) {
+        RNP_LOG("failed to copy public key part: %s", e.what());
         goto end;
     }
 
@@ -463,8 +465,8 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
                     const pgp_password_provider_t *password_provider,
                     pgp_key_store_format_t         secformat)
 {
-    pgp_transferable_subkey_t tskeysec = {};
-    pgp_transferable_subkey_t tskeypub = {};
+    pgp_transferable_subkey_t tskeysec;
+    pgp_transferable_subkey_t tskeypub;
     const pgp_key_pkt_t *     primary_seckey = NULL;
     pgp_key_pkt_t *           decrypted_primary_seckey = NULL;
     pgp_password_ctx_t        ctx = {};

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -190,7 +190,7 @@ pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt)
 {
     try {
         pgp_key_pkt_t keypkt = *pkt;
-        *key = {};
+        *key = pgp_key_t();
 
         /* parse secret key if not encrypted */
         if (is_secret_key_pkt(keypkt.tag)) {
@@ -1683,7 +1683,7 @@ pgp_key_add_userid_certified(pgp_key_t *              key,
     }
 
     /* Fill the transferable userid */
-    pgp_transferable_userid_t uid = {};
+    pgp_transferable_userid_t uid;
     uid.uid.tag = PGP_PKT_USER_ID;
     uid.uid.uid_len = strlen((char *) cert->userid);
     if (!(uid.uid.uid = (uint8_t *) malloc(uid.uid.uid_len))) {
@@ -1747,7 +1747,7 @@ pgp_key_set_expiration(pgp_key_t *                    key,
         RNP_LOG("Failed to unlock secret key");
         return false;
     }
-    pgp_signature_t newsig = {};
+    pgp_signature_t newsig;
     bool            res = false;
     if (!update_sig_expiration(&newsig, &subsig->sig, expiry)) {
         goto done;
@@ -1815,7 +1815,7 @@ pgp_subkey_set_expiration(pgp_key_t *                    sub,
         RNP_LOG("Failed to unlock primary key");
         return false;
     }
-    pgp_signature_t newsig = {};
+    pgp_signature_t newsig;
     bool            sublocked = false;
     if (subsign && pgp_key_is_locked(secsub)) {
         if (!pgp_key_unlock(secsub, prov)) {

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -858,7 +858,7 @@ pgp_key_latest_selfsig(pgp_key_t *key, pgp_sig_subpacket_type_t subpkt)
     return res;
 }
 
-pgp_subsig_t *
+static pgp_subsig_t *
 pgp_key_latest_uid_selfcert(pgp_key_t *key, uint32_t uid)
 {
     uint32_t      latest = 0;

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -2307,9 +2307,7 @@ pgp_subsig_t::~pgp_subsig_t()
 
 pgp_userid_t::pgp_userid_t(const pgp_userid_t &src)
 {
-    if (!copy_userid_pkt(&pkt, &src.pkt)) {
-        throw std::bad_alloc();
-    }
+    pkt = src.pkt;
     rawpkt = src.rawpkt;
     str = src.str;
 }
@@ -2317,8 +2315,7 @@ pgp_userid_t::pgp_userid_t(const pgp_userid_t &src)
 pgp_userid_t::pgp_userid_t(pgp_userid_t &&src)
 {
     str = std::move(src.str);
-    pkt = src.pkt;
-    src.pkt = {};
+    pkt = std::move(src.pkt);
     rawpkt = std::move(src.rawpkt);
 }
 
@@ -2328,11 +2325,7 @@ pgp_userid_t::operator=(const pgp_userid_t &src)
     if (&src == this) {
         return *this;
     }
-
-    free_userid_pkt(&pkt);
-    if (!copy_userid_pkt(&pkt, &src.pkt)) {
-        throw std::bad_alloc();
-    }
+    pkt = src.pkt;
     rawpkt = src.rawpkt;
     str = src.str;
     return *this;
@@ -2340,7 +2333,6 @@ pgp_userid_t::operator=(const pgp_userid_t &src)
 
 pgp_userid_t::~pgp_userid_t()
 {
-    free_userid_pkt(&pkt);
 }
 
 pgp_key_t::~pgp_key_t()

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -2119,10 +2119,6 @@ pgp_rawpacket_t::pgp_rawpacket_t(const pgp_userid_pkt_t &uid)
     tag = uid.tag;
 }
 
-pgp_rawpacket_t::~pgp_rawpacket_t()
-{
-}
-
 pgp_subsig_t::pgp_subsig_t(const pgp_subsig_t &src)
 {
     uid = src.uid;
@@ -2198,36 +2194,6 @@ pgp_subsig_t::operator=(const pgp_subsig_t &src)
 pgp_subsig_t::~pgp_subsig_t()
 {
     pgp_free_user_prefs(&prefs);
-}
-
-pgp_userid_t::pgp_userid_t(const pgp_userid_t &src)
-{
-    pkt = src.pkt;
-    rawpkt = src.rawpkt;
-    str = src.str;
-}
-
-pgp_userid_t::pgp_userid_t(pgp_userid_t &&src)
-{
-    str = std::move(src.str);
-    pkt = std::move(src.pkt);
-    rawpkt = std::move(src.rawpkt);
-}
-
-pgp_userid_t &
-pgp_userid_t::operator=(const pgp_userid_t &src)
-{
-    if (&src == this) {
-        return *this;
-    }
-    pkt = src.pkt;
-    rawpkt = src.rawpkt;
-    str = src.str;
-    return *this;
-}
-
-pgp_userid_t::~pgp_userid_t()
-{
 }
 
 pgp_key_t::pgp_key_t(const pgp_key_t &src, bool pubonly)

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -84,11 +84,10 @@ struct pgp_key_t {
     bool                   valid;        /* this key is valid and usable */
     bool                   validated;    /* this key was validated */
 
-    ~pgp_key_t();
     pgp_key_t() = default;
+    pgp_key_t(const pgp_key_t &src, bool pubonly = false);
     pgp_key_t &operator=(pgp_key_t &&);
     /* make sure we use only empty constructor/move operator */
-    pgp_key_t(const pgp_key_t &src) = delete;
     pgp_key_t(pgp_key_t &&src) = delete;
     pgp_key_t &operator=(const pgp_key_t &) = delete;
 };
@@ -101,27 +100,6 @@ struct pgp_key_t {
  * @return true if operation succeeded or false otherwise.
  */
 bool pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt);
-
-/**
- * @brief Copy key, optionally copying only the public key part.
- *
- * @param dst destination of copying
- * @param src source key
- * @param public if true then only public key fields will be copied, i.e. key converted from
- *               secret to public
- * @return RNP_SUCCESS if operation succeeded or error code otherwise
- */
-rnp_result_t pgp_key_copy(pgp_key_t &dst, const pgp_key_t &src, bool pubonly);
-
-/**
- * @brief Copy calculated key fields (grip, userid list, etc). Does not copy key packet/raw
- *        packets. Zeroes dst so should not be used with pre-filled objects.
- *
- * @param dst destination of copying
- * @param src source key
- * @return RNP_SUCCESS if operation succeeded or error code otherwise
- */
-rnp_result_t pgp_key_copy_fields(pgp_key_t &dst, const pgp_key_t &src);
 
 void pgp_free_user_prefs(pgp_user_prefs_t *prefs);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1196,8 +1196,11 @@ do_load_keys(rnp_ffi_t              ffi,
             continue;
         }
 
-        if ((tmpret = pgp_key_copy(keycp, key, true))) {
-            ret = tmpret;
+        try {
+            keycp = pgp_key_t(key, true);
+        } catch (const std::exception &e) {
+            RNP_LOG("Failed to copy public key part: %s", e.what());
+            ret = RNP_ERROR_GENERIC;
             goto done;
         }
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1151,7 +1151,7 @@ do_load_keys(rnp_ffi_t              ffi,
 {
     rnp_result_t     ret = RNP_ERROR_GENERIC;
     rnp_key_store_t *tmp_store = NULL;
-    pgp_key_t        keycp = {};
+    pgp_key_t        keycp;
     rnp_result_t     tmpret;
 
     // create a temporary key store to hold the keys
@@ -4369,10 +4369,10 @@ try {
     rnp_action_keygen_t keygen_desc = {};
     char *              identifier_type = NULL;
     char *              identifier = NULL;
-    pgp_key_t           primary_pub = {};
-    pgp_key_t           primary_sec = {};
-    pgp_key_t           sub_pub = {};
-    pgp_key_t           sub_sec = {};
+    pgp_key_t           primary_pub;
+    pgp_key_t           primary_sec;
+    pgp_key_t           sub_pub;
+    pgp_key_t           sub_sec;
     json_object *       jsoprimary = NULL;
     json_object *       jsosub = NULL;
     json_tokener_error  error;
@@ -5242,8 +5242,8 @@ try {
     }
 
     rnp_result_t            ret = RNP_ERROR_GENERIC;
-    pgp_key_t               pub = {};
-    pgp_key_t               sec = {};
+    pgp_key_t               pub;
+    pgp_key_t               sec;
     pgp_password_provider_t prov = {.callback = NULL};
 
     if (op->primary) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -5507,8 +5507,7 @@ try {
 
     ret = RNP_SUCCESS;
 done:
-    free_key_pkt(decrypted_seckey);
-    free(decrypted_seckey);
+    delete decrypted_seckey;
     return ret;
 }
 FFI_GUARD
@@ -6427,8 +6426,7 @@ try {
     ret = RNP_SUCCESS;
 
 done:
-    free_key_pkt(decrypted_seckey);
-    free(decrypted_seckey);
+    delete decrypted_seckey;
     return ret;
 }
 FFI_GUARD

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -190,6 +190,13 @@ typedef struct pgp_key_pkt_t {
     pgp_key_protection_t sec_protection;
     uint8_t *            sec_data;
     size_t               sec_len;
+
+    pgp_key_pkt_t();
+    pgp_key_pkt_t(const pgp_key_pkt_t &src, bool pubonly = false);
+    pgp_key_pkt_t(pgp_key_pkt_t &&src);
+    pgp_key_pkt_t &operator=(pgp_key_pkt_t &&src);
+    pgp_key_pkt_t &operator=(const pgp_key_pkt_t &src);
+    ~pgp_key_pkt_t();
 } pgp_key_pkt_t;
 
 typedef struct pgp_key_t pgp_key_t;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -208,6 +208,15 @@ typedef struct pgp_userid_pkt_t {
     pgp_pkt_type_t tag;
     uint8_t *      uid;
     size_t         uid_len;
+
+    pgp_userid_pkt_t() : tag(PGP_PKT_RESERVED), uid(NULL), uid_len(0){};
+    pgp_userid_pkt_t(const pgp_userid_pkt_t &src);
+    pgp_userid_pkt_t(pgp_userid_pkt_t &&src);
+    pgp_userid_pkt_t &operator=(pgp_userid_pkt_t &&src);
+    pgp_userid_pkt_t &operator=(const pgp_userid_pkt_t &src);
+    bool              operator==(const pgp_userid_pkt_t &src) const;
+    bool              operator!=(const pgp_userid_pkt_t &src) const;
+    ~pgp_userid_pkt_t();
 } pgp_userid_pkt_t;
 
 typedef struct pgp_signature_t pgp_signature_t;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -357,7 +357,6 @@ typedef struct pgp_rawpacket_t {
     pgp_rawpacket_t(const pgp_signature_t &sig);
     pgp_rawpacket_t(pgp_key_pkt_t &key);
     pgp_rawpacket_t(const pgp_userid_pkt_t &uid);
-    ~pgp_rawpacket_t();
 } pgp_rawpacket_t;
 
 typedef enum {
@@ -470,15 +469,6 @@ typedef struct pgp_userid_t {
     pgp_userid_pkt_t pkt;    /* User ID or User Attribute packet as it was loaded */
     pgp_rawpacket_t  rawpkt; /* Raw packet contents */
     std::string      str;    /* Human-readable representation of the userid */
-
-    pgp_userid_t() = default;
-    pgp_userid_t(const pgp_userid_t &src);
-    pgp_userid_t(pgp_userid_t &&src);
-    pgp_userid_t &operator=(const pgp_userid_t &src);
-    ~pgp_userid_t();
-
-    /* make sure we use only explicitly defined constructors/operators */
-    pgp_userid_t &operator=(pgp_userid_t &&) = delete;
 } pgp_userid_t;
 
 struct rnp_keygen_ecc_params_t {

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1132,14 +1132,9 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
             goto done;
         }
 
-        if (pgp_key_copy_fields(key, *pubkey)) {
-            RNP_LOG("failed to copy key fields");
-            goto done;
-        }
-
         /* public key packet has some more info then the secret part */
         try {
-            key.pkt = *pgp_key_get_pkt(pubkey);
+            key = pgp_key_t(*pubkey, true);
         } catch (const std::exception &e) {
             RNP_LOG("%s", e.what());
             goto done;

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1035,7 +1035,7 @@ g10_parse_seckey(pgp_key_pkt_t *seckey,
 done:
     destroy_s_exp(&s_exp);
     if (!ret) {
-        *seckey = {};
+        *seckey = pgp_key_pkt_t();
     }
     return ret;
 }
@@ -1100,8 +1100,8 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
                            const pgp_key_provider_t *key_provider)
 {
     const pgp_key_t *pubkey = NULL;
-    pgp_key_t        key = {};
-    pgp_key_pkt_t    seckey = {};
+    pgp_key_t        key;
+    pgp_key_pkt_t    seckey;
     pgp_source_t     memsrc = {};
     bool             ret = false;
 

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -99,7 +99,7 @@ rnp_key_store_add_transferable_subkey(rnp_key_store_t *          keyring,
                                       pgp_transferable_subkey_t *tskey,
                                       pgp_key_t *                pkey)
 {
-    pgp_key_t skey = {};
+    pgp_key_t skey;
 
     /* create subkey */
     if (!rnp_key_from_transferable_subkey(&skey, tskey, pkey)) {
@@ -152,7 +152,7 @@ rnp_key_add_transferable_userid(pgp_key_t *key, pgp_transferable_userid_t *uid)
 bool
 rnp_key_store_add_transferable_key(rnp_key_store_t *keyring, pgp_transferable_key_t *tkey)
 {
-    pgp_key_t  key = {};
+    pgp_key_t  key;
     pgp_key_t *addkey = NULL;
 
     /* create key from transferable key */
@@ -192,7 +192,7 @@ error:
 bool
 rnp_key_from_transferable_key(pgp_key_t *key, pgp_transferable_key_t *tkey)
 {
-    *key = {};
+    *key = pgp_key_t();
     /* create key */
     if (!pgp_key_from_pkt(key, &tkey->key)) {
         return false;
@@ -218,7 +218,7 @@ rnp_key_from_transferable_subkey(pgp_key_t *                subkey,
                                  pgp_transferable_subkey_t *tskey,
                                  pgp_key_t *                primary)
 {
-    *subkey = {};
+    *subkey = pgp_key_t();
 
     /* create key */
     if (!pgp_key_from_pkt(subkey, &tskey->subkey)) {

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -246,7 +246,7 @@ rnp_key_store_pgp_read_from_src(rnp_key_store_t *keyring, pgp_source_t *src)
 
     /* check whether we have transferable subkey in source */
     if (is_subkey_pkt(stream_pkt_type(src))) {
-        pgp_transferable_subkey_t tskey = {};
+        pgp_transferable_subkey_t tskey;
         ret = process_pgp_subkey(*src, tskey, keyring->skip_parsing_errors);
         if (ret) {
             return ret;

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -139,16 +139,14 @@ rnp_key_add_transferable_userid(pgp_key_t *key, pgp_transferable_userid_t *uid)
         return false;
     }
 
-    if (!copy_userid_pkt(&userid->pkt, &uid->uid)) {
-        RNP_LOG("failed to copy user id pkt");
+    try {
+        userid->pkt = uid->uid;
+    } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
         return false;
     }
 
-    if (!rnp_key_add_signatures(key, uid->signatures)) {
-        return false;
-    }
-
-    return true;
+    return rnp_key_add_signatures(key, uid->signatures);
 }
 
 bool

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -240,9 +240,9 @@ rnp_key_store_get_key_count(const rnp_key_store_t *keyring)
 static bool
 rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *primary)
 {
-    pgp_transferable_subkey_t dstkey = {};
-    pgp_transferable_subkey_t srckey = {};
-    pgp_key_t                 tmpkey = {};
+    pgp_transferable_subkey_t dstkey;
+    pgp_transferable_subkey_t srckey;
+    pgp_key_t                 tmpkey;
 
     if (!pgp_key_is_subkey(dst) || !pgp_key_is_subkey(src)) {
         RNP_LOG("wrong subkey merge call");

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -298,9 +298,9 @@ rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *prim
 static bool
 rnp_key_store_merge_key(pgp_key_t *dst, const pgp_key_t *src)
 {
-    pgp_transferable_key_t dstkey = {};
-    pgp_transferable_key_t srckey = {};
-    pgp_key_t              tmpkey = {};
+    pgp_transferable_key_t dstkey;
+    pgp_transferable_key_t srckey;
+    pgp_key_t              tmpkey;
 
     if (pgp_key_is_subkey(dst) || pgp_key_is_subkey(src)) {
         RNP_LOG("wrong key merge call");
@@ -526,7 +526,7 @@ rnp_key_store_import_key(rnp_key_store_t *        keyring,
                          bool                     pubkey,
                          pgp_key_import_status_t *status)
 {
-    pgp_key_t  keycp = {};
+    pgp_key_t  keycp;
     pgp_key_t *exkey = NULL;
     size_t     expackets = 0;
     bool       changed = false;
@@ -595,7 +595,7 @@ rnp_key_store_import_subkey_signature(rnp_key_store_t *      keyring,
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;
     }
 
-    pgp_key_t tmpkey = {};
+    pgp_key_t tmpkey;
     if (!pgp_key_from_pkt(&tmpkey, &key->pkt) || !rnp_key_add_signature(&tmpkey, sig) ||
         !pgp_subkey_refresh_data(&tmpkey, primary)) {
         RNP_LOG("Failed to add signature to the key.");
@@ -626,7 +626,7 @@ rnp_key_store_import_key_signature(rnp_key_store_t *      keyring,
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;
     }
 
-    pgp_key_t tmpkey = {};
+    pgp_key_t tmpkey;
     if (!pgp_key_from_pkt(&tmpkey, &key->pkt) || !rnp_key_add_signature(&tmpkey, sig) ||
         !pgp_key_refresh_data(&tmpkey)) {
         RNP_LOG("Failed to add signature to the key.");

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -914,7 +914,6 @@ stream_dump_userid(pgp_source_t *src, pgp_dest_t *dst)
     default:;
     }
 
-    free_userid_pkt(&uid);
     indent_dest_decrease(dst);
     return RNP_SUCCESS;
 }
@@ -1910,23 +1909,17 @@ stream_dump_userid_json(pgp_source_t *src, json_object *pkt)
     case PGP_PKT_USER_ID:
         if (!obj_add_field_json(
               pkt, "userid", json_object_new_string_len((char *) uid.uid, uid.uid_len))) {
-            ret = RNP_ERROR_OUT_OF_MEMORY;
-            goto done;
+            return RNP_ERROR_OUT_OF_MEMORY;
         }
         break;
     case PGP_PKT_USER_ATTR:
         if (!obj_add_hex_json(pkt, "userattr", uid.uid, uid.uid_len)) {
-            ret = RNP_ERROR_OUT_OF_MEMORY;
-            goto done;
+            return RNP_ERROR_OUT_OF_MEMORY;
         }
         break;
     default:;
     }
-
-    ret = RNP_SUCCESS;
-done:
-    free_userid_pkt(&uid);
-    return ret;
+    return RNP_SUCCESS;
 }
 
 static rnp_result_t

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -873,7 +873,6 @@ stream_dump_key(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
         }
     }
 
-    free_key_pkt(&key);
     indent_dest_decrease(dst);
     return RNP_SUCCESS;
 }
@@ -1892,10 +1891,8 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
             goto done;
         }
     }
-
     ret = RNP_SUCCESS;
 done:
-    free_key_pkt(&key);
     return ret;
 }
 

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -110,23 +110,6 @@ transferable_subkey_merge(pgp_transferable_subkey_t &dst, const pgp_transferable
     return ret;
 }
 
-bool
-transferable_key_copy(pgp_transferable_key_t &      dst,
-                      const pgp_transferable_key_t &src,
-                      bool                          pubonly)
-{
-    try {
-        dst.key = pgp_key_pkt_t(src.key, pubonly);
-        dst.userids = src.userids;
-        dst.subkeys = src.subkeys;
-        dst.signatures = src.signatures;
-    } catch (const std::exception &e) {
-        RNP_LOG("%s", e.what());
-        return false;
-    }
-    return true;
-}
-
 rnp_result_t
 transferable_key_from_key(pgp_transferable_key_t &dst, const pgp_key_t &key)
 {
@@ -671,7 +654,7 @@ process_pgp_subkey(pgp_source_t &src, pgp_transferable_subkey_t &subkey, bool sk
     int          ptag;
     rnp_result_t ret = RNP_ERROR_BAD_FORMAT;
 
-    subkey = {};
+    subkey = pgp_transferable_subkey_t();
     uint64_t keypos = src.readb;
     if (!is_subkey_pkt(ptag = stream_pkt_type(&src))) {
         RNP_LOG("wrong subkey ptag: %d at %" PRIu64, ptag, keypos);
@@ -1592,34 +1575,6 @@ pgp_key_pkt_t::~pgp_key_pkt_t()
     free(sec_data);
 }
 
-pgp_transferable_userid_t::pgp_transferable_userid_t(const pgp_transferable_userid_t &src)
-{
-    uid = src.uid;
-    signatures = src.signatures;
-}
-
-pgp_transferable_userid_t::pgp_transferable_userid_t(pgp_transferable_userid_t &&src)
-{
-    uid = std::move(src.uid);
-    signatures = std::move(src.signatures);
-}
-
-pgp_transferable_userid_t &
-pgp_transferable_userid_t::operator=(const pgp_transferable_userid_t &src)
-{
-    if (this == &src) {
-        return *this;
-    }
-    uid = src.uid;
-    signatures = src.signatures;
-    return *this;
-}
-
-pgp_transferable_userid_t::~pgp_transferable_userid_t()
-{
-    ;
-}
-
 pgp_transferable_subkey_t::pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src,
                                                      bool                             pubonly)
 {
@@ -1627,60 +1582,10 @@ pgp_transferable_subkey_t::pgp_transferable_subkey_t(const pgp_transferable_subk
     signatures = src.signatures;
 }
 
-pgp_transferable_subkey_t::pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src)
+pgp_transferable_key_t::pgp_transferable_key_t(const pgp_transferable_key_t &src, bool pubonly)
 {
-    subkey = std::move(src.subkey);
-    signatures = std::move(src.signatures);
-}
-
-pgp_transferable_subkey_t &
-pgp_transferable_subkey_t::operator=(const pgp_transferable_subkey_t &src)
-{
-    if (this == &src) {
-        return *this;
-    }
-    subkey = src.subkey;
+    key = pgp_key_pkt_t(src.key, pubonly);
+    userids = src.userids;
+    subkeys = src.subkeys;
     signatures = src.signatures;
-    return *this;
-}
-
-pgp_transferable_subkey_t &
-pgp_transferable_subkey_t::operator=(pgp_transferable_subkey_t &&src)
-{
-    if (this == &src) {
-        return *this;
-    }
-    subkey = std::move(src.subkey);
-    signatures = std::move(src.signatures);
-    return *this;
-}
-
-pgp_transferable_subkey_t::~pgp_transferable_subkey_t()
-{
-}
-
-pgp_transferable_key_t::pgp_transferable_key_t(pgp_transferable_key_t &&src)
-{
-    key = src.key;
-    src.key = {};
-    userids = std::move(src.userids);
-    subkeys = std::move(src.subkeys);
-    signatures = std::move(src.signatures);
-}
-
-pgp_transferable_key_t &
-pgp_transferable_key_t::operator=(pgp_transferable_key_t &&src)
-{
-    if (this == &src) {
-        return *this;
-    }
-    key = std::move(src.key);
-    userids = std::move(src.userids);
-    subkeys = std::move(src.subkeys);
-    signatures = std::move(src.signatures);
-    return *this;
-}
-
-pgp_transferable_key_t::~pgp_transferable_key_t()
-{
 }

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -280,7 +280,7 @@ transferable_userid_certify(const pgp_key_pkt_t &          key,
                             pgp_hash_alg_t                 hash_alg,
                             const rnp_selfsig_cert_info_t &cert)
 {
-    pgp_signature_t   sig = {};
+    pgp_signature_t   sig;
     pgp_key_id_t      keyid = {};
     pgp_fingerprint_t keyfp;
 
@@ -446,7 +446,7 @@ signature_calculate_binding(const pgp_key_pkt_t *key,
 
     /* unhashed subpackets. Primary key binding signature and issuer key id */
     if (subsign) {
-        pgp_signature_t embsig = {};
+        pgp_signature_t embsig;
 
         if (!signature_calculate_primary_binding(key, sub, sig->halg, &embsig, &rng)) {
             RNP_LOG("failed to calculate primary key binding signature");
@@ -481,7 +481,7 @@ transferable_subkey_bind(const pgp_key_pkt_t &             key,
         return NULL;
     }
 
-    pgp_signature_t sig = {};
+    pgp_signature_t sig;
     pgp_key_flags_t realkf = (pgp_key_flags_t) 0;
 
     sig.version = PGP_V4;
@@ -610,7 +610,7 @@ process_pgp_key_signatures(pgp_source_t *src, pgp_signature_list_t &sigs, bool s
 {
     int ptag;
     while ((ptag = stream_pkt_type(src)) == PGP_PKT_SIGNATURE) {
-        pgp_signature_t sig = {};
+        pgp_signature_t sig;
         uint64_t        sigpos = src->readb;
         rnp_result_t    ret = stream_parse_signature(src, &sig);
         if (ret) {
@@ -686,7 +686,7 @@ process_pgp_keys(pgp_source_t *src, pgp_key_sequence_t &keys, bool skiperrors)
     bool          has_public = false;
     rnp_result_t  ret = RNP_ERROR_GENERIC;
 
-    keys = {};
+    keys.keys.clear();
     /* check whether keys are armored */
 armoredpass:
     if (is_armored_source(src)) {
@@ -752,7 +752,7 @@ finish:
         src_close(&armorsrc);
     }
     if (ret) {
-        keys = {};
+        keys.keys.clear();
     }
     return ret;
 }
@@ -765,7 +765,7 @@ process_pgp_key(pgp_source_t *src, pgp_transferable_key_t &key, bool skiperrors)
     int          ptag;
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
-    key = {};
+    key = pgp_transferable_key_t();
     /* check whether keys are armored */
     if (is_armored_source(src)) {
         if ((ret = init_armored_src(&armorsrc, src))) {

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -38,13 +38,6 @@
 typedef struct pgp_transferable_userid_t {
     pgp_userid_pkt_t     uid;
     pgp_signature_list_t signatures;
-
-    pgp_transferable_userid_t() : uid({}){};
-    pgp_transferable_userid_t(const pgp_transferable_userid_t &src);
-    pgp_transferable_userid_t(pgp_transferable_userid_t &&src);
-    pgp_transferable_userid_t &operator=(pgp_transferable_userid_t &&src);
-    pgp_transferable_userid_t &operator=(const pgp_transferable_userid_t &src);
-    ~pgp_transferable_userid_t();
 } pgp_transferable_userid_t;
 
 /* subkey with all corresponding signatures */
@@ -52,12 +45,9 @@ typedef struct pgp_transferable_subkey_t {
     pgp_key_pkt_t        subkey;
     pgp_signature_list_t signatures;
 
-    pgp_transferable_subkey_t() : subkey({}){};
+    pgp_transferable_subkey_t() = default;
     pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src, bool pubonly = false);
-    pgp_transferable_subkey_t(pgp_transferable_subkey_t &&src);
-    pgp_transferable_subkey_t &operator=(pgp_transferable_subkey_t &&src);
-    pgp_transferable_subkey_t &operator=(const pgp_transferable_subkey_t &src);
-    ~pgp_transferable_subkey_t();
+    pgp_transferable_subkey_t &operator=(const pgp_transferable_subkey_t &) = default;
 } pgp_transferable_subkey_t;
 
 /* transferable key with userids, subkeys and revocation signatures */
@@ -67,22 +57,15 @@ typedef struct pgp_transferable_key_t {
     std::vector<pgp_transferable_subkey_t> subkeys;
     pgp_signature_list_t                   signatures;
 
-    pgp_transferable_key_t() : key({}){};
-    pgp_transferable_key_t(const pgp_transferable_key_t &src) = delete;
-    pgp_transferable_key_t(pgp_transferable_key_t &&src);
-    pgp_transferable_key_t &operator=(pgp_transferable_key_t &&src);
-    pgp_transferable_key_t &operator=(const pgp_transferable_key_t &src) = delete;
-    ~pgp_transferable_key_t();
+    pgp_transferable_key_t() = default;
+    pgp_transferable_key_t(const pgp_transferable_key_t &src, bool pubonly = false);
+    pgp_transferable_key_t &operator=(const pgp_transferable_key_t &) = default;
 } pgp_transferable_key_t;
 
 /* sequence of OpenPGP transferable keys */
 typedef struct pgp_key_sequence_t {
     std::vector<pgp_transferable_key_t> keys;
 } pgp_key_sequence_t;
-
-bool transferable_key_copy(pgp_transferable_key_t &      dst,
-                           const pgp_transferable_key_t &src,
-                           bool                          pubonly);
 
 rnp_result_t transferable_key_from_key(pgp_transferable_key_t &dst, const pgp_key_t &key);
 

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -2234,7 +2234,7 @@ stream_parse_key(pgp_source_t *src, pgp_key_pkt_t *key)
 finish:
     free_packet_body(&pkt);
     if (res) {
-        *key = {};
+        *key = pgp_key_pkt_t();
     }
     return res;
 }

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -2323,34 +2323,3 @@ stream_parse_userid(pgp_source_t *src, pgp_userid_pkt_t *userid)
     userid->uid_len = pkt.len;
     return RNP_SUCCESS;
 }
-
-bool
-copy_userid_pkt(pgp_userid_pkt_t *dst, const pgp_userid_pkt_t *src)
-{
-    *dst = *src;
-    if (src->uid) {
-        dst->uid = (uint8_t *) malloc(src->uid_len);
-        if (!dst->uid) {
-            return false;
-        }
-        memcpy(dst->uid, src->uid, src->uid_len);
-    }
-
-    return true;
-}
-
-bool
-userid_pkt_equal(const pgp_userid_pkt_t *uid1, const pgp_userid_pkt_t *uid2)
-{
-    if ((uid1->tag != uid2->tag) || (uid1->uid_len != uid2->uid_len)) {
-        return false;
-    }
-
-    return !memcmp(uid1->uid, uid2->uid, uid1->uid_len);
-}
-
-void
-free_userid_pkt(pgp_userid_pkt_t *userid)
-{
-    free(userid->uid);
-}

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -311,11 +311,7 @@ bool stream_write_key(pgp_key_pkt_t *key, pgp_dest_t *dst);
 
 rnp_result_t stream_parse_key(pgp_source_t *src, pgp_key_pkt_t *key);
 
-bool copy_key_pkt(pgp_key_pkt_t *dst, const pgp_key_pkt_t *src, bool pubonly);
-
 bool key_pkt_equal(const pgp_key_pkt_t *key1, const pgp_key_pkt_t *key2, bool pubonly);
-
-void free_key_pkt(pgp_key_pkt_t *key);
 
 /* User ID packet */
 

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -319,10 +319,4 @@ bool stream_write_userid(const pgp_userid_pkt_t *userid, pgp_dest_t *dst);
 
 rnp_result_t stream_parse_userid(pgp_source_t *src, pgp_userid_pkt_t *userid);
 
-bool copy_userid_pkt(pgp_userid_pkt_t *dst, const pgp_userid_pkt_t *src);
-
-bool userid_pkt_equal(const pgp_userid_pkt_t *uid1, const pgp_userid_pkt_t *uid2);
-
-void free_userid_pkt(pgp_userid_pkt_t *userid);
-
 #endif

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1940,8 +1940,7 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
 
             /* Destroy decrypted key */
             if (pgp_key_is_encrypted(seckey)) {
-                free_key_pkt(decrypted_seckey);
-                free(decrypted_seckey);
+                delete decrypted_seckey;
                 decrypted_seckey = NULL;
             }
 

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1112,7 +1112,7 @@ signed_write_signature(pgp_dest_signed_param_t *param,
                        pgp_dest_signer_info_t * signer,
                        pgp_dest_t *             writedst)
 {
-    pgp_signature_t sig = {};
+    pgp_signature_t sig;
     rnp_result_t    ret;
 
     sig.version = (pgp_version_t) 4;

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1102,11 +1102,8 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
 
     /* destroy decrypted secret key */
     if (pgp_key_is_encrypted(signer->key)) {
-        free_key_pkt(deckey);
-        free(deckey);
-        deckey = NULL;
+        delete deckey;
     }
-
     return ret;
 }
 

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -207,7 +207,7 @@ TEST_F(rnp_tests, rnp_test_eddsa)
 TEST_F(rnp_tests, rnp_test_x25519)
 {
     rnp_keygen_crypto_params_t key_desc = {};
-    pgp_key_pkt_t              seckey = {};
+    pgp_key_pkt_t              seckey;
     pgp_ecdh_encrypted_t       enc = {};
     uint8_t           in[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     uint8_t           out[16] = {};
@@ -708,7 +708,7 @@ read_key_pkt(pgp_key_pkt_t *key, const char *path)
 
 TEST_F(rnp_tests, test_validate_key_material)
 {
-    pgp_key_pkt_t key = {};
+    pgp_key_pkt_t key;
     rng_t         rng = {};
     rng_init(&rng, RNG_SYSTEM);
 
@@ -720,7 +720,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     key.material.rsa.n.mpi[key.material.rsa.n.len - 1] |= 1;
     key.material.rsa.e.mpi[key.material.rsa.e.len - 1] &= ~1;
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
-    key = {};
+    key = pgp_key_pkt_t();
 
     assert_true(read_key_pkt(&key, KEYS "rsa-sub.pgp"));
     assert_rnp_success(validate_pgp_key_material(&key.material, &rng));
@@ -729,7 +729,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     key.material.rsa.n.mpi[key.material.rsa.n.len - 1] |= 1;
     key.material.rsa.e.mpi[key.material.rsa.e.len - 1] &= ~1;
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
-    key = {};
+    key = pgp_key_pkt_t();
 
     assert_true(read_key_pkt(&key, KEYS "rsa-sec.pgp"));
     assert_rnp_success(decrypt_secret_key(&key, NULL));
@@ -745,7 +745,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
     key.material.rsa.p.mpi[key.material.rsa.q.len - 1] -= 2;
     assert_rnp_success(validate_pgp_key_material(&key.material, &rng));
-    key = {};
+    key = pgp_key_pkt_t();
 
     assert_true(read_key_pkt(&key, KEYS "rsa-ssb.pgp"));
     assert_rnp_success(decrypt_secret_key(&key, NULL));
@@ -761,7 +761,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
     key.material.rsa.p.mpi[key.material.rsa.q.len - 1] -= 2;
     assert_rnp_success(validate_pgp_key_material(&key.material, &rng));
-    key = {};
+    key = pgp_key_pkt_t();
 
     /* DSA-ElGamal key */
     assert_true(read_key_pkt(&key, KEYS "dsa-sec.pgp"));
@@ -780,7 +780,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     /* since Botan calculates y from x on key load we do not check x vs y */
     key.material.dsa.x = key.material.dsa.q;
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
-    key = {};
+    key = pgp_key_pkt_t();
 
     assert_true(read_key_pkt(&key, KEYS "eg-sec.pgp"));
     key.material.eg.p.mpi[key.material.eg.p.len - 1] += 2;
@@ -795,7 +795,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     /* since Botan calculates y from x on key load we do not check x vs y */
     key.material.eg.x = key.material.eg.p;
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
-    key = {};
+    key = pgp_key_pkt_t();
 
     /* ECDSA key */
     assert_true(read_key_pkt(&key, KEYS "ecdsa-p256-sec.pgp"));
@@ -808,7 +808,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     key.material.ec.p.mpi[10] -= 2;
     assert_rnp_success(decrypt_secret_key(&key, NULL));
     assert_true(key.material.secret);
-    key = {};
+    key = pgp_key_pkt_t();
 
     /* ECDH key */
     assert_true(read_key_pkt(&key, KEYS "ecdh-p256-sec.pgp"));
@@ -821,7 +821,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     key.material.ec.p.mpi[10] -= 2;
     assert_rnp_success(decrypt_secret_key(&key, NULL));
     assert_true(key.material.secret);
-    key = {};
+    key = pgp_key_pkt_t();
 
     /* EDDSA key, just test for header since any value can be secret key */
     assert_true(read_key_pkt(&key, KEYS "ed25519-sec.pgp"));
@@ -829,7 +829,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     key.material.ec.p.mpi[0] += 2;
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
     key.material.ec.p.mpi[0] -= 2;
-    key = {};
+    key = pgp_key_pkt_t();
 
     /* x25519 key, same as the previous - botan calculates pub key from the secret one */
     assert_true(read_key_pkt(&key, KEYS "x25519-sec.pgp"));
@@ -837,7 +837,7 @@ TEST_F(rnp_tests, test_validate_key_material)
     key.material.ec.p.mpi[0] += 2;
     assert_rnp_failure(validate_pgp_key_material(&key.material, &rng));
     key.material.ec.p.mpi[0] -= 2;
-    key = {};
+    key = pgp_key_pkt_t();
 
     rng_destroy(&rng);
 }

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -909,8 +909,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
     // primary
     {
-        pgp_key_t                 pub = {};
-        pgp_key_t                 sec = {};
+        pgp_key_t                 pub;
+        pgp_key_t                 sec;
         rnp_keygen_primary_desc_t desc;
         pgp_fingerprint_t         fp = {};
         pgp_sig_subpkt_t *        subpkt = NULL;
@@ -1049,8 +1049,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
     // sub
     {
-        pgp_key_t                pub = {};
-        pgp_key_t                sec = {};
+        pgp_key_t                pub;
+        pgp_key_t                sec;
         rnp_keygen_subkey_desc_t desc;
         pgp_fingerprint_t        fp = {};
         pgp_sig_subpkt_t *       subpkt = NULL;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -996,8 +996,11 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         psig->hashed_data[32] ^= 0xff;
         ssig->hashed_data[32] ^= 0xff;
         // ensure validation fails with incorrect uid
-        pgp_userid_pkt_t uid = {
-          .tag = PGP_PKT_USER_ID, .uid = (uint8_t *) "fake", .uid_len = 4};
+        pgp_userid_pkt_t uid;
+        uid.tag = PGP_PKT_USER_ID;
+        uid.uid = (uint8_t *) malloc(4);
+        uid.uid_len = 4;
+        memcpy(uid.uid, "fake", 4);
 
         assert_rnp_failure(
           signature_check_certification(&psiginfo, pgp_key_get_pkt(&pub), &uid));

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -76,9 +76,8 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
         assert_non_null(tmp = rnp_tests_get_key_by_id(ks, keyids[0], NULL));
 
         // steal this key from the store
-        key = new pgp_key_t();
+        key = new pgp_key_t(*tmp);
         assert_non_null(key);
-        pgp_key_copy(*key, *tmp, false);
         delete ks;
     }
 

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -51,7 +51,7 @@ TEST_F(rnp_tests, test_key_store_search)
     // add our fake test keys
     for (size_t i = 0; i < ARRAY_SIZE(testdata); i++) {
         for (size_t n = 0; n < testdata[i].count; n++) {
-            pgp_key_t key = {};
+            pgp_key_t key;
 
             key.pkt.tag = PGP_PKT_PUBLIC_KEY;
             key.pkt.version = PGP_V4;

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -715,7 +715,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_non_null(skey2 = rnp_key_store_get_key_by_id(secstore, sub2id, NULL));
 
     /* copy the secret key */
-    assert_rnp_success(pgp_key_copy(keycp, *key, false));
+    keycp = pgp_key_t(*key, false);
     assert_true(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(pgp_key_get_subkey_fp(&keycp, 0) == pgp_key_get_fp(skey1));
@@ -724,7 +724,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_SECRET_KEY);
 
     /* copy the public part */
-    assert_rnp_success(pgp_key_copy(keycp, *key, true));
+    keycp = pgp_key_t(*key, true);
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(check_subkey_fp(&keycp, skey1, 0));
@@ -736,7 +736,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
-    assert_rnp_success(pgp_key_copy(keycp, *skey1, true));
+    keycp = pgp_key_t(*skey1, true);
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 0));
@@ -748,7 +748,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
-    assert_rnp_success(pgp_key_copy(keycp, *skey2, true));
+    keycp = pgp_key_t(*skey2, true);
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 1));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -91,8 +91,7 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     assert_non_null(seckey);
 
     // cleanup
-    free_key_pkt(seckey);
-    free(seckey);
+    delete seckey;
     delete key_store;
 }
 

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -696,7 +696,7 @@ TEST_F(rnp_tests, test_load_merge)
 
 TEST_F(rnp_tests, test_load_public_from_secret)
 {
-    pgp_key_t *      key, *skey1, *skey2, keycp = {};
+    pgp_key_t *      key, *skey1, *skey2, keycp;
     pgp_key_id_t     keyid = {};
     pgp_key_id_t     sub1id = {};
     pgp_key_id_t     sub2id = {};


### PR DESCRIPTION
This PR refactors code to make packet structs more C++ : use constructors/destructors/operators instead of dedicated functions.
Separated from #1207 due to strange compilation problems.