### PR TITLE
Fix oss-fuzz invalid-enum-value issues

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -313,7 +313,7 @@ typedef enum {
  *
  * \see RFC4880 5.2.1
  */
-typedef enum {
+typedef enum : uint8_t {
     PGP_SIG_BINARY = 0x00,     /* Signature of a binary document */
     PGP_SIG_TEXT = 0x01,       /* Signature of a canonical text document */
     PGP_SIG_STANDALONE = 0x02, /* Standalone signature */

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -180,7 +180,7 @@ typedef enum : uint8_t {
  *
  * \see RFC4880 9.1
  */
-typedef enum {
+typedef enum : uint8_t {
     PGP_PKA_NOTHING = 0,                  /* No PKA */
     PGP_PKA_RSA = 1,                      /* RSA (Encrypt or Sign) */
     PGP_PKA_RSA_ENCRYPT_ONLY = 2,         /* RSA Encrypt-Only (deprecated -

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -287,7 +287,7 @@ typedef enum {
 
 /** s2k_specifier_t
  */
-typedef enum {
+typedef enum : uint8_t {
     PGP_S2KS_SIMPLE = 0,
     PGP_S2KS_SALTED = 1,
     PGP_S2KS_ITERATED_AND_SALTED = 3,

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -452,7 +452,7 @@ typedef enum pgp_op_t {
  *
  * \see RFC4880 9.4
  */
-typedef enum {
+typedef enum : uint8_t {
     PGP_HASH_UNKNOWN = 0, /* used to indicate errors */
     PGP_HASH_MD5 = 1,
     PGP_HASH_SHA1 = 2,

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -149,7 +149,7 @@ typedef enum {
  * @brief OpenPGP packet tags. See section 4.3 of RFC4880 for the detailed description.
  *
  */
-typedef enum {
+typedef enum : uint8_t {
     PGP_PKT_RESERVED = 0,       /* Reserved - a packet tag must not have this value */
     PGP_PKT_PK_SESSION_KEY = 1, /* Public-Key Encrypted Session Key Packet */
     PGP_PKT_SIGNATURE = 2,      /* Signature Packet */


### PR DESCRIPTION
Since we're using C++11 we can set an explicit type for these enums and that should fix these.
Testing locally with oss-fuzz shows all these to now be fixed.

EDIT: Proper wording since these are actual fixes