### PR TITLE
Fix oss-fuzz issue 25334: invalid enum value for pgp_revocation_type_t

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -137,7 +137,7 @@ typedef enum {
 #define MDC_PKT_TAG 0xd3
 #define MDC_V1_SIZE 22
 
-typedef enum {
+typedef enum : uint8_t {
     PGP_REVOCATION_NO_REASON = 0,
     PGP_REVOCATION_SUPERSEDED = 1,
     PGP_REVOCATION_COMPROMISED = 2,


### PR DESCRIPTION
As title says.