### PR TITLE
Refactor pgp_key_t fields access

### DIFF
--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -227,30 +227,3 @@ validate_pgp_key_material(const pgp_key_material_t *material, rng_t *rng)
     return RNP_ERROR_BAD_PARAMETERS;
 #endif
 }
-
-size_t
-key_bitlength(const pgp_key_material_t *key)
-{
-    switch (key->alg) {
-    case PGP_PKA_RSA:
-    case PGP_PKA_RSA_ENCRYPT_ONLY:
-    case PGP_PKA_RSA_SIGN_ONLY:
-        return 8 * mpi_bytes(&key->rsa.n);
-    case PGP_PKA_DSA:
-        return 8 * mpi_bytes(&key->dsa.p);
-    case PGP_PKA_ELGAMAL:
-    case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
-        return 8 * mpi_bytes(&key->eg.y);
-    case PGP_PKA_ECDH:
-    case PGP_PKA_ECDSA:
-    case PGP_PKA_EDDSA:
-    case PGP_PKA_SM2: {
-        // bn_num_bytes returns value <= curve order
-        const ec_curve_desc_t *curve = get_curve_desc(key->ec.curve);
-        return curve ? curve->bitlen : 0;
-    }
-    default:
-        RNP_LOG("Unknown public key alg in key_bitlength");
-        return 0;
-    }
-}

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -138,6 +138,4 @@ bool key_material_equal(const pgp_key_material_t *key1, const pgp_key_material_t
 
 rnp_result_t validate_pgp_key_material(const pgp_key_material_t *material, rng_t *rng);
 
-size_t key_bitlength(const pgp_key_material_t *key);
-
 #endif /* CRYPTO_H_ */

--- a/src/lib/crypto/dsa.cpp
+++ b/src/lib/crypto/dsa.cpp
@@ -380,9 +380,3 @@ dsa_choose_qsize_by_psize(size_t psize)
     return (psize == 1024) ? 160 :
                              (psize <= 2047) ? 224 : (psize <= 3072) ? DSA_MAX_Q_BITLEN : 0;
 }
-
-size_t
-dsa_qbits(const pgp_dsa_key_t *key)
-{
-    return 8 * mpi_bytes(&key->q);
-}

--- a/src/lib/crypto/dsa.h
+++ b/src/lib/crypto/dsa.h
@@ -142,6 +142,4 @@ pgp_hash_alg_t dsa_get_min_hash(size_t qsize);
  */
 size_t dsa_choose_qsize_by_psize(size_t psize);
 
-size_t dsa_qbits(const pgp_dsa_key_t *key);
-
 #endif

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -510,7 +510,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
         }
         primary_seckey = decrypted_primary_seckey;
     } else {
-        primary_seckey = pgp_key_get_pkt(primary_sec);
+        primary_seckey = &primary_sec->pkt();
     }
 
     // generate the raw key pair

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -69,7 +69,7 @@ pgp_request_key(const pgp_key_provider_t *provider, const pgp_key_request_ctx_t 
         return NULL;
     }
     // confirm that the key actually matches the search criteria
