### PR TITLE
Added --expiration flag to rnpkeys

### DIFF
--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -25,6 +25,7 @@ env:
   GPG_VERSION: stable
   SUDO: ""
   USE_STATIC_DEPENDENCIES: yes
+  RNP_LOG_CONSOLE: 1
 
 jobs:
   tests:

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
+#include <limits.h>
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #else
@@ -41,6 +42,7 @@
 #include "rnpcfg.h"
 #include "defaults.h"
 #include "logging.h"
+#include "time-utils.h"
 #include <rnp/rnp.h>
 
 // must be placed after include "utils.h"
@@ -362,92 +364,163 @@ rnp_cfg::~rnp_cfg()
  * @return true on success or false otherwise
  */
 
-static bool
-grabdate(const char *s, int64_t *t)
+/** @brief
+ *
+ *  @param s [in] NULL-terminated string with the date
+ *  @param t [out] UNIX timestamp of
+ * successfully parsed date
+ *  @return 0 when parsed successfully
+ *          1 when s doesn't match the regex
+ * -1 when
+ * s matches the regex but the date is not acceptable
+ *          -2 failure
+ */
+static int
+grabdate(const char *s, uint64_t *t)
 {
+    struct tm tm;
+    (void) memset(&tm, 0x0, sizeof(tm));
 #ifndef RNP_USE_STD_REGEX
     static regex_t r;
     static int     compiled;
     regmatch_t     matches[10];
-    struct tm      tm;
 
     if (!compiled) {
         compiled = 1;
         if (regcomp(&r,
-                    "([0-9][0-9][0-9][0-9])[-/]([0-9][0-9])[-/]([0-9][0-9])",
+                    "^([0-9][0-9][0-9][0-9])[-/]([0-9][0-9])[-/]([0-9][0-9])$",
                     REG_EXTENDED) != 0) {
             RNP_LOG("failed to compile regexp");
-            return false;
+            return -2;
         }
     }
-    if (regexec(&r, s, 10, matches, 0) == 0) {
-        (void) memset(&tm, 0x0, sizeof(tm));
-        tm.tm_year = (int) strtol(&s[(int) matches[1].rm_so], NULL, 10);
-        tm.tm_mon = (int) strtol(&s[(int) matches[2].rm_so], NULL, 10) - 1;
-        tm.tm_mday = (int) strtol(&s[(int) matches[3].rm_so], NULL, 10);
-        *t = mktime(&tm);
-        return true;
+    if (regexec(&r, s, 10, matches, 0) != 0) {
+        return 1;
     }
+    int year = (int) strtol(&s[(int) matches[1].rm_so], NULL, 10);
+    int mon = (int) strtol(&s[(int) matches[2].rm_so], NULL, 10);
+    tm.tm_mday = (int) strtol(&s[(int) matches[3].rm_so], NULL, 10);
 #else
-    struct tm tm;
-
-    static std::regex re("([0-9][0-9][0-9][0-9])[-/]([0-9][0-9])[-/]([0-9][0-9])",
-                         std::regex_constants::extended);
+    static std::regex re("^([0-9][0-9][0-9][0-9])[-/]([0-9][0-9])[-/]([0-9][0-9])$",
+                         std::regex_constants::ECMAScript);
     std::smatch       result;
     std::string       input = s;
 
-    if (std::regex_search(input, result, re)) {
-        (void) memset(&tm, 0x0, sizeof(tm));
-        tm.tm_year = (int) strtol(result[1].str().c_str(), NULL, 10);
-        tm.tm_mon = (int) strtol(result[2].str().c_str(), NULL, 10) - 1;
-        tm.tm_mday = (int) strtol(result[3].str().c_str(), NULL, 10);
-        *t = mktime(&tm);
-        return true;
+    if (!std::regex_search(input, result, re)) {
+        return 1;
     }
+    int year = (int) strtol(result[1].str().c_str(), NULL, 10);
+    int mon = (int) strtol(result[2].str().c_str(), NULL, 10);
+    tm.tm_mday = (int) strtol(result[3].str().c_str(), NULL, 10);
 #endif
-    return false;
+    if (year < 1970 || mon < 1 || mon > 12) {
+        return -1;
+    }
+    tm.tm_year = year - 1900;
+    tm.tm_mon = mon - 1;
+
+    struct tm check_tm = tm;
+    time_t    built_time = rnp_mktime(&tm);
+    // check that the time wasn't adjusted
+    if (check_tm.tm_year != tm.tm_year || check_tm.tm_mon != tm.tm_mon ||
+        check_tm.tm_mday != tm.tm_mday) {
+        return -1;
+    }
+    *t = built_time;
+    return 0;
 }
 
-uint64_t
-get_expiration(const char *s)
+int
+get_expiration(const char *s, uint32_t *res)
 {
-    uint64_t    now;
-    int64_t     t;
-    const char *mult;
-
     if (!s || !strlen(s)) {
-        return 0;
+        return -1;
     }
-    now = (uint64_t) strtoull(s, NULL, 10);
-    if ((mult = strchr("hdwmy", s[strlen(s) - 1])) != NULL) {
-        switch (*mult) {
-        case 'h':
-            return now * 60 * 60;
-        case 'd':
-            return now * 60 * 60 * 24;
-        case 'w':
-            return now * 60 * 60 * 24 * 7;
-        case 'm':
-            return now * 60 * 60 * 24 * 31;
-        case 'y':
-            return now * 60 * 60 * 24 * 365;
+    uint64_t delta;
+    uint64_t t;
+    int      grabdate_result = grabdate(s, &t);
+    if (!grabdate_result) {
+        uint32_t now = time(NULL);
+        if (t > now) {
+            delta = t - now;
+            if (delta > UINT_MAX) {
+                return -3;
+            }
+            *res = delta;
+            return 0;
+        }
+        return -2;
+    } else if (grabdate_result < 0) {
+        return -2;
+    }
+#ifndef RNP_USE_STD_REGEX
+    static regex_t r;
+    static int     compiled;
+    regmatch_t     matches[10];
+
+    if (!compiled) {
+        compiled = 1;
+        if (regcomp(&r, "^([0-9]+)([hdwmy]?)$", REG_EXTENDED | REG_ICASE) != 0) {
+            RNP_LOG("failed to compile regexp");
+            return -2;
         }
     }
-    if (grabdate(s, &t)) {
-        return t;
+    if (regexec(&r, s, 10, matches, 0) != 0) {
+        return -2;
     }
-    return (uint64_t) strtoll(s, NULL, 10);
+    auto delta_str = &s[(int) matches[1].rm_so];
+    char mult = s[(int) matches[2].rm_so];
+#else
+    static std::regex re("^([0-9]+)([hdwmy]?)$",
+                         std::regex_constants::ECMAScript | std::regex_constants::icase);
+    std::smatch       result;
+    std::string       input = s;
+
+    if (!std::regex_search(input, result, re)) {
+        return -2;
+    }
+    std::string delta_stdstr = result[1].str();
+    const char *delta_str = delta_stdstr.c_str();
+    char        mult = result[2].str()[0];
+#endif
+    errno = 0;
+    delta = (uint64_t) strtoul(delta_str, NULL, 10);
+    if (errno || delta > UINT_MAX) {
+        return -3;
+    }
+    switch (std::tolower(mult)) {
+    case 'h':
+        delta *= 60 * 60;
+        break;
+    case 'd':
+        delta *= 60 * 60 * 24;
+        break;
+    case 'w':
+        delta *= 60 * 60 * 24 * 7;
+        break;
+    case 'm':
+        delta *= 60 * 60 * 24 * 31;
+        break;
+    case 'y':
+        delta *= 60 * 60 * 24 * 365;
+        break;
+    }
+    if (delta > UINT_MAX) {
+        return -4;
+    }
+    *res = delta;
+    return 0;
 }
 
 int64_t
 get_creation(const char *s)
 {
-    int64_t t;
+    uint64_t t;
 
     if (!s || !strlen(s)) {
         return time(NULL);
     }
-    if (grabdate(s, &t)) {
+    if (!grabdate(s, &t)) {
         return t;
     }
     return (uint64_t) strtoll(s, NULL, 10);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -98,9 +98,11 @@
 #define CFG_KG_PRIMARY_ALG "kg-primary-alg"
 #define CFG_KG_PRIMARY_BITS "kg-primary-bits"
 #define CFG_KG_PRIMARY_CURVE "kg-primary-curve"
+#define CFG_KG_PRIMARY_EXPIRATION "kg-primary-expiration"
 #define CFG_KG_SUBKEY_ALG "kg-subkey-alg"
 #define CFG_KG_SUBKEY_BITS "kg-subkey-bits"
 #define CFG_KG_SUBKEY_CURVE "kg-subkey-curve"
+#define CFG_KG_SUBKEY_EXPIRATION "kg-subkey-expiration"
 #define CFG_KG_HASH "kg-hash"
 #define CFG_KG_PROT_HASH "kg-prot-hash"
 #define CFG_KG_PROT_ALG "kg-prot-alg"
@@ -175,10 +177,13 @@ class rnp_cfg {
  *  - 60000 : number of seconds
  *
  *  @param s [in] NULL-terminated string with the date
- *  @param t [out] On successful return result will be placed here
- *  @return expiration time in seconds
+ *  @param t [out] On successfull return result will be placed here
+ *  @return 0 on success
+ *          -1 on parse error
+ *          -2 if a date in the past was specified
+ *          -3 overflow
  */
-uint64_t get_expiration(const char *s);
+int get_expiration(const char *s, uint32_t *t);
 
 /** @brief Get signature validity start time from the user input
  *

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -72,6 +72,7 @@ const char *usage = "-h, --help OR\n"
                     "\t[--output=file] file OR\n"
                     "\t[--keystore-format=<format>] AND/OR\n"
                     "\t[--userid=<userid>] AND/OR\n"
+                    "\t[--expiration=<expiration>] AND/OR\n"
                     "\t[--rev-type, --rev-reason] AND/OR\n"
                     "\t[--verbose]\n";
 
@@ -110,6 +111,7 @@ struct option options[] = {
   {"numbits", required_argument, NULL, OPT_NUMBITS},
   {"s2k-iterations", required_argument, NULL, OPT_S2K_ITER},
   {"s2k-msec", required_argument, NULL, OPT_S2K_MSEC},
+  {"expiration", required_argument, NULL, OPT_EXPIRATION},
   {"verbose", no_argument, NULL, OPT_VERBOSE},
   {"pass-fd", required_argument, NULL, OPT_PASSWDFD},
   {"password", required_argument, NULL, OPT_PASSWD},
@@ -519,6 +521,10 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         cfg.set_int(CFG_S2K_ITER, iterations);
         return true;
     }
+    case OPT_EXPIRATION:
+        cfg.set_str(CFG_KG_PRIMARY_EXPIRATION, arg);
+        cfg.set_str(CFG_KG_SUBKEY_EXPIRATION, arg);
+        return true;
     case OPT_S2K_MSEC: {
         if (!arg) {
             ERR_MSG("No s2k msec argument provided");

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -45,6 +45,7 @@ typedef enum {
     OPT_SECRET,
     OPT_S2K_ITER,
     OPT_S2K_MSEC,
+    OPT_EXPIRATION,
     OPT_WITH_SIGS,
     OPT_REV_TYPE,
     OPT_REV_REASON,

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -393,6 +393,8 @@ void test_stream_dearmor_edge_cases(void **state);
 
 void test_cli_rnpkeys(void **state);
 
+void test_cli_rnpkeys_genkey(void **state);
+
 void test_cli_rnpkeys_unicode(void **state);
 
 void test_cli_rnp(void **state);


### PR DESCRIPTION
Closes #1388 
1) `--expiration` flag for `rnpkeys --gen-key` sets expiration for both primary and sub- generated keys.
2) `grabdate()` is fixed and tested with absolute values like '2022-12-31' and relative like '1', '1m', '1y' etc.
3) absolute date in past results in error
