### PR TITLE
Add --permissive option to rnpkeys.

### DIFF
--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -87,6 +87,7 @@
 #define CFG_RAW "raw"               /* dump raw packet contents */
 #define CFG_REV_TYPE "rev-type"     /* revocation reason code */
 #define CFG_REV_REASON "rev-reason" /* revocation reason human-readable string */
+#define CFG_PERMISSIVE "permissive" /* ignore bad packets during key import */
 
 /* rnp keyring setup variables */
 #define CFG_KR_PUB_FORMAT "kr-pub-format"

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -64,6 +64,7 @@ const char *usage = "--help OR\n"
                     "\t[--hash=<hash alg>] AND/OR\n"
                     "\t[--homedir=<homedir>] AND/OR\n"
                     "\t[--keyring=<keyring>] AND/OR\n"
+                    "\t[--permissive] AND/OR\n"
                     "\t[--output=file] file OR\n"
                     "\t[--keystore-format=<format>] AND/OR\n"
                     "\t[--userid=<userid>] AND/OR\n"
@@ -114,6 +115,7 @@ struct option options[] = {
   {"secret", no_argument, NULL, OPT_SECRET},
   {"rev-type", required_argument, NULL, OPT_REV_TYPE},
   {"rev-reason", required_argument, NULL, OPT_REV_REASON},
+  {"permissive", no_argument, NULL, OPT_PERMISSIVE},
   {NULL, 0, NULL, 0},
 };
 
@@ -168,6 +170,11 @@ import_keys(cli_rnp_t *rnp, const char *file)
     char *       results = NULL;
     json_object *jso = NULL;
     json_object *keys = NULL;
+
+    bool permissive = rnp_cfg_getbool(cli_rnp_cfg(rnp), CFG_PERMISSIVE);
+    if (permissive) {
+        flags |= RNP_LOAD_SAVE_PERMISSIVE;
+    }
 
     if (rnp_import_keys(rnp->ffi, input, flags, &results)) {
         ERR_MSG("failed to import keys from file %s", file);
@@ -575,6 +582,9 @@ setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, const char *arg)
     }
     case OPT_REV_REASON:
         ret = rnp_cfg_setstr(cfg, CFG_REV_REASON, arg);
+        break;
+    case OPT_PERMISSIVE:
+        ret = rnp_cfg_setbool(cfg, CFG_PERMISSIVE, true);
         break;
     default:
         *cmd = CMD_HELP;

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -41,6 +41,7 @@ typedef enum {
     OPT_WITH_SIGS,
     OPT_REV_TYPE,
     OPT_REV_REASON,
+    OPT_PERMISSIVE,
 
     /* debug */
     OPT_DEBUG

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1559,6 +1559,27 @@ class Misc(unittest.TestCase):
                         'exported packets mismatch')
         return
 
+    def test_rnp_permissive_key_import(self):
+        # Import keys while skipping bad packets, see #1160
+        clear_keyrings()
+        # Try to import  without --permissive option, should fail.
+        ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import-keys', data_path('test_key_edge_cases/pubring-malf-cert.pgp')])
+        if ret == 0:
+            raise_err('Imported bad packets without --permissive option set!')
+        # Import with --permissive
+        ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import-keys', '--permissive',data_path('test_key_edge_cases/pubring-malf-cert.pgp')])
+        if ret != 0:
+            raise_err('Failed to import keys with --permissive option')
+
+        # List imported keys and sigs
+        params = ['--homedir', RNPDIR, '--list-keys', '--with-sigs']
+        ret, out, err = run_proc(RNPK, params)
+        if ret != 0:
+            raise_err('packet listing failed', err)
+        compare_file_ex(data_path('test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt'), out,
+                        'listing mismatch')
+        return
+
     def test_rnp_list_packets(self):
         # List packets in humand-readable format
         params = ['--list-packets', data_path('test_list_packets/ecc-p256-pub.asc')]

--- a/src/tests/data/test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt
+++ b/src/tests/data/test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt
@@ -1,0 +1,29 @@
+7 keys found
+
+pub   1024/RSA (Encrypt or Sign) 7bc6709b15c23a4a 2017-07-20 [SC]
+      e95a3cbf583aa80a2ccc53aa7bc6709b15c23a4a
+uid           key0-uid0
+uid           key0-uid1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
+uid           key0-uid2
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
+sub   1024/RSA (Encrypt or Sign) 1ed63ee56fadc34d 2017-07-20 [E]
+      e332b27caf4742a11baa677f1ed63ee56fadc34d
+sub   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
+      c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sub   1024/RSA (Encrypt or Sign) 8a05b89fad5aded1 2017-07-20 [E]
+      5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+
+pub   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
+      be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
+uid           key1-uid0
+sig           2fcadf05ffa501bb 2017-07-29 key1-uid0
+uid           key1-uid2
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
+uid           key1-uid1
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
+sub   1024/Elgamal (Encrypt-Only) 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
+      a3e94de61a8cb229413d348e54505a936a4a970e
+sub   1024/Elgamal (Encrypt-Only) 326ef111425d14a5 2017-07-20 [E]
+      57f8ed6e5c197db63c60ffaf326ef111425d14a5
+


### PR DESCRIPTION
Adds --permissive option for --import-keys command, which makes rnp_import_keys() to be called with RNP_LOAD_SAVE_PERMISSIVE flag set.

Closes #1160 