-    if (!rnp_key_matches_search(key, &ctx->search) && pgp_key_is_secret(key) == ctx->secret) {
+    if (!rnp_key_matches_search(key, &ctx->search) && key->is_secret() == ctx->secret) {
         return NULL;
     }
     return key;
@@ -81,8 +81,7 @@ rnp_key_provider_key_ptr_list(const pgp_key_request_ctx_t *ctx, void *userdata)
     list key_list = (list) userdata;
     for (list_item *item = list_front(key_list); item; item = list_next(item)) {
         pgp_key_t *key = *(pgp_key_t **) item;
-        if (rnp_key_matches_search(key, &ctx->search) &&
-            pgp_key_is_secret(key) == ctx->secret) {
+        if (rnp_key_matches_search(key, &ctx->search) && (key->is_secret() == ctx->secret)) {
             return key;
         }
     }
@@ -111,7 +110,7 @@ rnp_key_provider_store(const pgp_key_request_ctx_t *ctx, void *userdata)
 
     for (pgp_key_t *key = rnp_key_store_search(ks, &ctx->search, NULL); key;
          key = rnp_key_store_search(ks, &ctx->search, key)) {
-        if (pgp_key_is_secret(key) == ctx->secret) {
+        if (key->is_secret() == ctx->secret) {
             return key;
         }
     }

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -41,11 +41,11 @@ rnp_key_matches_search(const pgp_key_t *key, const pgp_key_search_t *search)
     }
     switch (search->type) {
     case PGP_KEY_SEARCH_KEYID:
-        return pgp_key_get_keyid(key) == search->by.keyid;
+        return key->keyid() == search->by.keyid;
     case PGP_KEY_SEARCH_FINGERPRINT:
-        return pgp_key_get_fp(key) == search->by.fingerprint;
+        return key->fp() == search->by.fingerprint;
     case PGP_KEY_SEARCH_GRIP:
-        return pgp_key_get_grip(key) == search->by.grip;
+        return key->grip() == search->by.grip;
     case PGP_KEY_SEARCH_USERID:
         if (key->has_uid(search->by.userid)) {
             return true;

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -72,23 +72,6 @@
 #include <stdexcept>
 #include "defaults.h"
 
-/**
- \ingroup HighLevel_KeyGeneral
-
- \brief Returns the public key in the given key.
- \param key
-
-  \return Pointer to public key
-
-  \note This is not a copy, do not free it after use.
-*/
-
-const pgp_key_material_t *
-pgp_key_get_material(const pgp_key_t *key)
-{
-    return &key->pkt().material;
-}
-
 pgp_pubkey_alg_t
 pgp_key_get_alg(const pgp_key_t *key)
 {
@@ -102,13 +85,13 @@ pgp_key_get_dsa_qbits(const pgp_key_t *key)
         return 0;
     }
 
-    return dsa_qbits(&pgp_key_get_material(key)->dsa);
+    return dsa_qbits(&key->material().dsa);
 }
 
 size_t
 pgp_key_get_bits(const pgp_key_t *key)
 {
-    return key_bitlength(pgp_key_get_material(key));
+    return key_bitlength(&key->material());
 }
 
 pgp_curve_t
@@ -119,7 +102,7 @@ pgp_key_get_curve(const pgp_key_t *key)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
-        return pgp_key_get_material(key)->ec.curve;
+        return key->material().ec.curve;
     default:
         return PGP_CURVE_UNKNOWN;
     }
@@ -2185,4 +2168,10 @@ void
 pgp_key_t::set_pkt(const pgp_key_pkt_t &pkt)
 {
     pkt_ = pkt;
+}
+
+const pgp_key_material_t &
+pgp_key_t::material() const
+{
+    return pkt_.material;
 }

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -167,11 +167,11 @@ struct pgp_key_t {
     const pgp_key_pkt_t &pkt() const;
     pgp_key_pkt_t &      pkt();
     void                 set_pkt(const pgp_key_pkt_t &pkt);
+
+    const pgp_key_material_t &material() const;
 };
 
 typedef struct rnp_key_store_t rnp_key_store_t;
-
-const pgp_key_material_t *pgp_key_get_material(const pgp_key_t *key);
 
 pgp_pubkey_alg_t pgp_key_get_alg(const pgp_key_t *key);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -130,10 +130,10 @@ struct pgp_key_t {
     pgp_fingerprint_t         primary_fp_{}; /* fingerprint of the primary key (for subkeys) */
     bool                      primary_fp_set_{};
     std::vector<pgp_fingerprint_t>
-      subkey_fps_{}; /* array of subkey fingerprints (for primary keys) */
+                    subkey_fps_{}; /* array of subkey fingerprints (for primary keys) */
+    pgp_rawpacket_t rawpkt_{};     /* key raw packet */
 
   public:
-    pgp_rawpacket_t        rawpkt{};     /* key raw packet */
     uint32_t               uid0{};       /* primary uid index in uids array */
     bool                   uid0_set{};   /* flag for the above */
     bool                   revoked{};    /* key has been revoked */
@@ -222,6 +222,11 @@ struct pgp_key_t {
      */
     const pgp_fingerprint_t &             get_subkey_fp(size_t idx) const;
     const std::vector<pgp_fingerprint_t> &subkey_fps() const;
+
+    size_t                 rawpkt_count() const;
+    pgp_rawpacket_t &      rawpkt();
+    const pgp_rawpacket_t &rawpkt() const;
+    void                   set_rawpkt(const pgp_rawpacket_t &src);
 };
 
 typedef struct rnp_key_store_t rnp_key_store_t;
@@ -283,11 +288,6 @@ void pgp_key_validate_signature(pgp_key_t &   key,
 bool pgp_key_refresh_data(pgp_key_t *key);
 
 bool pgp_subkey_refresh_data(pgp_key_t *sub, pgp_key_t *key);
-
-size_t pgp_key_get_rawpacket_count(const pgp_key_t *);
-
-pgp_rawpacket_t &      pgp_key_get_rawpacket(pgp_key_t *);
-const pgp_rawpacket_t &pgp_key_get_rawpacket(const pgp_key_t *);
 
 /**
  * @brief Get the key's subkey by it's index

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -124,15 +124,16 @@ struct pgp_key_t {
     pgp_key_pkt_t             pkt_{};      /* pubkey/seckey data packet */
     uint8_t                   flags_{};    /* key flags */
     time_t                    expiration_{}; /* key expiration time, if available */
+    pgp_key_id_t              keyid_{};
+    pgp_fingerprint_t         fingerprint_{};
+    pgp_key_grip_t            grip_{};
+
   public:
     std::vector<pgp_fingerprint_t>
                            subkey_fps{}; /* array of subkey fingerprints (for primary keys) */
     pgp_fingerprint_t      primary_fp{}; /* fingerprint of primary key (for subkeys) */
     bool                   primary_fp_set{};
-    pgp_rawpacket_t        rawpkt{}; /* key raw packet */
-    pgp_key_id_t           keyid{};
-    pgp_fingerprint_t      fingerprint{};
-    pgp_key_grip_t         grip{};
+    pgp_rawpacket_t        rawpkt{};     /* key raw packet */
     uint32_t               uid0{};       /* primary uid index in uids array */
     bool                   uid0_set{};   /* flag for the above */
     bool                   revoked{};    /* key has been revoked */
@@ -189,6 +190,13 @@ struct pgp_key_t {
     bool     is_secret() const;
     bool     is_primary() const;
     bool     is_subkey() const;
+
+    /** @brief Get key's id */
+    const pgp_key_id_t &keyid() const;
+    /** @brief Get key's fingerprint */
+    const pgp_fingerprint_t &fp() const;
+    /** @brief Get key's grip */
+    const pgp_key_grip_t &grip() const;
 };
 
 typedef struct rnp_key_store_t rnp_key_store_t;
@@ -201,30 +209,6 @@ pgp_key_pkt_t *pgp_decrypt_seckey_pgp(const uint8_t *,
 pgp_key_pkt_t *pgp_decrypt_seckey(const pgp_key_t *,
                                   const pgp_password_provider_t *,
                                   const pgp_password_ctx_t *);
-
-/**
- * @brief Get key's keyid
- *
- * @param key populated key, should not be NULL
- * @return reference to keyid object
- */
-const pgp_key_id_t &pgp_key_get_keyid(const pgp_key_t *key);
-
-/**
- * @brief Get key's fingerprint
- *
- * @param key populated key, should not be NULL
- * @return reference to the fingerprint structure
- */
-const pgp_fingerprint_t &pgp_key_get_fp(const pgp_key_t *key);
-
-/**
- * @brief Get key's grip
- *
- * @param key populated key, should not be NULL
- * @return key's grip
- */
-const pgp_key_grip_t &pgp_key_get_grip(const pgp_key_t *key);
 
 /**
  * @brief Get primary key's fingerprint for the subkey, if available.

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -122,14 +122,14 @@ struct pgp_key_t {
     std::vector<pgp_sig_id_t> keysigs_{};  /* direct-key signature ids in the original order */
     std::vector<pgp_userid_t> uids_{};     /* array of user ids */
     pgp_key_pkt_t             pkt_{};      /* pubkey/seckey data packet */
+    uint8_t                   flags_{};    /* key flags */
+    time_t                    expiration_{}; /* key expiration time, if available */
   public:
     std::vector<pgp_fingerprint_t>
                            subkey_fps{}; /* array of subkey fingerprints (for primary keys) */
     pgp_fingerprint_t      primary_fp{}; /* fingerprint of primary key (for subkeys) */
     bool                   primary_fp_set{};
-    time_t                 expiration{}; /* key expiration time, if available */
-    pgp_rawpacket_t        rawpkt{};     /* key raw packet */
-    uint8_t                key_flags{};  /* key flags */
+    pgp_rawpacket_t        rawpkt{}; /* key raw packet */
     pgp_key_id_t           keyid{};
     pgp_fingerprint_t      fingerprint{};
     pgp_key_grip_t         grip{};
@@ -169,49 +169,29 @@ struct pgp_key_t {
     void                 set_pkt(const pgp_key_pkt_t &pkt);
 
     const pgp_key_material_t &material() const;
+
+    pgp_pubkey_alg_t alg() const;
+    pgp_curve_t      curve() const;
+    pgp_version_t    version() const;
+    pgp_pkt_type_t   type() const;
+    bool             encrypted() const;
+    uint8_t          flags() const;
+    void             set_flags(uint8_t flags);
+    bool             can_sign() const;
+    bool             can_certify() const;
+    bool             can_encrypt() const;
+    /** @brief Get key's expiration time in seconds. If 0 then it doesn't expire. */
+    uint32_t expiration() const;
+    void     set_expiration(uint32_t expiry);
+    /** @brief Get key's creation time in seconds since Jan, 1 1970. */
+    uint32_t creation() const;
+    bool     is_public() const;
+    bool     is_secret() const;
+    bool     is_primary() const;
+    bool     is_subkey() const;
 };
 
 typedef struct rnp_key_store_t rnp_key_store_t;
-
-pgp_pubkey_alg_t pgp_key_get_alg(const pgp_key_t *key);
-
-size_t pgp_key_get_dsa_qbits(const pgp_key_t *key);
-
-size_t pgp_key_get_bits(const pgp_key_t *key);
-
-pgp_curve_t pgp_key_get_curve(const pgp_key_t *key);
-
-pgp_version_t pgp_key_get_version(const pgp_key_t *key);
-
-pgp_pkt_type_t pgp_key_get_type(const pgp_key_t *key);
-
-bool pgp_key_is_encrypted(const pgp_key_t *);
-
-uint8_t pgp_key_get_flags(const pgp_key_t *key);
-bool    pgp_key_can_sign(const pgp_key_t *key);
-bool    pgp_key_can_certify(const pgp_key_t *key);
-bool    pgp_key_can_encrypt(const pgp_key_t *key);
-
-/**
- * @brief Get key's expiration time in seconds. If 0 then it doesn't expire.
- *
- * @param key populated key, could not be NULL
- * @return key expiration time
- */
-uint32_t pgp_key_get_expiration(const pgp_key_t *key);
-
-/**
- * @brief Get key's creation time in seconds since Jan, 1 1980.
- *
- * @param key populated key, could not be NULL
- * @return key creation time
- */
-uint32_t pgp_key_get_creation(const pgp_key_t *key);
-
-bool pgp_key_is_public(const pgp_key_t *);
-bool pgp_key_is_secret(const pgp_key_t *);
-bool pgp_key_is_primary_key(const pgp_key_t *key);
-bool pgp_key_is_subkey(const pgp_key_t *key);
 
 pgp_key_pkt_t *pgp_decrypt_seckey_pgp(const uint8_t *,
                                       size_t,

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -121,13 +121,13 @@ struct pgp_key_t {
     std::vector<pgp_sig_id_t> sigs_{};     /* subsig ids to lookup actual sig in map */
     std::vector<pgp_sig_id_t> keysigs_{};  /* direct-key signature ids in the original order */
     std::vector<pgp_userid_t> uids_{};     /* array of user ids */
+    pgp_key_pkt_t             pkt_{};      /* pubkey/seckey data packet */
   public:
     std::vector<pgp_fingerprint_t>
                            subkey_fps{}; /* array of subkey fingerprints (for primary keys) */
     pgp_fingerprint_t      primary_fp{}; /* fingerprint of primary key (for subkeys) */
     bool                   primary_fp_set{};
     time_t                 expiration{}; /* key expiration time, if available */
-    pgp_key_pkt_t          pkt{};        /* pubkey/seckey data packet */
     pgp_rawpacket_t        rawpkt{};     /* key raw packet */
     uint8_t                key_flags{};  /* key flags */
     pgp_key_id_t           keyid{};
@@ -163,11 +163,13 @@ struct pgp_key_t {
     pgp_userid_t &      add_uid(const pgp_transferable_userid_t &uid);
     bool                has_uid(const std::string &uid) const;
     void                clear_revokes();
+
+    const pgp_key_pkt_t &pkt() const;
+    pgp_key_pkt_t &      pkt();
+    void                 set_pkt(const pgp_key_pkt_t &pkt);
 };
 
 typedef struct rnp_key_store_t rnp_key_store_t;
-
-const pgp_key_pkt_t *pgp_key_get_pkt(const pgp_key_t *);
 
 const pgp_key_material_t *pgp_key_get_material(const pgp_key_t *key);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1372,8 +1372,6 @@ add_key_status(json_object *           keys,
                pgp_key_import_status_t pub,
                pgp_key_import_status_t sec)
 {
-    const pgp_fingerprint_t &fp = pgp_key_get_fp(key);
-
     json_object *jsokey = json_object_new_object();
     if (!jsokey) {
         return RNP_ERROR_OUT_OF_MEMORY;
@@ -1383,7 +1381,7 @@ add_key_status(json_object *           keys,
           jsokey, "public", json_object_new_string(key_status_to_str(pub))) ||
         !obj_add_field_json(
           jsokey, "secret", json_object_new_string(key_status_to_str(sec))) ||
-        !obj_add_hex_json(jsokey, "fingerprint", fp.fingerprint, fp.length) ||
+        !obj_add_hex_json(jsokey, "fingerprint", key->fp().fingerprint, key->fp().length) ||
         !array_add_element_json(keys, jsokey)) {
         json_object_put(jsokey);
         return RNP_ERROR_OUT_OF_MEMORY;
@@ -1481,9 +1479,9 @@ try {
             continue;
         }
         if (validate_pgp_key_material(&key.material(), &ffi->rng)) {
-            char                hex[PGP_KEY_ID_SIZE * 2 + 1] = {0};
-            const pgp_key_id_t &keyid = pgp_key_get_keyid(&key);
-            rnp_hex_encode(keyid.data(), keyid.size(), hex, sizeof(hex), RNP_HEX_LOWERCASE);
+            char hex[PGP_KEY_ID_SIZE * 2 + 1] = {0};
+            rnp_hex_encode(
+              key.keyid().data(), key.keyid().size(), hex, sizeof(hex), RNP_HEX_LOWERCASE);
             FFI_LOG(ffi, "warning! attempt to import key %s with invalid material.", hex);
             continue;
         }
@@ -1499,8 +1497,7 @@ try {
                 goto done;
             }
             // add uids, certifications and other stuff from the public key if any
-            pgp_key_t *expub =
-              rnp_key_store_get_key_by_fpr(ffi->pubring, pgp_key_get_fp(&key));
+            pgp_key_t *expub = rnp_key_store_get_key_by_fpr(ffi->pubring, key.fp());
             if (expub && !rnp_key_store_import_key(ffi->secring, expub, true, NULL)) {
                 ret = RNP_ERROR_BAD_PARAMETERS;
                 goto done;
@@ -1564,7 +1561,7 @@ add_sig_status(json_object *           sigs,
     }
 
     if (signer) {
-        const pgp_fingerprint_t &fp = pgp_key_get_fp(signer);
+        const pgp_fingerprint_t &fp = signer->fp();
         if (!obj_add_hex_json(jsosig, "signer fingerprint", fp.fingerprint, fp.length)) {
             json_object_put(jsosig);
             return RNP_ERROR_OUT_OF_MEMORY;
@@ -2196,7 +2193,7 @@ rnp_op_add_signature(rnp_ffi_t                 ffi,
     if (signkey && !signkey->is_secret()) {
         pgp_key_request_ctx_t ctx = {.op = PGP_OP_SIGN, .secret = true};
         ctx.search.type = PGP_KEY_SEARCH_GRIP;
-        ctx.search.by.grip = pgp_key_get_grip(signkey);
+        ctx.search.by.grip = signkey->grip();
         signkey = pgp_request_key(&key->ffi->key_provider, &ctx);
     }
     if (!signkey) {
@@ -4344,8 +4341,8 @@ gen_json_grips(char **result, const pgp_key_t *primary, const pgp_key_t *sub)
             goto done;
         }
         json_object_object_add(jso, "primary", jsoprimary);
-        if (!rnp_hex_encode(pgp_key_get_grip(primary).data(),
-                            pgp_key_get_grip(primary).size(),
+        if (!rnp_hex_encode(primary->grip().data(),
+                            primary->grip().size(),
                             grip,
                             sizeof(grip),
                             RNP_HEX_UPPERCASE)) {
@@ -4363,11 +4360,8 @@ gen_json_grips(char **result, const pgp_key_t *primary, const pgp_key_t *sub)
             goto done;
         }
         json_object_object_add(jso, "sub", jsosub);
-        if (!rnp_hex_encode(pgp_key_get_grip(sub).data(),
-                            pgp_key_get_grip(sub).size(),
-                            grip,
-                            sizeof(grip),
-                            RNP_HEX_UPPERCASE)) {
+        if (!rnp_hex_encode(
+              sub->grip().data(), sub->grip().size(), grip, sizeof(grip), RNP_HEX_UPPERCASE)) {
             goto done;
         }
         json_object *jsogrip = json_object_new_string(grip);
@@ -5380,7 +5374,7 @@ get_key_require_public(rnp_key_handle_t handle)
 
         // try fingerprint
         request.search.type = PGP_KEY_SEARCH_FINGERPRINT;
-        request.search.by.fingerprint = pgp_key_get_fp(handle->sec);
+        request.search.by.fingerprint = handle->sec->fp();
         handle->pub = pgp_request_key(&handle->ffi->key_provider, &request);
         if (handle->pub) {
             return handle->pub;
@@ -5388,7 +5382,7 @@ get_key_require_public(rnp_key_handle_t handle)
 
         // try keyid
         request.search.type = PGP_KEY_SEARCH_KEYID;
-        request.search.by.keyid = pgp_key_get_keyid(handle->sec);
+        request.search.by.keyid = handle->sec->keyid();
         handle->pub = pgp_request_key(&handle->ffi->key_provider, &request);
     }
     return handle->pub;
@@ -5410,7 +5404,7 @@ get_key_require_secret(rnp_key_handle_t handle)
 
         // try fingerprint
         request.search.type = PGP_KEY_SEARCH_FINGERPRINT;
-        request.search.by.fingerprint = pgp_key_get_fp(handle->pub);
+        request.search.by.fingerprint = handle->pub->fp();
         handle->sec = pgp_request_key(&handle->ffi->key_provider, &request);
         if (handle->sec) {
             return handle->sec;
@@ -5418,7 +5412,7 @@ get_key_require_secret(rnp_key_handle_t handle)
 
         // try keyid
         request.search.type = PGP_KEY_SEARCH_KEYID;
-        request.search.by.keyid = pgp_key_get_keyid(handle->pub);
+        request.search.by.keyid = handle->pub->keyid();
         handle->sec = pgp_request_key(&handle->ffi->key_provider, &request);
     }
     return handle->sec;
@@ -6093,7 +6087,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    const pgp_fingerprint_t &fp = pgp_key_get_fp(get_key_prefer_public(handle));
+    const pgp_fingerprint_t &fp = get_key_prefer_public(handle)->fp();
     return hex_encode_value(fp.fingerprint, fp.length, fprint, RNP_HEX_UPPERCASE);
 }
 FFI_GUARD
@@ -6107,7 +6101,7 @@ try {
 
     pgp_key_t *key = get_key_prefer_public(handle);
     return hex_encode_value(
-      pgp_key_get_keyid(key).data(), pgp_key_get_keyid(key).size(), keyid, RNP_HEX_UPPERCASE);
+      key->keyid().data(), key->keyid().size(), keyid, RNP_HEX_UPPERCASE);
 }
 FFI_GUARD
 
@@ -6118,7 +6112,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    const pgp_key_grip_t &kgrip = pgp_key_get_grip(get_key_prefer_public(handle));
+    const pgp_key_grip_t &kgrip = get_key_prefer_public(handle)->grip();
     return hex_encode_value(kgrip.data(), kgrip.size(), grip, RNP_HEX_UPPERCASE);
 }
 FFI_GUARD
@@ -6133,7 +6127,7 @@ rnp_get_grip_by_fp(rnp_ffi_t ffi, const pgp_fingerprint_t &fp)
     if (!key && ffi->secring) {
         key = rnp_key_store_get_key_by_fpr(ffi->secring, fp);
     }
-    return key ? &pgp_key_get_grip(key) : NULL;
+    return key ? &key->grip() : NULL;
 }
 
 rnp_result_t
@@ -7199,11 +7193,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
 
     // keyid
     char keyid[PGP_KEY_ID_SIZE * 2 + 1];
-    if (!rnp_hex_encode(pgp_key_get_keyid(key).data(),
-                        pgp_key_get_keyid(key).size(),
-                        keyid,
-                        sizeof(keyid),
-                        RNP_HEX_UPPERCASE)) {
+    if (!rnp_hex_encode(
+          key->keyid().data(), key->keyid().size(), keyid, sizeof(keyid), RNP_HEX_UPPERCASE)) {
         return RNP_ERROR_GENERIC;
     }
     if (!add_json_string_field(jso, "keyid", keyid)) {
@@ -7211,11 +7202,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     }
     // fingerprint
     char fpr[PGP_FINGERPRINT_SIZE * 2 + 1];
-    if (!rnp_hex_encode(pgp_key_get_fp(key).fingerprint,
-                        pgp_key_get_fp(key).length,
-                        fpr,
-                        sizeof(fpr),
-                        RNP_HEX_UPPERCASE)) {
+    if (!rnp_hex_encode(
+          key->fp().fingerprint, key->fp().length, fpr, sizeof(fpr), RNP_HEX_UPPERCASE)) {
         return RNP_ERROR_GENERIC;
     }
     if (!add_json_string_field(jso, "fingerprint", fpr)) {
@@ -7223,11 +7211,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     }
     // grip
     char grip[PGP_KEY_GRIP_SIZE * 2 + 1];
-    if (!rnp_hex_encode(pgp_key_get_grip(key).data(),
-                        pgp_key_get_grip(key).size(),
-                        grip,
-                        sizeof(grip),
-                        RNP_HEX_UPPERCASE)) {
+    if (!rnp_hex_encode(
+          key->grip().data(), key->grip().size(), grip, sizeof(grip), RNP_HEX_UPPERCASE)) {
         return RNP_ERROR_GENERIC;
     }
     if (!add_json_string_field(jso, "grip", grip)) {
@@ -7647,27 +7632,21 @@ key_iter_get_item(const rnp_identifier_iterator_t it, char *buf, size_t buf_len)
     const pgp_key_t *key = &**it->keyp;
     switch (it->type) {
     case PGP_KEY_SEARCH_KEYID: {
-        const pgp_key_id_t &keyid = pgp_key_get_keyid(key);
-        if (!rnp_hex_encode(keyid.data(), keyid.size(), buf, buf_len, RNP_HEX_UPPERCASE)) {
+        if (!rnp_hex_encode(
+              key->keyid().data(), key->keyid().size(), buf, buf_len, RNP_HEX_UPPERCASE)) {
             return false;
         }
         break;
     }
     case PGP_KEY_SEARCH_FINGERPRINT:
-        if (!rnp_hex_encode(pgp_key_get_fp(key).fingerprint,
-                            pgp_key_get_fp(key).length,
-                            buf,
-                            buf_len,
-                            RNP_HEX_UPPERCASE)) {
+        if (!rnp_hex_encode(
+              key->fp().fingerprint, key->fp().length, buf, buf_len, RNP_HEX_UPPERCASE)) {
             return false;
         }
         break;
     case PGP_KEY_SEARCH_GRIP:
-        if (!rnp_hex_encode(pgp_key_get_grip(key).data(),
-                            pgp_key_get_grip(key).size(),
-                            buf,
-                            buf_len,
-                            RNP_HEX_UPPERCASE)) {
+        if (!rnp_hex_encode(
+              key->grip().data(), key->grip().size(), buf, buf_len, RNP_HEX_UPPERCASE)) {
             return false;
         }
         break;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3826,8 +3826,7 @@ rnp_key_get_revocation(rnp_ffi_t         ffi,
         FFI_LOG(ffi, "Failed to unlock secret key");
         return RNP_ERROR_BAD_PASSWORD;
     }
-    *sig =
-      transferable_key_revoke(*pgp_key_get_pkt(key), *pgp_key_get_pkt(revoker), halg, revinfo);
+    *sig = transferable_key_revoke(key->pkt(), revoker->pkt(), halg, revinfo);
     if (!*sig) {
         FFI_LOG(ffi, "Failed to generate revocation signature");
     }
@@ -5489,7 +5488,7 @@ try {
     if (!public_key && secret_key->format == PGP_KEY_STORE_G10) {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    seckey = &secret_key->pkt;
+    seckey = &secret_key->pkt();
     if (!seckey->material.secret) {
         pgp_password_ctx_t ctx = {.op = PGP_OP_ADD_USERID, .key = secret_key};
         decrypted_seckey = pgp_decrypt_seckey(secret_key, &handle->ffi->pass_provider, &ctx);
@@ -6369,8 +6368,8 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    pgp_s2k_t & s2k = key->sec->pkt.sec_protection.s2k;
-    const char *res = "Unknown";
+    const pgp_s2k_t &s2k = key->sec->pkt().sec_protection.s2k;
+    const char *     res = "Unknown";
     if (s2k.usage == PGP_S2KU_NONE) {
         res = "None";
     }
@@ -6404,16 +6403,16 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if (key->sec->pkt.sec_protection.s2k.usage == PGP_S2KU_NONE) {
+    if (key->sec->pkt().sec_protection.s2k.usage == PGP_S2KU_NONE) {
         return ret_str_value("None", mode);
     }
-    if (key->sec->pkt.sec_protection.s2k.specifier == PGP_S2KS_EXPERIMENTAL) {
+    if (key->sec->pkt().sec_protection.s2k.specifier == PGP_S2KS_EXPERIMENTAL) {
         return ret_str_value("Unknown", mode);
     }
 
     return get_map_value(cipher_mode_map,
                          ARRAY_SIZE(cipher_mode_map),
-                         key->sec->pkt.sec_protection.cipher_mode,
+                         key->sec->pkt().sec_protection.cipher_mode,
                          mode);
 }
 FFI_GUARD
@@ -6421,8 +6420,8 @@ FFI_GUARD
 static bool
 pgp_key_has_encryption_info(const pgp_key_t *key)
 {
-    return (key->pkt.sec_protection.s2k.usage != PGP_S2KU_NONE) &&
-           (key->pkt.sec_protection.s2k.specifier != PGP_S2KS_EXPERIMENTAL);
+    return (key->pkt().sec_protection.s2k.usage != PGP_S2KU_NONE) &&
+           (key->pkt().sec_protection.s2k.specifier != PGP_S2KS_EXPERIMENTAL);
 }
 
 rnp_result_t
@@ -6439,7 +6438,7 @@ try {
     }
 
     return get_map_value(
-      symm_alg_map, ARRAY_SIZE(symm_alg_map), key->sec->pkt.sec_protection.symm_alg, cipher);
+      symm_alg_map, ARRAY_SIZE(symm_alg_map), key->sec->pkt().sec_protection.symm_alg, cipher);
 }
 FFI_GUARD
 
@@ -6456,8 +6455,10 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    return get_map_value(
-      hash_alg_map, ARRAY_SIZE(hash_alg_map), key->sec->pkt.sec_protection.s2k.hash_alg, hash);
+    return get_map_value(hash_alg_map,
+                         ARRAY_SIZE(hash_alg_map),
+                         key->sec->pkt().sec_protection.s2k.hash_alg,
+                         hash);
 }
 FFI_GUARD
 
@@ -6474,8 +6475,8 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if (key->sec->pkt.sec_protection.s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
-        *iterations = pgp_s2k_decode_iterations(key->sec->pkt.sec_protection.s2k.iterations);
+    if (key->sec->pkt().sec_protection.s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
+        *iterations = pgp_s2k_decode_iterations(key->sec->pkt().sec_protection.s2k.iterations);
     } else {
         *iterations = 1;
     }
@@ -6593,7 +6594,7 @@ try {
     if (!key) {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    seckey = &key->pkt;
+    seckey = &key->pkt();
     if (pgp_key_is_encrypted(key)) {
         pgp_password_ctx_t ctx = {.op = PGP_OP_PROTECT, .key = key};
         decrypted_seckey = pgp_decrypt_seckey(key, &handle->ffi->pass_provider, &ctx);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3689,7 +3689,7 @@ find_encrypting_subkey(rnp_ffi_t ffi, const pgp_key_t &primary)
     pgp_key_search_t search = {};
     search.type = PGP_KEY_SEARCH_FINGERPRINT;
 
-    for (auto &fp : primary.subkey_fps) {
+    for (auto &fp : primary.subkey_fps()) {
         search.by.fingerprint = fp;
         pgp_key_t *subkey = find_key(ffi, &search, KEY_TYPE_PUBLIC, true);
         if (!subkey) {
@@ -5989,7 +5989,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t *key = get_key_prefer_public(handle);
-    *count = pgp_key_get_subkey_count(key);
+    *count = key->subkey_count();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -6001,10 +6001,10 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t *key = get_key_prefer_public(handle);
-    if (idx >= pgp_key_get_subkey_count(key)) {
+    if (idx >= key->subkey_count()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    const pgp_fingerprint_t &fp = pgp_key_get_subkey_fp(key, idx);
+    const pgp_fingerprint_t &fp = key->get_subkey_fp(idx);
     char                     fphex[PGP_FINGERPRINT_SIZE * 2 + 1] = {0};
     if (!rnp_hex_encode(fp.fingerprint, fp.length, fphex, sizeof(fphex), RNP_HEX_UPPERCASE)) {
         return RNP_ERROR_BAD_STATE;
@@ -6141,11 +6141,11 @@ try {
     if (!key->is_subkey()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    if (!pgp_key_has_primary_fp(key)) {
+    if (!key->has_primary_fp()) {
         *grip = NULL;
         return RNP_SUCCESS;
     }
-    const pgp_key_grip_t *pgrip = rnp_get_grip_by_fp(handle->ffi, pgp_key_get_primary_fp(key));
+    const pgp_key_grip_t *pgrip = rnp_get_grip_by_fp(handle->ffi, key->primary_fp());
     if (!pgrip) {
         *grip = NULL;
         return RNP_SUCCESS;
@@ -6165,11 +6165,11 @@ try {
     if (!key->is_subkey()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    if (!pgp_key_has_primary_fp(key)) {
+    if (!key->has_primary_fp()) {
         *fprint = NULL;
         return RNP_SUCCESS;
     }
-    const pgp_fingerprint_t &fp = pgp_key_get_primary_fp(key);
+    const pgp_fingerprint_t &fp = key->primary_fp();
     return hex_encode_value(fp.fingerprint, fp.length, fprint, RNP_HEX_UPPERCASE);
 }
 FFI_GUARD
@@ -6267,14 +6267,14 @@ try {
     }
 
     /* for subkey we need primary key */
-    if (!pgp_key_has_primary_fp(pkey)) {
+    if (!pkey->has_primary_fp()) {
         FFI_LOG(key->ffi, "Primary key fp not available.");
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
     pgp_key_search_t search = {};
     search.type = PGP_KEY_SEARCH_FINGERPRINT;
-    search.by.fingerprint = pgp_key_get_primary_fp(pkey);
+    search.by.fingerprint = pkey->primary_fp();
     pgp_key_t *prim_sec = find_key(key->ffi, &search, KEY_TYPE_SECRET, true);
     if (!prim_sec) {
         FFI_LOG(key->ffi, "Primary secret key not found.");
@@ -7251,7 +7251,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
             return RNP_ERROR_OUT_OF_MEMORY;
         }
         json_object_object_add(jso, "subkey grips", jsosubkeys_arr);
-        for (auto &subfp : key->subkey_fps) {
+        for (auto &subfp : key->subkey_fps()) {
             const pgp_key_grip_t *subgrip = rnp_get_grip_by_fp(handle->ffi, subfp);
             if (!subgrip) {
                 continue;
@@ -7266,9 +7266,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
                 return RNP_ERROR_OUT_OF_MEMORY;
             }
         }
-    } else if (pgp_key_has_primary_fp(key)) {
-        auto                  pfp = pgp_key_get_primary_fp(key);
-        const pgp_key_grip_t *pgrip = rnp_get_grip_by_fp(handle->ffi, pfp);
+    } else if (key->has_primary_fp()) {
+        auto pgrip = rnp_get_grip_by_fp(handle->ffi, key->primary_fp());
         if (pgrip) {
             if (!rnp_hex_encode(
                   pgrip->data(), pgrip->size(), grip, sizeof(grip), RNP_HEX_UPPERCASE)) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1184,8 +1184,7 @@ do_load_keys(rnp_ffi_t              ffi,
     for (auto &key : tmp_store->keys) {
         // check that the key is the correct type and has not already been loaded
         // add secret key part if it is and we need it
-        if (pgp_key_is_secret(&key) &&
-            ((key_type == KEY_TYPE_SECRET) || (key_type == KEY_TYPE_ANY))) {
+        if (key.is_secret() && ((key_type == KEY_TYPE_SECRET) || (key_type == KEY_TYPE_ANY))) {
             if (key_needs_conversion(&key, ffi->secring)) {
                 FFI_LOG(ffi, "This key format conversion is not yet supported");
                 ret = RNP_ERROR_NOT_IMPLEMENTED;
@@ -1478,7 +1477,7 @@ try {
     for (auto &key : tmp_store->keys) {
         pgp_key_import_status_t pub_status = PGP_KEY_IMPORT_STATUS_UNKNOWN;
         pgp_key_import_status_t sec_status = PGP_KEY_IMPORT_STATUS_UNKNOWN;
-        if (!pub && pgp_key_is_public(&key)) {
+        if (!pub && key.is_public()) {
             continue;
         }
         if (validate_pgp_key_material(&key.material(), &ffi->rng)) {
@@ -1494,7 +1493,7 @@ try {
             goto done;
         }
         // import secret key part if available and requested
-        if (sec && pgp_key_is_secret(&key)) {
+        if (sec && key.is_secret()) {
             if (!rnp_key_store_import_key(ffi->secring, &key, false, &sec_status)) {
                 ret = RNP_ERROR_BAD_PARAMETERS;
                 goto done;
@@ -2194,7 +2193,7 @@ rnp_op_add_signature(rnp_ffi_t                 ffi,
 
     pgp_key_t *signkey = find_suitable_key(
       PGP_OP_SIGN, get_key_prefer_public(key), &key->ffi->key_provider, PGP_KF_SIGN);
-    if (signkey && !pgp_key_is_secret(signkey)) {
+    if (signkey && !signkey->is_secret()) {
         pgp_key_request_ctx_t ctx = {.op = PGP_OP_SIGN, .secret = true};
         ctx.search.type = PGP_KEY_SEARCH_GRIP;
         ctx.search.by.grip = pgp_key_get_grip(signkey);
@@ -3646,17 +3645,15 @@ try {
         return RNP_ERROR_NOT_IMPLEMENTED;
     }
     if (armored) {
-        rnp_result_t res;
-        if ((res = init_armored_dst(&armordst,
-                                    &output->dst,
-                                    pgp_key_is_secret(key) ? PGP_ARMORED_SECRET_KEY :
-                                                             PGP_ARMORED_PUBLIC_KEY))) {
+        auto msgtype = key->is_secret() ? PGP_ARMORED_SECRET_KEY : PGP_ARMORED_PUBLIC_KEY;
+        rnp_result_t res = init_armored_dst(&armordst, &output->dst, msgtype);
+        if (res) {
             return res;
         }
         dst = &armordst;
     }
     // write
-    if (pgp_key_is_primary_key(key)) {
+    if (key->is_primary()) {
         // primary key, write just the primary or primary and all subkeys
         if (!pgp_key_write_xfer(dst, key, export_subs ? store : NULL)) {
             return RNP_ERROR_GENERIC;
@@ -3701,7 +3698,7 @@ find_encrypting_subkey(rnp_ffi_t ffi, const pgp_key_t &primary)
         if (!subkey) {
             subkey = find_key(ffi, &search, KEY_TYPE_SECRET, true);
         }
-        if (subkey && subkey->valid && pgp_key_can_encrypt(subkey)) {
+        if (subkey && subkey->valid && subkey->can_encrypt()) {
             return subkey;
         }
     }
@@ -3723,8 +3720,7 @@ try {
     }
     /* Get the primary key */
     pgp_key_t *primary = get_key_prefer_public(key);
-    if (!primary || !pgp_key_is_primary_key(primary) || !primary->valid ||
-        !pgp_key_can_sign(primary)) {
+    if (!primary || !primary->is_primary() || !primary->valid || !primary->can_sign()) {
         FFI_LOG(key->ffi, "No valid signing primary key");
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -3732,7 +3728,7 @@ try {
     pgp_key_t *sub = NULL;
     if (subkey) {
         sub = get_key_prefer_public(subkey);
-        if (sub && (!sub->valid || !pgp_key_can_encrypt(sub))) {
+        if (sub && (!sub->valid || !sub->can_encrypt())) {
             FFI_LOG(key->ffi, "Invalid or non-encrypting subkey");
             return RNP_ERROR_BAD_PARAMETERS;
         }
@@ -3778,7 +3774,7 @@ rnp_key_get_revoker(rnp_key_handle_t key)
     if (!exkey) {
         return NULL;
     }
-    if (pgp_key_is_subkey(exkey)) {
+    if (exkey->is_subkey()) {
         return rnp_key_store_get_primary_key(key->ffi->secring, exkey);
     }
     // TODO: search through revocation key subpackets as well
@@ -3852,7 +3848,7 @@ try {
     }
 
     pgp_key_t *exkey = get_key_prefer_public(key);
-    if (!exkey || !pgp_key_is_primary_key(exkey)) {
+    if (!exkey || !exkey->is_primary()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     pgp_key_t *revoker = rnp_key_get_revoker(key);
@@ -3950,7 +3946,7 @@ try {
     if (!pub && !sec) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    if (sub && pgp_key_is_subkey(get_key_prefer_public(key))) {
+    if (sub && get_key_prefer_public(key)->is_subkey()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -4884,7 +4880,7 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if (!pgp_key_can_sign(primary->sec)) {
+    if (!primary->sec->can_sign()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -5880,7 +5876,7 @@ try {
             return RNP_ERROR_KEY_NOT_FOUND;
         }
         pgp_key_t *primary = NULL;
-        if (pgp_key_is_subkey(sig->key)) {
+        if (sig->key->is_subkey()) {
             primary = rnp_key_store_get_primary_key(sig->ffi->pubring, sig->key);
             if (!primary) {
                 return RNP_ERROR_KEY_NOT_FOUND;
@@ -6030,8 +6026,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t *key = get_key_prefer_public(handle);
-    return get_map_value(
-      pubkey_alg_map, ARRAY_SIZE(pubkey_alg_map), pgp_key_get_alg(key), alg);
+    return get_map_value(pubkey_alg_map, ARRAY_SIZE(pubkey_alg_map), key->alg(), alg);
 }
 FFI_GUARD
 
@@ -6042,7 +6037,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t *key = get_key_prefer_public(handle);
-    size_t     _bits = pgp_key_get_bits(key);
+    size_t     _bits = key->material().bits();
     if (!_bits) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -6058,7 +6053,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t *key = get_key_prefer_public(handle);
-    size_t     _qbits = pgp_key_get_dsa_qbits(key);
+    size_t     _qbits = key->material().qbits();
     if (!_qbits) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -6074,7 +6069,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t * key = get_key_prefer_public(handle);
-    pgp_curve_t _curve = pgp_key_get_curve(key);
+    pgp_curve_t _curve = key->curve();
     if (_curve == PGP_CURVE_UNKNOWN) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -6149,7 +6144,7 @@ try {
     }
 
     pgp_key_t *key = get_key_prefer_public(handle);
-    if (!pgp_key_is_subkey(key)) {
+    if (!key->is_subkey()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     if (!pgp_key_has_primary_fp(key)) {
@@ -6173,7 +6168,7 @@ try {
     }
 
     pgp_key_t *key = get_key_prefer_public(handle);
-    if (!pgp_key_is_subkey(key)) {
+    if (!key->is_subkey()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     if (!pgp_key_has_primary_fp(key)) {
@@ -6199,7 +6194,7 @@ try {
     if (!key) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    *result = pgp_key_get_flags(key) & flag;
+    *result = key->flags() & flag;
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -6214,7 +6209,7 @@ try {
     if (!key) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    *result = pgp_key_get_creation(key);
+    *result = key->creation();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -6244,7 +6239,7 @@ try {
     if (!key) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    *result = pgp_key_get_expiration(key);
+    *result = key->expiration();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -6266,7 +6261,7 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if (pgp_key_is_primary_key(pkey)) {
+    if (pkey->is_primary()) {
         if (!pgp_key_set_expiration(pkey, skey, expiry, &key->ffi->pass_provider)) {
             return RNP_ERROR_GENERIC;
         }
@@ -6595,7 +6590,7 @@ try {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
     seckey = &key->pkt();
-    if (pgp_key_is_encrypted(key)) {
+    if (key->encrypted()) {
         pgp_password_ctx_t ctx = {.op = PGP_OP_PROTECT, .key = key};
         decrypted_seckey = pgp_decrypt_seckey(key, &handle->ffi->pass_provider, &ctx);
         if (!decrypted_seckey) {
@@ -6654,7 +6649,7 @@ try {
         // we can't currently determine this for a G10 secret key
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    *result = pgp_key_is_primary_key(key);
+    *result = key->is_primary();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -6670,7 +6665,7 @@ try {
         // we can't currently determine this for a G10 secret key
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    *result = pgp_key_is_subkey(key);
+    *result = key->is_subkey();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -6888,7 +6883,7 @@ static rnp_result_t
 add_json_secret_mpis(json_object *jso, pgp_key_t *key)
 {
     const pgp_key_material_t &km = key->material();
-    switch (pgp_key_get_alg(key)) {
+    switch (key->alg()) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
@@ -7150,7 +7145,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     const pgp_key_material_t &material = key->material();
 
     // type
-    ARRAY_LOOKUP_BY_ID(pubkey_alg_map, type, string, pgp_key_get_alg(key), str);
+    ARRAY_LOOKUP_BY_ID(pubkey_alg_map, type, string, key->alg(), str);
     if (!str) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -7158,11 +7153,11 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // length
-    if (!add_json_int_field(jso, "length", pgp_key_get_bits(key))) {
+    if (!add_json_int_field(jso, "length", key->material().bits())) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // curve / alg-specific items
-    switch (pgp_key_get_alg(key)) {
+    switch (key->alg()) {
     case PGP_PKA_ECDH: {
         const char *hash_name = NULL;
         ARRAY_LOOKUP_BY_ID(hash_alg_map, type, string, material.ec.kdf_hash_alg, hash_name);
@@ -7245,27 +7240,27 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     }
     json_object_object_add(jso, "revoked", jsorevoked);
     // creation time
-    json_object *jsocreation_time = json_object_new_int64(pgp_key_get_creation(key));
+    json_object *jsocreation_time = json_object_new_int64(key->creation());
     if (!jsocreation_time) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     json_object_object_add(jso, "creation time", jsocreation_time);
     // expiration
-    json_object *jsoexpiration = json_object_new_int64(pgp_key_get_expiration(key));
+    json_object *jsoexpiration = json_object_new_int64(key->expiration());
     if (!jsoexpiration) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     json_object_object_add(jso, "expiration", jsoexpiration);
     // key flags (usage)
-    if (!add_json_key_usage(jso, pgp_key_get_flags(key))) {
+    if (!add_json_key_usage(jso, key->flags())) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // key flags (other)
-    if (!add_json_key_flags(jso, pgp_key_get_flags(key))) {
+    if (!add_json_key_flags(jso, key->flags())) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // parent / subkeys
-    if (pgp_key_is_primary_key(key)) {
+    if (key->is_primary()) {
         json_object *jsosubkeys_arr = json_object_new_array();
         if (!jsosubkeys_arr) {
             return RNP_ERROR_OUT_OF_MEMORY;
@@ -7356,7 +7351,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
         json_object_object_add(jsosecret, "protected", jsoprotected);
     }
     // userids
-    if (pgp_key_is_primary_key(key)) {
+    if (key->is_primary()) {
         json_object *jsouids_arr = json_object_new_array();
         if (!jsouids_arr) {
             return RNP_ERROR_OUT_OF_MEMORY;
@@ -7385,7 +7380,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
             }
             rnp_result_t tmpret;
             if ((tmpret =
-                   add_json_subsig(jsosig, pgp_key_is_subkey(key), flags, &key->get_sig(i)))) {
+                   add_json_subsig(jsosig, key->is_subkey(), flags, &key->get_sig(i)))) {
                 return tmpret;
             }
         }

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -163,6 +163,9 @@ typedef struct pgp_key_material_t {
         pgp_eg_key_t  eg;
         pgp_ec_key_t  ec;
     };
+
+    size_t bits() const;
+    size_t qbits() const;
 } pgp_key_material_t;
 
 /**

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -56,7 +56,7 @@ void         set_rnp_log_switch(int8_t);
             break;                                                                     \
         }                                                                              \
         char                keyid[PGP_KEY_ID_SIZE * 2 + 1] = {0};                      \
-        const pgp_key_id_t &id = pgp_key_get_keyid(key);                               \
+        const pgp_key_id_t &id = key->keyid();                                         \
         rnp_hex_encode(id.data(), id.size(), keyid, sizeof(keyid), RNP_HEX_LOWERCASE); \
         RNP_LOG(msg, keyid);                                                           \
     } while (0)

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1062,38 +1062,37 @@ g10_decrypt_seckey(const uint8_t *      data,
 }
 
 static bool
-copy_secret_fields(pgp_key_pkt_t *dst, const pgp_key_pkt_t *src)
+copy_secret_fields(pgp_key_pkt_t &dst, const pgp_key_pkt_t &src)
 {
-    switch (src->alg) {
+    switch (src.alg) {
     case PGP_PKA_DSA:
-        dst->material.dsa.x = src->material.dsa.x;
+        dst.material.dsa.x = src.material.dsa.x;
         break;
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
-        dst->material.rsa.d = src->material.rsa.d;
-        dst->material.rsa.p = src->material.rsa.p;
-        dst->material.rsa.q = src->material.rsa.q;
-        dst->material.rsa.u = src->material.rsa.u;
+        dst.material.rsa.d = src.material.rsa.d;
+        dst.material.rsa.p = src.material.rsa.p;
+        dst.material.rsa.q = src.material.rsa.q;
+        dst.material.rsa.u = src.material.rsa.u;
         break;
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
-        dst->material.eg.x = src->material.eg.x;
+        dst.material.eg.x = src.material.eg.x;
         break;
     case PGP_PKA_ECDSA:
     case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
-        dst->material.ec.x = src->material.ec.x;
+        dst.material.ec.x = src.material.ec.x;
         break;
     default:
-        RNP_LOG("Unsupported public key algorithm: %d", (int) src->alg);
+        RNP_LOG("Unsupported public key algorithm: %d", (int) src.alg);
         return false;
     }
 
-    dst->material.secret = src->material.secret;
-    dst->sec_protection = src->sec_protection;
-    dst->tag = is_subkey_pkt(dst->tag) ? PGP_PKT_SECRET_SUBKEY : PGP_PKT_SECRET_KEY;
-
+    dst.material.secret = src.material.secret;
+    dst.sec_protection = src.sec_protection;
+    dst.tag = is_subkey_pkt(dst.tag) ? PGP_PKT_SECRET_SUBKEY : PGP_PKT_SECRET_KEY;
     return true;
 }
 
@@ -1143,11 +1142,11 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
             goto done;
         }
 
-        if (!copy_secret_fields(&key.pkt, &seckey)) {
+        if (!copy_secret_fields(key.pkt(), seckey)) {
             goto done;
         }
     } else {
-        key.pkt = std::move(seckey);
+        key.set_pkt(std::move(seckey));
     }
 
     try {

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1150,8 +1150,8 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
     }
 
     try {
-        key.rawpkt = pgp_rawpacket_t(
-          (uint8_t *) mem_src_get_memory(&memsrc), memsrc.size, PGP_PKT_RESERVED);
+        key.set_rawpkt(pgp_rawpacket_t(
+          (uint8_t *) mem_src_get_memory(&memsrc), memsrc.size, PGP_PKT_RESERVED));
     } catch (const std::exception &e) {
         RNP_LOG("failed to add packet: %s", e.what());
         goto done;
@@ -1558,14 +1558,11 @@ error:
 bool
 rnp_key_store_g10_key_to_dst(pgp_key_t *key, pgp_dest_t *dest)
 {
-    if (!pgp_key_get_rawpacket_count(key)) {
-        return false;
-    }
     if (key->format != PGP_KEY_STORE_G10) {
         RNP_LOG("incorrect format: %d", key->format);
         return false;
     }
-    pgp_rawpacket_t &packet = pgp_key_get_rawpacket(key);
+    pgp_rawpacket_t &packet = key->rawpkt();
     dst_write(dest, packet.raw.data(), packet.raw.size());
     return dest->werr == RNP_SUCCESS;
 }

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -576,7 +576,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
         goto finish;
     }
 
-    if (!pbuf(&memdst, pgp_key_get_fp(key).fingerprint, PGP_FINGERPRINT_SIZE) ||
+    if (!pbuf(&memdst, key->fp().fingerprint, PGP_FINGERPRINT_SIZE) ||
         !pu32(&memdst, memdst.writeb - 8) || // offset to keyid (part of fpr for V4)
         !pu16(&memdst, 0) ||                 // flags, not used by GnuPG
         !pu16(&memdst, 0)) {                 // RFU
@@ -586,7 +586,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
     // same as above, for each subkey
     for (auto &sfp : key->subkey_fps) {
         pgp_key_t *subkey = rnp_key_store_get_key_by_fpr(key_store, sfp);
-        if (!pbuf(&memdst, pgp_key_get_fp(subkey).fingerprint, PGP_FINGERPRINT_SIZE) ||
+        if (!pbuf(&memdst, subkey->fp().fingerprint, PGP_FINGERPRINT_SIZE) ||
             !pu32(&memdst, memdst.writeb - 8) || // offset to keyid (part of fpr for V4)
             !pu16(&memdst, 0) ||                 // flags, not used by GnuPG
             !pu16(&memdst, 0)) {                 // RFU

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -569,7 +569,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
         goto finish;
     }
 
-    if (!pu16(&memdst, 1 + key->subkey_fps.size())) { // number of keys in keyblock
+    if (!pu16(&memdst, 1 + key->subkey_count())) { // number of keys in keyblock
         goto finish;
     }
     if (!pu16(&memdst, 28)) { // size of key info structure)
@@ -584,7 +584,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
     }
 
     // same as above, for each subkey
-    for (auto &sfp : key->subkey_fps) {
+    for (auto &sfp : key->subkey_fps()) {
         pgp_key_t *subkey = rnp_key_store_get_key_by_fpr(key_store, sfp);
         if (!pbuf(&memdst, subkey->fp().fingerprint, PGP_FINGERPRINT_SIZE) ||
             !pu32(&memdst, memdst.writeb - 8) || // offset to keyid (part of fpr for V4)
@@ -692,7 +692,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
         goto finish;
     }
 
-    for (auto &sfp : key->subkey_fps) {
+    for (auto &sfp : key->subkey_fps()) {
         const pgp_key_t *subkey = rnp_key_store_get_key_by_fpr(key_store, sfp);
         if (!pgp_key_write_packets(subkey, &memdst)) {
             goto finish;

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -765,7 +765,7 @@ rnp_key_store_kbx_to_dst(rnp_key_store_t *key_store, pgp_dest_t *dst)
     }
 
     for (auto &key : key_store->keys) {
-        if (!pgp_key_is_primary_key(&key)) {
+        if (!key.is_primary()) {
             continue;
         }
         if (!rnp_key_store_kbx_write_pgp(key_store, &key, dst)) {

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -206,11 +206,11 @@ static bool
 do_write(rnp_key_store_t *key_store, pgp_dest_t *dst, bool secret)
 {
     for (auto &key : key_store->keys) {
-        if (pgp_key_is_secret(&key) != secret) {
+        if (key.is_secret() != secret) {
             continue;
         }
         // skip subkeys, they are written below (orphans are ignored)
-        if (!pgp_key_is_primary_key(&key)) {
+        if (!key.is_primary()) {
             continue;
         }
 

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -78,6 +78,7 @@ rnp_key_store_add_transferable_subkey(rnp_key_store_t *          keyring,
         /* add it to the storage */
         return rnp_key_store_add_key(keyring, &skey);
     } catch (const std::exception &e) {
+        RNP_LOG("%s", e.what());
         RNP_LOG_KEY_PKT("failed to create subkey %s", tskey->subkey);
         RNP_LOG_KEY("primary key is %s", pkey);
         return false;
@@ -221,7 +222,7 @@ do_write(rnp_key_store_t *key_store, pgp_dest_t *dst, bool secret)
         if (!pgp_key_write_packets(&key, dst)) {
             return false;
         }
-        for (auto &sfp : key.subkey_fps) {
+        for (auto &sfp : key.subkey_fps()) {
             pgp_key_t *subkey = rnp_key_store_get_key_by_fpr(key_store, sfp);
             if (!subkey) {
                 RNP_LOG("Missing subkey");

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -287,9 +287,9 @@ rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *prim
     if (pgp_key_is_secret(dst) && !pgp_key_is_locked(dst)) {
         /* we may do thing below only because key material is opaque structure without
          * pointers! */
-        tmpkey.pkt.material = dst->pkt.material;
+        tmpkey.pkt().material = dst->pkt().material;
     } else if (pgp_key_is_secret(src) && !pgp_key_is_locked(src)) {
-        tmpkey.pkt.material = src->pkt.material;
+        tmpkey.pkt().material = src->pkt().material;
     }
     /* copy validity status */
     tmpkey.valid = dst->valid && src->valid;
@@ -355,9 +355,9 @@ rnp_key_store_merge_key(pgp_key_t *dst, const pgp_key_t *src)
     if (pgp_key_is_secret(dst) && !pgp_key_is_locked(dst)) {
         /* we may do thing below only because key material is opaque structure without
          * pointers! */
-        tmpkey.pkt.material = dst->pkt.material;
+        tmpkey.pkt().material = dst->pkt().material;
     } else if (pgp_key_is_secret(src) && !pgp_key_is_locked(src)) {
-        tmpkey.pkt.material = src->pkt.material;
+        tmpkey.pkt().material = src->pkt().material;
     }
     /* copy validity status */
     tmpkey.valid = dst->valid && src->valid;
@@ -603,7 +603,7 @@ rnp_key_store_import_subkey_signature(rnp_key_store_t *      keyring,
     }
 
     try {
-        pgp_key_t tmpkey(key->pkt);
+        pgp_key_t tmpkey(key->pkt());
         tmpkey.add_sig(*sig);
         if (!pgp_subkey_refresh_data(&tmpkey, primary)) {
             RNP_LOG("Failed to add signature to the key.");
@@ -639,7 +639,7 @@ rnp_key_store_import_key_signature(rnp_key_store_t *      keyring,
     }
 
     try {
-        pgp_key_t tmpkey(key->pkt);
+        pgp_key_t tmpkey(key->pkt());
         tmpkey.add_sig(*sig);
         if (!pgp_key_refresh_data(&tmpkey)) {
             RNP_LOG("Failed to add signature to the key.");

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -543,7 +543,7 @@ rnp_key_store_import_key(rnp_key_store_t *        keyring,
 {
     /* add public key */
     pgp_key_t *exkey = rnp_key_store_get_key_by_fpr(keyring, srckey->fp());
-    size_t     expackets = exkey ? pgp_key_get_rawpacket_count(exkey) : 0;
+    size_t     expackets = exkey ? exkey->rawpkt_count() : 0;
     keyring->disable_validation = true;
     try {
         pgp_key_t keycp(*srckey, pubkey);
@@ -558,7 +558,7 @@ rnp_key_store_import_key(rnp_key_store_t *        keyring,
         RNP_LOG("failed to add key to the keyring");
         return NULL;
     }
-    bool changed = pgp_key_get_rawpacket_count(exkey) > expackets;
+    bool changed = exkey->rawpkt_count() > expackets;
     if (changed || !exkey->validated) {
         /* this will revalidated primary key with all subkeys */
         pgp_key_revalidate_updated(exkey, keyring);
@@ -616,15 +616,14 @@ rnp_key_store_import_subkey_signature(rnp_key_store_t *      keyring,
             return PGP_SIG_IMPORT_STATUS_UNKNOWN;
         }
 
-        size_t expackets = pgp_key_get_rawpacket_count(key);
+        size_t expackets = key->rawpkt_count();
         key = rnp_key_store_add_key(keyring, &tmpkey);
         if (!key) {
             RNP_LOG("Failed to add key with imported sig to the keyring");
             return PGP_SIG_IMPORT_STATUS_UNKNOWN;
         }
-        return (pgp_key_get_rawpacket_count(key) > expackets) ?
-                 PGP_SIG_IMPORT_STATUS_NEW :
-                 PGP_SIG_IMPORT_STATUS_UNCHANGED;
+        return (key->rawpkt_count() > expackets) ? PGP_SIG_IMPORT_STATUS_NEW :
+                                                   PGP_SIG_IMPORT_STATUS_UNCHANGED;
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;
@@ -652,15 +651,14 @@ rnp_key_store_import_key_signature(rnp_key_store_t *      keyring,
             return PGP_SIG_IMPORT_STATUS_UNKNOWN;
         }
 
-        size_t expackets = pgp_key_get_rawpacket_count(key);
+        size_t expackets = key->rawpkt_count();
         key = rnp_key_store_add_key(keyring, &tmpkey);
         if (!key) {
             RNP_LOG("Failed to add key with imported sig to the keyring");
             return PGP_SIG_IMPORT_STATUS_UNKNOWN;
         }
-        return (pgp_key_get_rawpacket_count(key) > expackets) ?
-                 PGP_SIG_IMPORT_STATUS_NEW :
-                 PGP_SIG_IMPORT_STATUS_UNCHANGED;
+        return (key->rawpkt_count() > expackets) ? PGP_SIG_IMPORT_STATUS_NEW :
+                                                   PGP_SIG_IMPORT_STATUS_UNCHANGED;
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -450,11 +450,6 @@ rnp_key_store_add_subkey(rnp_key_store_t *keyring, pgp_key_t *srckey, pgp_key_t 
             keyring->keys.emplace_back();
             oldkey = &keyring->keys.back();
             keyring->keybyfp[srckey->fp()] = std::prev(keyring->keys.end());
-        } catch (const std::exception &e) {
-            RNP_LOG("%s", e.what());
-            return NULL;
-        }
-        try {
             *oldkey = pgp_key_t(*srckey);
             if (primary) {
                 primary->link_subkey_fp(*oldkey);
@@ -463,8 +458,10 @@ rnp_key_store_add_subkey(rnp_key_store_t *keyring, pgp_key_t *srckey, pgp_key_t 
             RNP_LOG_KEY("key %s copying failed", srckey);
             RNP_LOG_KEY("primary key is %s", primary);
             RNP_LOG("%s", e.what());
-            keyring->keys.pop_back();
-            keyring->keybyfp.erase(srckey->fp());
+            if (oldkey) {
+                keyring->keys.pop_back();
+                keyring->keybyfp.erase(srckey->fp());
+            }
             return NULL;
         }
     }
@@ -506,11 +503,6 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
             keyring->keys.emplace_back();
             added_key = &keyring->keys.back();
             keyring->keybyfp[srckey->fp()] = std::prev(keyring->keys.end());
-        } catch (const std::exception &e) {
-            RNP_LOG("%s", e.what());
-            return NULL;
-        }
-        try {
             *added_key = pgp_key_t(*srckey);
             /* primary key may be added after subkeys, so let's handle this case correctly */
             if (!rnp_key_store_refresh_subkey_grips(keyring, added_key)) {
@@ -519,8 +511,10 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
         } catch (const std::exception &e) {
             RNP_LOG_KEY("key %s copying failed", srckey);
             RNP_LOG("%s", e.what());
-            keyring->keys.pop_back();
-            keyring->keybyfp.erase(srckey->fp());
+            if (added_key) {
+                keyring->keys.pop_back();
+                keyring->keybyfp.erase(srckey->fp());
+            }
             return NULL;
         }
     }

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1998,7 +1998,7 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
                     continue;
                 }
             } else {
-                decrypted_seckey = &(seckey->pkt);
+                decrypted_seckey = &seckey->pkt();
             }
 
             /* Try to initialize the decryption */

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1989,7 +1989,7 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
                 continue;
             }
             /* Decrypt key */
-            if (pgp_key_is_encrypted(seckey)) {
+            if (seckey->encrypted()) {
                 pgp_password_ctx_t pass_ctx{.op = PGP_OP_DECRYPT, .key = seckey};
                 decrypted_seckey =
                   pgp_decrypt_seckey(seckey, handler->password_provider, &pass_ctx);
@@ -2012,7 +2012,7 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
             }
 
             /* Destroy decrypted key */
-            if (pgp_key_is_encrypted(seckey)) {
+            if (seckey->encrypted()) {
                 delete decrypted_seckey;
                 decrypted_seckey = NULL;
             }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -345,15 +345,15 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
     }
 
     /* check key creation time vs signature creation */
-    kcreate = pgp_key_get_creation(sinfo->signer);
+    kcreate = sinfo->signer->creation();
     if (kcreate > create) {
         RNP_LOG("key is newer than signature");
         sinfo->valid = false;
     }
 
     /* check whether key was not expired when sig created */
-    if (!sinfo->ignore_expiry && pgp_key_get_expiration(sinfo->signer) &&
-        (kcreate + pgp_key_get_expiration(sinfo->signer) < create)) {
+    if (!sinfo->ignore_expiry && sinfo->signer->expiration() &&
+        (kcreate + sinfo->signer->expiration() < create)) {
         RNP_LOG("signature made after key expiration");
         sinfo->valid = false;
     }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -323,8 +323,7 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
 
     /* Validate signature itself */
     if (sinfo->signer_valid || sinfo->signer->valid) {
-        sinfo->valid =
-          !signature_validate(sinfo->sig, pgp_key_get_material(sinfo->signer), hash);
+        sinfo->valid = !signature_validate(sinfo->sig, &sinfo->signer->material(), hash);
     } else {
         sinfo->valid = false;
         RNP_LOG("invalid or untrusted key");

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -397,7 +397,7 @@ signature_check_binding(pgp_signature_info_t *sinfo,
     pgp_hash_t   hash = {};
     rnp_result_t res = RNP_ERROR_SIGNATURE_INVALID;
 
-    if (!signature_hash_binding(sinfo->sig, key, pgp_key_get_pkt(subkey), &hash)) {
+    if (!signature_hash_binding(sinfo->sig, key, &subkey->pkt(), &hash)) {
         return RNP_ERROR_BAD_FORMAT;
     }
 
@@ -428,7 +428,7 @@ signature_check_binding(pgp_signature_info_t *sinfo,
         return res;
     }
 
-    if (!signature_hash_binding(subpkt->fields.sig, key, pgp_key_get_pkt(subkey), &hash)) {
+    if (!signature_hash_binding(subpkt->fields.sig, key, &subkey->pkt(), &hash)) {
         return RNP_ERROR_BAD_FORMAT;
     }
     pgp_signature_info_t bindinfo = {};

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -359,7 +359,7 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
     }
 
     /* Check signer's fingerprint */
-    if (sinfo->sig->has_keyfp() && (sinfo->sig->keyfp() != pgp_key_get_fp(sinfo->signer))) {
+    if (sinfo->sig->has_keyfp() && (sinfo->sig->keyfp() != sinfo->signer->fp())) {
         RNP_LOG("issuer fingerprint doesn't match signer's one");
         sinfo->valid = false;
     }

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -520,7 +520,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
     /* Fill pkey */
     pkey.version = PGP_PKSK_V3;
     pkey.alg = userkey->alg();
-    pkey.key_id = pgp_key_get_keyid(userkey);
+    pkey.key_id = userkey->keyid();
 
     /* Encrypt the session key */
     enckey[0] = param->ctx->ealg;
@@ -566,7 +566,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
                                  enckey,
                                  keylen + 3,
                                  &userkey->material().ec,
-                                 pgp_key_get_fp(userkey));
+                                 userkey->fp());
         if (ret != RNP_SUCCESS) {
             RNP_LOG("ECDH encryption failed %d", ret);
             goto finish;
@@ -1063,8 +1063,8 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
 
     /* fill signature fields */
     try {
-        sig->set_keyfp(pgp_key_get_fp(signer->key));
-        sig->set_keyid(pgp_key_get_keyid(signer->key));
+        sig->set_keyfp(signer->key->fp());
+        sig->set_keyid(signer->key->keyid());
         sig->set_creation(signer->sigcreate ? signer->sigcreate : time(NULL));
         sig->set_expiration(signer->sigexpire);
     } catch (const std::exception &e) {
@@ -1256,7 +1256,7 @@ signed_add_signer(pgp_dest_signed_param_t *param, rnp_signer_info_t *signer, boo
     sinfo.onepass.type = PGP_SIG_BINARY;
     sinfo.onepass.halg = sinfo.halg;
     sinfo.onepass.palg = sinfo.key->alg();
-    sinfo.onepass.keyid = pgp_key_get_keyid(sinfo.key);
+    sinfo.onepass.keyid = sinfo.key->keyid();
     sinfo.onepass.nested = false;
     try {
         param->siginfos.push_back(sinfo);

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1056,10 +1056,10 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
                       pgp_signature_t *        sig,
                       pgp_dest_signer_info_t * signer)
 {
-    pgp_key_pkt_t *    deckey = NULL;
-    pgp_hash_t         hash;
-    pgp_password_ctx_t ctx = {.op = PGP_OP_SIGN, .key = signer->key};
-    rnp_result_t       ret = RNP_ERROR_GENERIC;
+    const pgp_key_pkt_t *deckey = NULL;
+    pgp_hash_t           hash;
+    pgp_password_ctx_t   ctx = {.op = PGP_OP_SIGN, .key = signer->key};
+    rnp_result_t         ret = RNP_ERROR_GENERIC;
 
     /* fill signature fields */
     try {
@@ -1090,7 +1090,7 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
             return RNP_ERROR_BAD_PASSWORD;
         }
     } else {
-        deckey = &(signer->key->pkt);
+        deckey = &signer->key->pkt();
     }
 
     /* calculate the signature */
@@ -1115,7 +1115,7 @@ signed_write_signature(pgp_dest_signed_param_t *param,
         sig.palg = signer->onepass.palg;
         sig.set_type(signer->onepass.type);
     } else {
-        sig.halg = pgp_hash_adjust_alg_to_key(signer->halg, pgp_key_get_pkt(signer->key));
+        sig.halg = pgp_hash_adjust_alg_to_key(signer->halg, &signer->key->pkt());
         sig.palg = pgp_key_get_alg(signer->key);
         sig.set_type(param->ctx->detached ? PGP_SIG_BINARY : PGP_SIG_TEXT);
     }
@@ -1234,7 +1234,7 @@ signed_add_signer(pgp_dest_signed_param_t *param, rnp_signer_info_t *signer, boo
     sinfo.sigexpire = signer->sigexpire;
 
     /* Add hash to the list */
-    sinfo.halg = pgp_hash_adjust_alg_to_key(signer->halg, pgp_key_get_pkt(signer->key));
+    sinfo.halg = pgp_hash_adjust_alg_to_key(signer->halg, &signer->key->pkt());
     if (!pgp_hash_list_add(param->hashes, sinfo.halg)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -540,7 +540,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
                                 &pkey.material.rsa,
                                 enckey,
                                 keylen + 3,
-                                &pgp_key_get_material(userkey)->rsa);
+                                &userkey->material().rsa);
         if (ret) {
             RNP_LOG("rsa_encrypt_pkcs1 failed");
             goto finish;
@@ -553,7 +553,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
                           enckey,
                           keylen + 3,
                           PGP_HASH_SM3,
-                          &pgp_key_get_material(userkey)->ec);
+                          &userkey->material().ec);
         if (ret != RNP_SUCCESS) {
             RNP_LOG("sm2_encrypt failed");
             goto finish;
@@ -565,7 +565,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
                                  &pkey.material.ecdh,
                                  enckey,
                                  keylen + 3,
-                                 &pgp_key_get_material(userkey)->ec,
+                                 &userkey->material().ec,
                                  pgp_key_get_fp(userkey));
         if (ret != RNP_SUCCESS) {
             RNP_LOG("ECDH encryption failed %d", ret);
@@ -578,7 +578,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
                                     &pkey.material.eg,
                                     enckey,
                                     keylen + 3,
-                                    &pgp_key_get_material(userkey)->eg);
+                                    &userkey->material().eg);
         if (ret) {
             RNP_LOG("pgp_elgamal_public_encrypt failed");
             goto finish;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -9838,7 +9838,7 @@ check_key_autocrypt(rnp_output_t       memout,
     if ((key->pub->sig_count() != 1) || (sub->pub->sig_count() != 1)) {
         return false;
     }
-    if (!pgp_key_can_sign(key->pub) || !pgp_key_can_encrypt(sub->pub)) {
+    if (!key->pub->can_sign() || !sub->pub->can_encrypt()) {
         return false;
     }
     if ((key->pub->uid_count() != 1) || (key->pub->get_uid(0).str != uid)) {

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -961,8 +961,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
         psiginfo.sig = psig;
         psiginfo.signer = &pub;
-        assert_rnp_success(signature_check_certification(
-          &psiginfo, pgp_key_get_pkt(&pub), &pub.get_uid(0).pkt));
+        assert_rnp_success(
+          signature_check_certification(&psiginfo, &pub.pkt(), &pub.get_uid(0).pkt));
         assert_true(psig->keyfp() == pgp_key_get_fp(&pub));
         // check subpackets and their contents
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_ISSUER_FPR);
@@ -980,18 +980,18 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
         ssiginfo.sig = ssig;
         ssiginfo.signer = &sec;
-        assert_rnp_success(signature_check_certification(
-          &ssiginfo, pgp_key_get_pkt(&sec), &sec.get_uid(0).pkt));
+        assert_rnp_success(
+          signature_check_certification(&ssiginfo, &sec.pkt(), &sec.get_uid(0).pkt));
         assert_true(ssig->keyfp() == pgp_key_get_fp(&sec));
 
         // modify a hashed portion of the sig packets
         psig->hashed_data[32] ^= 0xff;
         ssig->hashed_data[32] ^= 0xff;
         // ensure validation fails
-        assert_rnp_failure(signature_check_certification(
-          &psiginfo, pgp_key_get_pkt(&pub), &pub.get_uid(0).pkt));
-        assert_rnp_failure(signature_check_certification(
-          &ssiginfo, pgp_key_get_pkt(&sec), &sec.get_uid(0).pkt));
+        assert_rnp_failure(
+          signature_check_certification(&psiginfo, &pub.pkt(), &pub.get_uid(0).pkt));
+        assert_rnp_failure(
+          signature_check_certification(&ssiginfo, &sec.pkt(), &sec.get_uid(0).pkt));
         // restore the original data
         psig->hashed_data[32] ^= 0xff;
         ssig->hashed_data[32] ^= 0xff;
@@ -1002,10 +1002,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         uid.uid_len = 4;
         memcpy(uid.uid, "fake", 4);
 
-        assert_rnp_failure(
-          signature_check_certification(&psiginfo, pgp_key_get_pkt(&pub), &uid));
-        assert_rnp_failure(
-          signature_check_certification(&ssiginfo, pgp_key_get_pkt(&sec), &uid));
+        assert_rnp_failure(signature_check_certification(&psiginfo, &pub.pkt(), &uid));
+        assert_rnp_failure(signature_check_certification(&ssiginfo, &sec.pkt(), &uid));
 
         // validate via an alternative method
         // primary_pub + pubring
@@ -1086,8 +1084,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         // validate the binding sig
         psiginfo.sig = psig;
         psiginfo.signer = primary_pub;
-        assert_rnp_success(
-          signature_check_binding(&psiginfo, pgp_key_get_pkt(primary_pub), &pub));
+        assert_rnp_success(signature_check_binding(&psiginfo, &primary_pub->pkt(), &pub));
         assert_true(psig->keyfp() == pgp_key_get_fp(primary_pub));
         // check subpackets and their contents
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_ISSUER_FPR);
@@ -1107,18 +1104,15 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
         ssiginfo.sig = ssig;
         ssiginfo.signer = primary_pub;
-        assert_rnp_success(
-          signature_check_binding(&ssiginfo, pgp_key_get_pkt(primary_pub), &sec));
+        assert_rnp_success(signature_check_binding(&ssiginfo, &primary_pub->pkt(), &sec));
         assert_true(ssig->keyfp() == pgp_key_get_fp(primary_sec));
 
         // modify a hashed portion of the sig packets
         psig->hashed_data[10] ^= 0xff;
         ssig->hashed_data[10] ^= 0xff;
         // ensure validation fails
-        assert_rnp_failure(
-          signature_check_binding(&psiginfo, pgp_key_get_pkt(primary_pub), &pub));
-        assert_rnp_failure(
-          signature_check_binding(&ssiginfo, pgp_key_get_pkt(primary_pub), &sec));
+        assert_rnp_failure(signature_check_binding(&psiginfo, &primary_pub->pkt(), &pub));
+        assert_rnp_failure(signature_check_binding(&ssiginfo, &primary_pub->pkt(), &sec));
         // restore the original data
         psig->hashed_data[10] ^= 0xff;
         ssig->hashed_data[10] ^= 0xff;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -934,8 +934,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_true(rnp_key_store_add_key(pubring, &pub));
         assert_true(rnp_key_store_add_key(secring, &sec));
         // retrieve back from our rings (for later)
-        primary_pub = rnp_key_store_get_key_by_grip(pubring, pgp_key_get_grip(&pub));
-        primary_sec = rnp_key_store_get_key_by_grip(secring, pgp_key_get_grip(&pub));
+        primary_pub = rnp_key_store_get_key_by_grip(pubring, pub.grip());
+        primary_sec = rnp_key_store_get_key_by_grip(secring, pub.grip());
         assert_non_null(primary_pub);
         assert_non_null(primary_sec);
         assert_true(primary_pub->valid);
@@ -963,7 +963,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         psiginfo.signer = &pub;
         assert_rnp_success(
           signature_check_certification(&psiginfo, &pub.pkt(), &pub.get_uid(0).pkt));
-        assert_true(psig->keyfp() == pgp_key_get_fp(&pub));
+        assert_true(psig->keyfp() == pub.fp());
         // check subpackets and their contents
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_ISSUER_FPR);
         assert_non_null(subpkt);
@@ -971,8 +971,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_ISSUER_KEY_ID, false);
         assert_non_null(subpkt);
         assert_false(subpkt->hashed);
-        assert_int_equal(
-          0, memcmp(subpkt->fields.issuer, pgp_key_get_keyid(&pub).data(), PGP_KEY_ID_SIZE));
+        assert_int_equal(0,
+                         memcmp(subpkt->fields.issuer, pub.keyid().data(), PGP_KEY_ID_SIZE));
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_CREATION_TIME);
         assert_non_null(subpkt);
         assert_true(subpkt->hashed);
@@ -982,7 +982,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         ssiginfo.signer = &sec;
         assert_rnp_success(
           signature_check_certification(&ssiginfo, &sec.pkt(), &sec.get_uid(0).pkt));
-        assert_true(ssig->keyfp() == pgp_key_get_fp(&sec));
+        assert_true(ssig->keyfp() == sec.fp());
 
         // modify a hashed portion of the sig packets
         psig->hashed_data[32] ^= 0xff;
@@ -1085,7 +1085,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         psiginfo.sig = psig;
         psiginfo.signer = primary_pub;
         assert_rnp_success(signature_check_binding(&psiginfo, &primary_pub->pkt(), &pub));
-        assert_true(psig->keyfp() == pgp_key_get_fp(primary_pub));
+        assert_true(psig->keyfp() == primary_pub->fp());
         // check subpackets and their contents
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_ISSUER_FPR);
         assert_non_null(subpkt);
@@ -1093,10 +1093,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_ISSUER_KEY_ID, false);
         assert_non_null(subpkt);
         assert_false(subpkt->hashed);
-        assert_int_equal(0,
-                         memcmp(subpkt->fields.issuer,
-                                pgp_key_get_keyid(primary_pub).data(),
-                                PGP_KEY_ID_SIZE));
+        assert_int_equal(
+          0, memcmp(subpkt->fields.issuer, primary_pub->keyid().data(), PGP_KEY_ID_SIZE));
         subpkt = psig->get_subpkt(PGP_SIG_SUBPKT_CREATION_TIME);
         assert_non_null(subpkt);
         assert_true(subpkt->hashed);
@@ -1105,7 +1103,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         ssiginfo.sig = ssig;
         ssiginfo.signer = primary_pub;
         assert_rnp_success(signature_check_binding(&ssiginfo, &primary_pub->pkt(), &sec));
-        assert_true(ssig->keyfp() == pgp_key_get_fp(primary_sec));
+        assert_true(ssig->keyfp() == primary_sec->fp());
 
         // modify a hashed portion of the sig packets
         psig->hashed_data[10] ^= 0xff;
@@ -1121,8 +1119,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_true(rnp_key_store_add_key(pubring, &pub));
         assert_true(rnp_key_store_add_key(secring, &sec));
         // retrieve back from our rings
-        sub_pub = rnp_key_store_get_key_by_grip(pubring, pgp_key_get_grip(&pub));
-        sub_sec = rnp_key_store_get_key_by_grip(secring, pgp_key_get_grip(&pub));
+        sub_pub = rnp_key_store_get_key_by_grip(pubring, pub.grip());
+        sub_sec = rnp_key_store_get_key_by_grip(secring, pub.grip());
         assert_non_null(sub_pub);
         assert_non_null(sub_sec);
         assert_true(sub_pub->valid);

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -944,8 +944,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_true(primary_sec->validated);
 
         // check packet and subsig counts
-        assert_int_equal(3, pgp_key_get_rawpacket_count(&pub));
-        assert_int_equal(3, pgp_key_get_rawpacket_count(&sec));
+        assert_int_equal(3, pub.rawpkt_count());
+        assert_int_equal(3, sec.rawpkt_count());
         assert_int_equal(1, pub.sig_count());
         assert_int_equal(1, sec.sig_count());
         psig = &pub.get_sig(0).sig;
@@ -1069,8 +1069,8 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_true(sec.validated);
 
         // check packet and subsig counts
-        assert_int_equal(2, pgp_key_get_rawpacket_count(&pub));
-        assert_int_equal(2, pgp_key_get_rawpacket_count(&sec));
+        assert_int_equal(2, pub.rawpkt_count());
+        assert_int_equal(2, sec.rawpkt_count());
         assert_int_equal(1, pub.sig_count());
         assert_int_equal(1, sec.sig_count());
         psig = &pub.get_sig(0).sig;

--- a/src/tests/issues/1171.cpp
+++ b/src/tests/issues/1171.cpp
@@ -60,8 +60,7 @@ TEST_F(rnp_tests, test_issue_1171_key_import_and_remove)
     assert_int_equal(bits, 256);
 
     /* directly use rnp_key_store_get_key_by_grip() which caused crash */
-    pgp_key_t *subkey =
-      rnp_key_store_get_key_by_grip(ffi->pubring, pgp_key_get_grip(key->pub));
+    pgp_key_t *subkey = rnp_key_store_get_key_by_grip(ffi->pubring, key->pub->grip());
     assert_int_equal(subkey->material().bits(), 256);
     assert_rnp_success(rnp_key_handle_destroy(key));
 

--- a/src/tests/issues/1171.cpp
+++ b/src/tests/issues/1171.cpp
@@ -62,7 +62,7 @@ TEST_F(rnp_tests, test_issue_1171_key_import_and_remove)
     /* directly use rnp_key_store_get_key_by_grip() which caused crash */
     pgp_key_t *subkey =
       rnp_key_store_get_key_by_grip(ffi->pubring, pgp_key_get_grip(key->pub));
-    assert_int_equal(pgp_key_get_bits(subkey), 256);
+    assert_int_equal(subkey->material().bits(), 256);
     assert_rnp_success(rnp_key_handle_destroy(key));
 
     assert_rnp_success(

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -77,8 +77,8 @@ TEST_F(rnp_tests, test_key_add_userid)
     // make sure this userid has been marked as primary
     assert_int_equal(key->uid_count() - 1, key->uid0);
     // make sure key expiration and flags are set
-    assert_int_equal(123456789, pgp_key_get_expiration(key));
-    assert_int_equal(0xAB, pgp_key_get_flags(key));
+    assert_int_equal(123456789, key->expiration());
+    assert_int_equal(0xAB, key->flags());
 
     // try to add the same userid (should fail)
     rnp_selfsig_cert_info_t dup_selfsig = {};
@@ -103,8 +103,8 @@ TEST_F(rnp_tests, test_key_add_userid)
     assert_int_equal(key->sig_count(), subsigc + 2);
 
     // make sure key expiration and flags are now updated
-    assert_int_equal(0, pgp_key_get_expiration(key));
-    assert_int_equal(0xCD, pgp_key_get_flags(key));
+    assert_int_equal(0, key->expiration());
+    assert_int_equal(0xCD, key->flags());
     // check the userids array
     // added1
     assert_true(key->get_uid(uidc).str == "added1");
@@ -137,8 +137,8 @@ TEST_F(rnp_tests, test_key_add_userid)
     assert_int_equal(key->sig_count(), subsigc + 2);
 
     // make sure correct key expiration and flags are set
-    assert_int_equal(0, pgp_key_get_expiration(key));
-    assert_int_equal(0xCD, pgp_key_get_flags(key));
+    assert_int_equal(0, key->expiration());
+    assert_int_equal(0xCD, key->flags());
 
     // check the userids array
     // added1

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -72,8 +72,7 @@ TEST_F(rnp_tests, test_key_add_userid)
     selfsig.key_flags = 0xAB;
     selfsig.key_expiration = 123456789;
     selfsig.primary = 1;
-    assert_true(
-      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig));
+    assert_true(pgp_key_add_userid_certified(key, &key->pkt(), PGP_HASH_SHA1, &selfsig));
 
     // make sure this userid has been marked as primary
     assert_int_equal(key->uid_count() - 1, key->uid0);
@@ -84,23 +83,20 @@ TEST_F(rnp_tests, test_key_add_userid)
     // try to add the same userid (should fail)
     rnp_selfsig_cert_info_t dup_selfsig = {};
     memcpy(dup_selfsig.userid, "added1", 7);
-    assert_false(
-      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &dup_selfsig));
+    assert_false(pgp_key_add_userid_certified(key, &key->pkt(), PGP_HASH_SHA1, &dup_selfsig));
 
     // try to add another primary userid (should fail)
     rnp_selfsig_cert_info_t selfsig2 = {};
     memcpy(selfsig2.userid, "added2", 7);
     selfsig2.primary = 1;
-    assert_false(
-      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
+    assert_false(pgp_key_add_userid_certified(key, &key->pkt(), PGP_HASH_SHA1, &selfsig2));
 
     memcpy(selfsig2.userid, "added2", 7);
     selfsig2.key_flags = 0xCD;
     selfsig2.primary = 0;
 
     // actually add another userid
-    assert_true(
-      pgp_key_add_userid_certified(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
+    assert_true(pgp_key_add_userid_certified(key, &key->pkt(), PGP_HASH_SHA1, &selfsig2));
 
     // confirm that the counts have increased as expected
     assert_int_equal(key->uid_count(), uidc + 2);

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -76,7 +76,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
     }
 
     // confirm that this key is indeed RSA
-    assert_int_equal(pgp_key_get_alg(key), PGP_PKA_RSA);
+    assert_int_equal(key->alg(), PGP_PKA_RSA);
 
     // confirm key material is currently all NULL (in other words, the key is locked)
     assert_true(mpi_empty(key->material().rsa.d));

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -127,7 +127,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
     {
         pgp_source_t     memsrc = {};
         rnp_key_store_t *ks = new rnp_key_store_t();
-        pgp_rawpacket_t &pkt = pgp_key_get_rawpacket(key);
+        pgp_rawpacket_t &pkt = key->rawpkt();
 
         assert_rnp_success(init_mem_src(&memsrc, pkt.raw.data(), pkt.raw.size(), false));
         assert_rnp_success(rnp_key_store_pgp_read_from_src(ks, &memsrc));

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -55,9 +55,9 @@ TEST_F(rnp_tests, test_key_store_search)
         for (size_t n = 0; n < testdata[i].count; n++) {
             pgp_key_t key;
 
-            key.pkt.tag = PGP_PKT_PUBLIC_KEY;
-            key.pkt.version = PGP_V4;
-            key.pkt.alg = PGP_PKA_RSA;
+            key.pkt().tag = PGP_PKT_PUBLIC_KEY;
+            key.pkt().version = PGP_V4;
+            key.pkt().alg = PGP_PKA_RSA;
 
             // set the keyid
             assert_true(rnp_hex_decode(testdata[i].keyid, key.keyid.data(), key.keyid.size()));

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -88,10 +88,10 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     rnp_buffer_destroy(alg);
 
     // confirm the secret MPIs are NULL
-    assert_int_equal(pgp_key_get_material(key->sec)->rsa.d.len, 0);
-    assert_int_equal(pgp_key_get_material(key->sec)->rsa.p.len, 0);
-    assert_int_equal(pgp_key_get_material(key->sec)->rsa.q.len, 0);
-    assert_int_equal(pgp_key_get_material(key->sec)->rsa.u.len, 0);
+    assert_true(mpi_empty(key->sec->material().rsa.d));
+    assert_true(mpi_empty(key->sec->material().rsa.p));
+    assert_true(mpi_empty(key->sec->material().rsa.q));
+    assert_true(mpi_empty(key->sec->material().rsa.u));
 
     // try to unlock with a failing password provider
     provider.callback = failing_password_callback;
@@ -116,10 +116,10 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     assert_false(locked);
 
     // confirm the secret MPIs are now filled in
-    assert_int_not_equal(pgp_key_get_material(key->sec)->rsa.d.len, 0);
-    assert_int_not_equal(pgp_key_get_material(key->sec)->rsa.p.len, 0);
-    assert_int_not_equal(pgp_key_get_material(key->sec)->rsa.q.len, 0);
-    assert_int_not_equal(pgp_key_get_material(key->sec)->rsa.u.len, 0);
+    assert_false(mpi_empty(key->sec->material().rsa.d));
+    assert_false(mpi_empty(key->sec->material().rsa.p));
+    assert_false(mpi_empty(key->sec->material().rsa.q));
+    assert_false(mpi_empty(key->sec->material().rsa.u));
 
     // now the signing key is unlocked, confirm that no password is required for signing
     assert_rnp_success(

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -38,8 +38,8 @@ all_keys_valid(const rnp_key_store_t *keyring)
 
     for (auto &key : keyring->keys) {
         if (!key.valid) {
-            assert_true(rnp_hex_encode(pgp_key_get_keyid(&key).data(),
-                                       pgp_key_get_keyid(&key).size(),
+            assert_true(rnp_hex_encode(key.keyid().data(),
+                                       key.keyid().size(),
                                        keyid,
                                        sizeof(keyid),
                                        RNP_HEX_LOWERCASE));

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -353,7 +353,7 @@ TEST_F(rnp_tests, test_key_validity)
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_true(key->valid);
-    assert_int_equal(pgp_key_get_subkey_count(key), 1);
+    assert_int_equal(key->subkey_count(), 1);
     pgp_key_t *subkey = NULL;
     assert_non_null(subkey = pgp_key_get_subkey(key, pubring, 0));
     assert_false(subkey->valid);
@@ -371,7 +371,7 @@ TEST_F(rnp_tests, test_key_validity)
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_true(key->valid);
-    assert_int_equal(pgp_key_get_subkey_count(key), 1);
+    assert_int_equal(key->subkey_count(), 1);
     assert_non_null(subkey = pgp_key_get_subkey(key, pubring, 0));
     assert_false(subkey->valid);
     delete pubring;
@@ -385,7 +385,7 @@ TEST_F(rnp_tests, test_key_validity)
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_false(key->valid);
-    assert_int_equal(pgp_key_get_subkey_count(key), 1);
+    assert_int_equal(key->subkey_count(), 1);
     assert_non_null(subkey = pgp_key_get_subkey(key, pubring, 0));
     assert_false(subkey->valid);
     delete pubring;
@@ -399,7 +399,7 @@ TEST_F(rnp_tests, test_key_validity)
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_true(key->valid);
-    assert_int_equal(pgp_key_get_subkey_count(key), 1);
+    assert_int_equal(key->subkey_count(), 1);
     assert_non_null(subkey = pgp_key_get_subkey(key, pubring, 0));
     assert_false(subkey->valid);
     delete pubring;
@@ -413,7 +413,7 @@ TEST_F(rnp_tests, test_key_validity)
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C", NULL));
     assert_true(key->valid);
-    assert_int_equal(pgp_key_get_subkey_count(key), 1);
+    assert_int_equal(key->subkey_count(), 1);
     assert_non_null(subkey = pgp_key_get_subkey(key, pubring, 0));
     assert_true(subkey->valid);
     delete pubring;
@@ -429,7 +429,7 @@ TEST_F(rnp_tests, test_key_validity)
     assert_true(rnp_key_store_load_from_path(pubring, NULL));
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C", NULL));
     assert_true(key->valid);
-    assert_int_equal(pgp_key_get_subkey_count(key), 1);
+    assert_int_equal(key->subkey_count(), 1);
     assert_non_null(subkey = pgp_key_get_subkey(key, pubring, 0));
     assert_true(subkey->valid);
     delete pubring;

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -85,7 +85,7 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     assert_true(pgp_key_is_locked(key));
 
     // decrypt the key
-    const pgp_rawpacket_t &pkt = pgp_key_get_rawpacket(key);
+    const pgp_rawpacket_t &pkt = key->rawpkt();
     pgp_key_pkt_t *        seckey =
       pgp_decrypt_seckey_pgp(pkt.raw.data(), pkt.raw.size(), &key->pkt(), "password");
     assert_non_null(seckey);
@@ -400,8 +400,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(key->valid);
     assert_true(key->is_primary());
     assert_true(key->is_secret());
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_SECRET_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
@@ -412,8 +412,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(key->valid);
     assert_true(key->is_subkey());
     assert_true(key->is_secret());
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(key->rawpkt_count(), 2);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
 
     assert_true(rnp_hex_decode("16CD16F267CCDD4F", keyid.data(), keyid.size()));
@@ -421,8 +421,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(key->valid);
     assert_true(key->is_subkey());
     assert_true(key->is_secret());
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(key->rawpkt_count(), 2);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
 
     /* both user ids should be present */
@@ -462,7 +462,7 @@ load_keystore(rnp_key_store_t *keystore, const char *fname)
 static bool
 check_subkey_fp(pgp_key_t *key, pgp_key_t *subkey, size_t index)
 {
-    if (pgp_key_get_subkey_fp(key, index) != subkey->fp()) {
+    if (key->get_subkey_fp(index) != subkey->fp()) {
         return false;
     }
     if (!subkey->has_primary_fp()) {
@@ -495,8 +495,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 1);
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_false(key->valid);
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 1);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 1);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
 
     /* load key + user id 1 without sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-1-no-sigs.pgp"));
@@ -505,8 +505,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_false(key->valid);
     assert_int_equal(key->uid_count(), 1);
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 2);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_null(rnp_tests_key_search(key_store, "key-merge-uid-1"));
     assert_true(key == rnp_tests_get_key_by_id(key_store, "9747D2A6B3A63124", NULL));
@@ -518,8 +518,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_int_equal(key->uid_count(), 1);
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 3);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 3);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
@@ -533,8 +533,8 @@ TEST_F(rnp_tests, test_load_merge)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_int_equal(key->uid_count(), 2);
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
@@ -553,15 +553,15 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(key->uid_count(), 2);
     assert_int_equal(key->subkey_count(), 1);
     assert_true(check_subkey_fp(key, skey1, 0));
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(1).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey1->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey1), 1);
-    assert_int_equal(pgp_key_get_rawpacket(skey1).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(skey1->rawpkt_count(), 1);
+    assert_int_equal(skey1->rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
 
     /* load just subkey 1 but with signature */
     assert_true(load_transferable_subkey(&tskey, MERGE_PATH "key-pub-no-key-subkey-1.pgp"));
@@ -576,15 +576,15 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(key->uid_count(), 2);
     assert_int_equal(key->subkey_count(), 1);
     assert_true(check_subkey_fp(key, skey1, 0));
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(1).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey1->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(skey1->rawpkt_count(), 2);
+    assert_int_equal(skey1->rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_int_equal(skey1->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
 
     /* load key + subkey 2 with signature */
@@ -603,19 +603,19 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(key->subkey_count(), 2);
     assert_true(check_subkey_fp(key, skey1, 0));
     assert_true(check_subkey_fp(key, skey2, 1));
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(1).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey1->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(skey1->rawpkt_count(), 2);
+    assert_int_equal(skey1->rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_int_equal(skey1->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey2->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey2).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(skey2->rawpkt_count(), 2);
+    assert_int_equal(skey2->rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_int_equal(skey2->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
 
     /* load secret key & subkeys */
@@ -634,19 +634,19 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(key->subkey_count(), 2);
     assert_true(check_subkey_fp(key, skey1, 0));
     assert_true(check_subkey_fp(key, skey2, 1));
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_SECRET_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(1).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey1->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1).tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(skey1->rawpkt_count(), 2);
+    assert_int_equal(skey1->rawpkt().tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(skey1->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey2->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey2).tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(skey2->rawpkt_count(), 2);
+    assert_int_equal(skey2->rawpkt().tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(skey2->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
 
     assert_true(pgp_key_unlock(key, &provider));
@@ -669,19 +669,19 @@ TEST_F(rnp_tests, test_load_merge)
     assert_int_equal(key->subkey_count(), 2);
     assert_true(check_subkey_fp(key, skey1, 0));
     assert_true(check_subkey_fp(key, skey2, 1));
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(key->rawpkt_count(), 5);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_SECRET_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(key->get_uid(1).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(1).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey1->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1).tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(skey1->rawpkt_count(), 2);
+    assert_int_equal(skey1->rawpkt().tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(skey1->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_int_equal(skey2->uid_count(), 0);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey2).tag, PGP_PKT_SECRET_SUBKEY);
+    assert_int_equal(skey2->rawpkt_count(), 2);
+    assert_int_equal(skey2->rawpkt().tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(skey2->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-1"));
     assert_true(key == rnp_tests_key_search(key_store, "key-merge-uid-2"));
@@ -713,10 +713,10 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     keycp = pgp_key_t(*key, false);
     assert_true(keycp.is_secret());
     assert_int_equal(keycp.subkey_count(), 2);
-    assert_true(pgp_key_get_subkey_fp(&keycp, 0) == skey1->fp());
-    assert_true(pgp_key_get_subkey_fp(&keycp, 1) == skey2->fp());
+    assert_true(keycp.get_subkey_fp(0) == skey1->fp());
+    assert_true(keycp.get_subkey_fp(1) == skey2->fp());
     assert_true(keycp.grip() == key->grip());
-    assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_SECRET_KEY);
+    assert_int_equal(keycp.rawpkt().tag, PGP_PKT_SECRET_KEY);
 
     /* copy the public part */
     keycp = pgp_key_t(*key, true);
@@ -725,7 +725,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_fp(&keycp, skey1, 0));
     assert_true(check_subkey_fp(&keycp, skey2, 1));
     assert_true(keycp.grip() == key->grip());
-    assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(keycp.rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_null(keycp.pkt().sec_data);
     assert_int_equal(keycp.pkt().sec_len, 0);
     assert_false(keycp.pkt().material.secret);
@@ -737,7 +737,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_fp(key, &keycp, 0));
     assert_true(keycp.grip() == skey1->grip());
     assert_true(keycp.keyid() == sub1id);
-    assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(keycp.rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(keycp.pkt().sec_data);
     assert_int_equal(keycp.pkt().sec_len, 0);
     assert_false(keycp.pkt().material.secret);
@@ -749,7 +749,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_fp(key, &keycp, 1));
     assert_true(keycp.grip() == skey2->grip());
     assert_true(keycp.keyid() == sub2id);
-    assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(keycp.rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(keycp.pkt().sec_data);
     assert_int_equal(keycp.pkt().sec_len, 0);
     assert_false(keycp.pkt().material.secret);
@@ -965,8 +965,8 @@ TEST_F(rnp_tests, test_load_subkey)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 1);
     assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_false(skey1->valid);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
-    assert_int_equal(pgp_key_get_rawpacket(skey1).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(skey1->rawpkt_count(), 2);
+    assert_int_equal(skey1->rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_int_equal(skey1->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_false(skey1->has_primary_fp());
 
@@ -975,8 +975,8 @@ TEST_F(rnp_tests, test_load_subkey)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 2);
     assert_non_null(skey2 = rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_false(skey2->valid);
-    assert_int_equal(pgp_key_get_rawpacket_count(skey2), 1);
-    assert_int_equal(pgp_key_get_rawpacket(skey2).tag, PGP_PKT_PUBLIC_SUBKEY);
+    assert_int_equal(skey2->rawpkt_count(), 1);
+    assert_int_equal(skey2->rawpkt().tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_false(skey2->has_primary_fp());
     assert_false(skey1 == skey2);
 
@@ -985,8 +985,8 @@ TEST_F(rnp_tests, test_load_subkey)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 3);
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
-    assert_int_equal(pgp_key_get_rawpacket_count(key), 3);
-    assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_PUBLIC_KEY);
+    assert_int_equal(key->rawpkt_count(), 3);
+    assert_int_equal(key->rawpkt().tag, PGP_PKT_PUBLIC_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
     assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -462,10 +462,10 @@ load_keystore(rnp_key_store_t *keystore, const char *fname)
 static bool
 check_subkey_fp(pgp_key_t *key, pgp_key_t *subkey, size_t index)
 {
-    if (pgp_key_get_subkey_fp(key, index) != pgp_key_get_fp(subkey)) {
+    if (pgp_key_get_subkey_fp(key, index) != subkey->fp()) {
         return false;
     }
-    return pgp_key_get_fp(key) == pgp_key_get_primary_fp(subkey);
+    return key->fp() == pgp_key_get_primary_fp(subkey);
 }
 
 TEST_F(rnp_tests, test_load_merge)
@@ -710,9 +710,9 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     keycp = pgp_key_t(*key, false);
     assert_true(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
-    assert_true(pgp_key_get_subkey_fp(&keycp, 0) == pgp_key_get_fp(skey1));
-    assert_true(pgp_key_get_subkey_fp(&keycp, 1) == pgp_key_get_fp(skey2));
-    assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(key));
+    assert_true(pgp_key_get_subkey_fp(&keycp, 0) == skey1->fp());
+    assert_true(pgp_key_get_subkey_fp(&keycp, 1) == skey2->fp());
+    assert_true(keycp.grip() == key->grip());
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_SECRET_KEY);
 
     /* copy the public part */
@@ -721,7 +721,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(check_subkey_fp(&keycp, skey1, 0));
     assert_true(check_subkey_fp(&keycp, skey2, 1));
-    assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(key));
+    assert_true(keycp.grip() == key->grip());
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_KEY);
     assert_null(keycp.pkt().sec_data);
     assert_int_equal(keycp.pkt().sec_len, 0);
@@ -732,8 +732,8 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 0));
-    assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(skey1));
-    assert_true(pgp_key_get_keyid(&keycp) == sub1id);
+    assert_true(keycp.grip() == skey1->grip());
+    assert_true(keycp.keyid() == sub1id);
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(keycp.pkt().sec_data);
     assert_int_equal(keycp.pkt().sec_len, 0);
@@ -744,8 +744,8 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_false(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 1));
-    assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(skey2));
-    assert_true(pgp_key_get_keyid(&keycp) == sub2id);
+    assert_true(keycp.grip() == skey2->grip());
+    assert_true(keycp.keyid() == sub2id);
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_SUBKEY);
     assert_null(keycp.pkt().sec_data);
     assert_int_equal(keycp.pkt().sec_len, 0);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -54,11 +54,11 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     assert_non_null(key);
 
     // confirm the key flags are correct
-    assert_int_equal(pgp_key_get_flags(key),
+    assert_int_equal(key->flags(),
                      PGP_KF_ENCRYPT | PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH);
 
     // confirm that key expiration is correct
-    assert_int_equal(pgp_key_get_expiration(key), 0);
+    assert_int_equal(key->expiration(), 0);
 
     // cleanup
     delete key_store;
@@ -77,11 +77,11 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     assert_non_null(key);
 
     // confirm the key flags are correct
-    assert_int_equal(pgp_key_get_flags(key),
+    assert_int_equal(key->flags(),
                      PGP_KF_ENCRYPT | PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH);
 
     // check if the key is secret and is locked
-    assert_true(pgp_key_is_secret(key));
+    assert_true(key->is_secret());
     assert_true(pgp_key_is_locked(key));
 
     // decrypt the key
@@ -117,7 +117,7 @@ TEST_F(rnp_tests, test_load_v4_keyring_pgp)
     assert_non_null(key);
 
     // confirm the key flags are correct
-    assert_int_equal(pgp_key_get_flags(key), PGP_KF_ENCRYPT);
+    assert_int_equal(key->flags(), PGP_KF_ENCRYPT);
 
     // cleanup
     delete key_store;
@@ -140,7 +140,7 @@ check_pgp_keyring_counts(const char *   path,
     // count primary keys first
     unsigned total_primary_count = 0;
     for (auto &key : key_store->keys) {
-        if (pgp_key_is_primary_key(&key)) {
+        if (key.is_primary()) {
             total_primary_count++;
         }
     }
@@ -150,10 +150,10 @@ check_pgp_keyring_counts(const char *   path,
     unsigned total_subkey_count = 0;
     unsigned primary = 0;
     for (auto &key : key_store->keys) {
-        if (pgp_key_is_primary_key(&key)) {
+        if (key.is_primary()) {
             // check the subkey count for this primary key
             assert_int_equal(pgp_key_get_subkey_count(&key), subkey_counts[primary++]);
-        } else if (pgp_key_is_subkey(&key)) {
+        } else if (key.is_subkey()) {
             total_subkey_count++;
         }
     }
@@ -215,7 +215,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
         assert_int_equal(sig->expiration(), 0);
     }
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 0);
+    assert_int_equal(key->expiration(), 0);
 
     // find
     key = NULL;
@@ -230,11 +230,11 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     assert_true(keyid == sig->keyid());
     // check SS_CREATION_TIME [0]
     assert_int_equal(sig->creation(), 1500569820);
-    assert_int_equal(sig->creation(), pgp_key_get_creation(key));
+    assert_int_equal(sig->creation(), key->creation());
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(sig->expiration(), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 0);
+    assert_int_equal(key->expiration(), 0);
 
     // find
     key = NULL;
@@ -249,11 +249,11 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     assert_true(keyid == sig->keyid());
     // check SS_CREATION_TIME [0]
     assert_int_equal(sig->creation(), 1500569851);
-    assert_int_equal(sig->creation(), pgp_key_get_creation(key));
+    assert_int_equal(sig->creation(), key->creation());
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(sig->expiration(), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 123 * 24 * 60 * 60 /* 123 days */);
+    assert_int_equal(key->expiration(), 123 * 24 * 60 * 60 /* 123 days */);
 
     // find
     key = NULL;
@@ -268,11 +268,11 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     assert_true(keyid == sig->keyid());
     // check SS_CREATION_TIME [0]
     assert_int_equal(sig->creation(), 1500569896);
-    assert_int_equal(sig->creation(), pgp_key_get_creation(key));
+    assert_int_equal(sig->creation(), key->creation());
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(sig->expiration(), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 0);
+    assert_int_equal(key->expiration(), 0);
 
     // find
     key = NULL;
@@ -295,7 +295,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
         assert_int_equal(sig->expiration(), 0);
     }
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 2076663808);
+    assert_int_equal(key->expiration(), 2076663808);
 
     // find
     key = NULL;
@@ -310,11 +310,11 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     assert_true(keyid == sig->keyid());
     // check SS_CREATION_TIME [0]
     assert_int_equal(sig->creation(), 1500569946);
-    assert_int_equal(sig->creation(), pgp_key_get_creation(key));
+    assert_int_equal(sig->creation(), key->creation());
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(sig->expiration(), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 2076663808);
+    assert_int_equal(key->expiration(), 2076663808);
 
     // find
     key = NULL;
@@ -329,11 +329,11 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     assert_true(keyid == sig->keyid());
     // check SS_CREATION_TIME [0]
     assert_int_equal(sig->creation(), 1500570165);
-    assert_int_equal(sig->creation(), pgp_key_get_creation(key));
+    assert_int_equal(sig->creation(), key->creation());
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(sig->expiration(), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(pgp_key_get_expiration(key), 0);
+    assert_int_equal(key->expiration(), 0);
 
     // cleanup
     delete key_store;
@@ -359,7 +359,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
     key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check key version
-    assert_int_equal(pgp_key_get_version(key), PGP_V3);
+    assert_int_equal(key->version(), PGP_V3);
     // check subsig count
     assert_int_equal(key->sig_count(), 1);
     sig = &key->get_sig(0).sig;
@@ -370,11 +370,11 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
     assert_true(keyid == sig->keyid());
     // check creation time
     assert_int_equal(sig->creation(), 1005209227);
-    assert_int_equal(sig->creation(), pgp_key_get_creation(key));
+    assert_int_equal(sig->creation(), key->creation());
     // check signature expiration time (V3 sigs have none)
     assert_int_equal(sig->expiration(), 0);
     // check key expiration
-    assert_int_equal(pgp_key_get_expiration(key), 0); // only for V4 keys
+    assert_int_equal(key->expiration(), 0); // only for V4 keys
     assert_int_equal(key->pkt().v3_days, 0);
 
     // cleanup
@@ -398,8 +398,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(rnp_hex_decode("9747D2A6B3A63124", keyid.data(), keyid.size()));
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
-    assert_true(pgp_key_is_primary_key(key));
-    assert_true(pgp_key_is_secret(key));
+    assert_true(key->is_primary());
+    assert_true(key->is_secret());
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_KEY);
     assert_int_equal(key->get_uid(0).rawpkt.tag, PGP_PKT_USER_ID);
@@ -410,8 +410,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", keyid.data(), keyid.size()));
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
-    assert_true(pgp_key_is_subkey(key));
-    assert_true(pgp_key_is_secret(key));
+    assert_true(key->is_subkey());
+    assert_true(key->is_secret());
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
@@ -419,8 +419,8 @@ TEST_F(rnp_tests, test_load_armored_pub_sec)
     assert_true(rnp_hex_decode("16CD16F267CCDD4F", keyid.data(), keyid.size()));
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
-    assert_true(pgp_key_is_subkey(key));
-    assert_true(pgp_key_is_secret(key));
+    assert_true(key->is_subkey());
+    assert_true(key->is_secret());
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key).tag, PGP_PKT_SECRET_SUBKEY);
     assert_int_equal(key->get_sig(0).rawpkt.tag, PGP_PKT_SIGNATURE);
@@ -708,7 +708,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
 
     /* copy the secret key */
     keycp = pgp_key_t(*key, false);
-    assert_true(pgp_key_is_secret(&keycp));
+    assert_true(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(pgp_key_get_subkey_fp(&keycp, 0) == pgp_key_get_fp(skey1));
     assert_true(pgp_key_get_subkey_fp(&keycp, 1) == pgp_key_get_fp(skey2));
@@ -717,7 +717,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
 
     /* copy the public part */
     keycp = pgp_key_t(*key, true);
-    assert_false(pgp_key_is_secret(&keycp));
+    assert_false(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_true(check_subkey_fp(&keycp, skey1, 0));
     assert_true(check_subkey_fp(&keycp, skey2, 1));
@@ -729,7 +729,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
     keycp = pgp_key_t(*skey1, true);
-    assert_false(pgp_key_is_secret(&keycp));
+    assert_false(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 0));
     assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(skey1));
@@ -741,7 +741,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
     keycp = pgp_key_t(*skey2, true);
-    assert_false(pgp_key_is_secret(&keycp));
+    assert_false(keycp.is_secret());
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_true(check_subkey_fp(key, &keycp, 1));
     assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(skey2));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -87,7 +87,7 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     // decrypt the key
     const pgp_rawpacket_t &pkt = pgp_key_get_rawpacket(key);
     pgp_key_pkt_t *        seckey =
-      pgp_decrypt_seckey_pgp(pkt.raw.data(), pkt.raw.size(), pgp_key_get_pkt(key), "password");
+      pgp_decrypt_seckey_pgp(pkt.raw.data(), pkt.raw.size(), &key->pkt(), "password");
     assert_non_null(seckey);
 
     // cleanup
@@ -375,7 +375,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
     assert_int_equal(sig->expiration(), 0);
     // check key expiration
     assert_int_equal(pgp_key_get_expiration(key), 0); // only for V4 keys
-    assert_int_equal(pgp_key_get_pkt(key)->v3_days, 0);
+    assert_int_equal(key->pkt().v3_days, 0);
 
     // cleanup
     delete key_store;
@@ -723,9 +723,9 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_fp(&keycp, skey2, 1));
     assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(key));
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_KEY);
-    assert_null(pgp_key_get_pkt(&keycp)->sec_data);
-    assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
-    assert_false(pgp_key_get_pkt(&keycp)->material.secret);
+    assert_null(keycp.pkt().sec_data);
+    assert_int_equal(keycp.pkt().sec_len, 0);
+    assert_false(keycp.pkt().material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
     keycp = pgp_key_t(*skey1, true);
@@ -735,9 +735,9 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(skey1));
     assert_true(pgp_key_get_keyid(&keycp) == sub1id);
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_SUBKEY);
-    assert_null(pgp_key_get_pkt(&keycp)->sec_data);
-    assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
-    assert_false(pgp_key_get_pkt(&keycp)->material.secret);
+    assert_null(keycp.pkt().sec_data);
+    assert_int_equal(keycp.pkt().sec_len, 0);
+    assert_false(keycp.pkt().material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
     keycp = pgp_key_t(*skey2, true);
@@ -747,9 +747,9 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(pgp_key_get_grip(&keycp) == pgp_key_get_grip(skey2));
     assert_true(pgp_key_get_keyid(&keycp) == sub2id);
     assert_int_equal(pgp_key_get_rawpacket(&keycp).tag, PGP_PKT_PUBLIC_SUBKEY);
-    assert_null(pgp_key_get_pkt(&keycp)->sec_data);
-    assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
-    assert_false(pgp_key_get_pkt(&keycp)->material.secret);
+    assert_null(keycp.pkt().sec_data);
+    assert_int_equal(keycp.pkt().sec_len, 0);
+    assert_false(keycp.pkt().material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* save pubring */
     assert_true(rnp_key_store_write_to_path(pubstore));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -379,14 +379,14 @@ TEST_F(rnp_tests, test_stream_signatures)
     secring = new rnp_key_store_t(PGP_KEY_STORE_GPG, "data/test_stream_signatures/sec.asc");
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_non_null(key = rnp_key_store_get_key_by_id(secring, sig.keyid(), NULL));
-    assert_true(pgp_key_is_secret(key));
+    assert_true(key->is_secret());
     /* fill signature */
     uint32_t create = time(NULL);
     uint32_t expire = 123456;
     sig = {};
     sig.version = PGP_V4;
     sig.halg = halg;
-    sig.palg = pgp_key_get_alg(key);
+    sig.palg = key->alg();
     sig.set_type(PGP_SIG_BINARY);
     sig.set_keyfp(pgp_key_get_fp(key));
     sig.set_keyid(pgp_key_get_keyid(key));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -388,8 +388,8 @@ TEST_F(rnp_tests, test_stream_signatures)
     sig.halg = halg;
     sig.palg = key->alg();
     sig.set_type(PGP_SIG_BINARY);
-    sig.set_keyfp(pgp_key_get_fp(key));
-    sig.set_keyid(pgp_key_get_keyid(key));
+    sig.set_keyfp(key->fp());
+    sig.set_keyid(key->keyid());
     sig.set_creation(create);
     sig.set_expiration(expire);
     assert_true(signature_fill_hashed_data(&sig));
@@ -408,7 +408,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     assert_int_equal(sig.creation(), create);
     assert_int_equal(sig.expiration(), expire);
     assert_true(sig.has_subpkt(PGP_SIG_SUBPKT_ISSUER_FPR));
-    assert_true(sig.keyfp() == pgp_key_get_fp(key));
+    assert_true(sig.keyfp() == key->fp());
     assert_rnp_success(signature_validate(&sig, &key->material(), &hash));
     /* cleanup */
     delete pubring;

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -497,6 +497,13 @@ test_value_equal(const char *what, const char *expected_value, const uint8_t v[]
     return 0;
 }
 
+bool
+mpi_empty(const pgp_mpi_t &val)
+{
+    pgp_mpi_t zero{};
+    return (val.len == 0) && !memcmp(val.mpi, zero.mpi, PGP_MPINT_SIZE);
+}
+
 char *
 uint_to_string(char *buff, const int buffsize, unsigned int num, int base)
 {

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -152,6 +152,7 @@ int test_value_equal(const char *  what,
                      const uint8_t v[],
                      size_t        v_len);
 
+bool mpi_empty(const pgp_mpi_t &val);
 /*
  */
 char *uint_to_string(char *buff, const int buffsize, unsigned int num, int base);


### PR DESCRIPTION
This PR refactors getters/setters for cleaner code.
Will be followed with other pgp_key_t functions refactoring, as it is too much changes for a single PR.