### PR TITLE
Add FFI functions rnp_key_is_valid()/rnp_key_valid_till().

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1420,6 +1420,29 @@ RNP_API rnp_result_t rnp_key_get_expiration(rnp_key_handle_t key, uint32_t *resu
 RNP_API rnp_result_t rnp_key_set_expiration(rnp_key_handle_t key, uint32_t expiry);
 
 /**
+ * @brief Check whether public key is valid. This includes checks of the self-signatures,
+ *        expiration times, revocations and so on.
+ *        Note: it doesn't take in account secret key, if it is available.
+ *
+ * @param key key's handle.
+ * @param result on success true or false will be stored here. Cannot be NULL.
+ * @return RNP_SUCCESS or error code on failure.
+ */
+RNP_API rnp_result_t rnp_key_is_valid(rnp_key_handle_t key, bool *result);
+
+/**
+ * @brief Get the timestamp till which key can be considered as valid.
+ *        Note: this will take into account not only key's expiration, but revocations as well.
+ *        For the subkey primary key's validity time will be also checked.
+ * @param key key's handle.
+ * @param result on success timestamp will be stored here. If key doesn't expire then maximum
+ *               value will be stored here. If key was never valid then zero value will be
+ * stored here.
+ * @return RNP_SUCCESS or error code on failure.
+ */
+RNP_API rnp_result_t rnp_key_valid_till(rnp_key_handle_t key, uint32_t *result);
+
+/**
  * @brief Check whether key is revoked.
  *
  * @param key key handle, should not be NULL

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -157,11 +157,11 @@ struct pgp_key_t {
     bool            uid0_set_{};   /* flag for the above */
     bool            revoked_{};    /* key has been revoked */
     pgp_revoke_t    revocation_{}; /* revocation reason */
-    bool            valid_{};      /* this key is valid and usable */
-    bool            validated_{};  /* this key was validated */
+    pgp_validity_t  validity_{};   /* key's validity */
 
     pgp_subsig_t *latest_uid_selfcert(uint32_t uid);
     void          validate_primary(rnp_key_store_t &keyring);
+    void          merge_validity(const pgp_validity_t &src);
 
   public:
     pgp_key_store_format_t format{}; /* the format of the key in packets[0] */
@@ -210,6 +210,8 @@ struct pgp_key_t {
     bool             can_encrypt() const;
     /** @brief Get key's expiration time in seconds. If 0 then it doesn't expire. */
     uint32_t expiration() const;
+    /** @brief Check whether key is expired. Must be validated before that. */
+    bool expired() const;
     /** @brief Get key's creation time in seconds since Jan, 1 1970. */
     uint32_t creation() const;
     bool     is_public() const;

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -79,25 +79,28 @@ typedef struct pgp_rawpacket_t {
     void write(pgp_dest_t &dst) const;
 } pgp_rawpacket_t;
 
-/* validity information for the signature */
-typedef struct pgp_sig_validity_t {
-    bool validated{}; /* signature was validated */
-    bool sigvalid{};  /* signature is valid by signature/key checks and calculations.
+/* validity information for the signature/key/userid */
+typedef struct pgp_validity_t {
+    bool validated{}; /* item was validated */
+    bool valid{};     /* item is valid by signature/key checks and calculations.
                          Still may be revoked or expired. */
-    bool expired{};   /* signature is expired */
-} pgp_sig_validity_t;
+    bool expired{};   /* item is expired */
+
+    void mark_valid();
+    void reset();
+} pgp_validity_t;
 
 /** information about the signature */
 typedef struct pgp_subsig_t {
-    uint32_t           uid{};         /* index in userid array in key for certification sig */
-    pgp_signature_t    sig{};         /* signature packet */
-    pgp_sig_id_t       sigid{};       /* signature identifier */
-    pgp_rawpacket_t    rawpkt{};      /* signature's rawpacket */
-    uint8_t            trustlevel{};  /* level of trust */
-    uint8_t            trustamount{}; /* amount of trust */
-    uint8_t            key_flags{};   /* key flags for certification/direct key sig */
-    pgp_user_prefs_t   prefs{};       /* user preferences for certification sig */
-    pgp_sig_validity_t validity{};    /* signature validity information */
+    uint32_t         uid{};         /* index in userid array in key for certification sig */
+    pgp_signature_t  sig{};         /* signature packet */
+    pgp_sig_id_t     sigid{};       /* signature identifier */
+    pgp_rawpacket_t  rawpkt{};      /* signature's rawpacket */
+    uint8_t          trustlevel{};  /* level of trust */
+    uint8_t          trustamount{}; /* amount of trust */
+    uint8_t          key_flags{};   /* key flags for certification/direct key sig */
+    pgp_user_prefs_t prefs{};       /* user preferences for certification sig */
+    pgp_validity_t   validity{};    /* signature validity information */
 
     pgp_subsig_t() = delete;
     pgp_subsig_t(const pgp_signature_t &sig);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -162,6 +162,7 @@ struct pgp_key_t {
     pgp_subsig_t *latest_uid_selfcert(uint32_t uid);
     void          validate_primary(rnp_key_store_t &keyring);
     void          merge_validity(const pgp_validity_t &src);
+    uint32_t      valid_till_common(bool expiry) const;
 
   public:
     pgp_key_store_format_t format{}; /* the format of the key in packets[0] */
@@ -227,6 +228,10 @@ struct pgp_key_t {
 
     bool valid() const;
     bool validated() const;
+    /** @brief return time till which primary key is considered to be valid */
+    uint32_t valid_till() const;
+    /** @brief return time till which subkey is considered to be valid */
+    uint32_t valid_till(const pgp_key_t &primary) const;
 
     /** @brief Get key's id */
     const pgp_key_id_t &keyid() const;

--- a/src/tests/ffi-key-sig.cpp
+++ b/src/tests/ffi-key-sig.cpp
@@ -260,7 +260,17 @@ TEST_F(rnp_tests, test_ffi_import_signatures)
     assert_string_equal(type, "key revocation");
     rnp_buffer_destroy(type);
     assert_rnp_success(rnp_signature_is_valid(sig, 0));
+    uint32_t screate = 0;
+    assert_rnp_success(rnp_signature_get_creation(sig, &screate));
+    assert_int_equal(screate, 1578663151);
     rnp_signature_handle_destroy(sig);
+    /* check key validity */
+    bool valid = true;
+    assert_rnp_success(rnp_key_is_valid(key_handle, &valid));
+    assert_false(valid);
+    uint32_t till = 0;
+    assert_rnp_success(rnp_key_valid_till(key_handle, &till));
+    assert_int_equal(till, 1578663151);
     /* check import with NULL results param */
     assert_rnp_success(rnp_input_from_path(&input, "data/test_key_validity/alice-rev.pgp"));
     assert_rnp_success(rnp_import_signatures(ffi, input, 0, NULL));
@@ -295,6 +305,10 @@ TEST_F(rnp_tests, test_ffi_import_signatures)
     assert_int_equal(sigcount, 1);
     assert_rnp_success(rnp_key_is_revoked(key_handle, &revoked));
     assert_true(revoked);
+    assert_rnp_success(rnp_key_is_valid(key_handle, &valid));
+    assert_false(valid);
+    assert_rnp_success(rnp_key_valid_till(key_handle, &till));
+    assert_int_equal(till, 1578663151);
     assert_rnp_success(rnp_key_handle_destroy(key_handle));
     assert_int_equal(unlink("pubring.gpg"), 0);
 

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -940,8 +940,10 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_non_null(primary_sec);
         assert_true(primary_pub->valid());
         assert_true(primary_pub->validated());
+        assert_false(primary_pub->expired());
         assert_true(primary_sec->valid());
         assert_true(primary_sec->validated());
+        assert_false(primary_sec->expired());
 
         // check packet and subsig counts
         assert_int_equal(3, pub.rawpkt_count());
@@ -1010,18 +1012,22 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         primary_pub->validate(*pubring);
         assert_true(primary_pub->valid());
         assert_true(primary_pub->validated());
+        assert_false(primary_pub->expired());
         // primary_sec + pubring
         primary_sec->validate(*pubring);
         assert_true(primary_sec->valid());
         assert_true(primary_sec->validated());
+        assert_false(primary_sec->expired());
         // primary_pub + secring
         primary_pub->validate(*secring);
         assert_true(primary_pub->valid());
         assert_true(primary_pub->validated());
+        assert_false(primary_pub->expired());
         // primary_sec + secring
         primary_sec->validate(*secring);
         assert_true(primary_sec->valid());
         assert_true(primary_sec->validated());
+        assert_false(primary_sec->expired());
         // modify a hashed portion of the sig packet, offset may change in future
         pgp_subsig_t &sig = primary_pub->get_sig(0);
         sig.sig.hashed_data[10] ^= 0xff;
@@ -1030,12 +1036,14 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         primary_pub->validate(*pubring);
         assert_false(primary_pub->valid());
         assert_true(primary_pub->validated());
+        assert_false(primary_pub->expired());
         // restore the original data
         sig.sig.hashed_data[10] ^= 0xff;
         sig.validity.validated = false;
         primary_pub->validate(*pubring);
         assert_true(primary_pub->valid());
         assert_true(primary_pub->validated());
+        assert_false(primary_pub->expired());
     }
 
     // sub
@@ -1059,8 +1067,10 @@ TEST_F(rnp_tests, test_generated_key_sigs)
           &desc, true, primary_sec, primary_pub, &sec, &pub, NULL, PGP_KEY_STORE_GPG));
         assert_true(pub.valid());
         assert_true(pub.validated());
+        assert_false(pub.expired());
         assert_true(sec.valid());
         assert_true(sec.validated());
+        assert_false(sec.expired());
 
         // check packet and subsig counts
         assert_int_equal(2, pub.rawpkt_count());
@@ -1119,16 +1129,20 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         assert_non_null(sub_sec);
         assert_true(sub_pub->valid());
         assert_true(sub_pub->validated());
+        assert_false(sub_pub->expired());
         assert_true(sub_sec->valid());
         assert_true(sub_sec->validated());
+        assert_false(sub_sec->expired());
 
         // validate via an alternative method
         sub_pub->validate(*pubring);
         assert_true(sub_pub->valid());
         assert_true(sub_pub->validated());
+        assert_false(sub_pub->expired());
         sub_sec->validate(*pubring);
         assert_true(sub_sec->valid());
         assert_true(sub_sec->validated());
+        assert_false(sub_sec->expired());
     }
 
     delete pubring;


### PR DESCRIPTION
First function would allow caller to check whether public key is considered to be valid for operations (encryption/verifications).
`rnp_key_valid_till()` would allow to fetch the latest timestamp when key is considered to be valid, so it may be used to validate old signatures.

Fixes #1214 

Should be rebased after #1368 is merged.