### PR TITLE
Fix a bunch of GCC warnings.

### DIFF
--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -135,7 +135,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto,
             seckey->material.ec.curve = crypto->ecc.curve;
             break;
         }
-    /* FALLTHROUGH for non-x25519 curves */
+    /* FALLS THROUGH for non-x25519 curves */
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
         if (ec_generate(crypto->rng, &seckey->material.ec, seckey->alg, crypto->ecc.curve)) {

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -145,10 +145,10 @@ hexdump(FILE *fp, const char *header, const uint8_t *src, size_t length)
     char   line[LINELEN + 1];
 
     (void) fprintf(fp, "%s%s", (header) ? header : "", (header) ? "" : "");
-    (void) fprintf(fp, " (%" PRIsize "u byte%s):\n", length, (length == 1) ? "" : "s");
+    (void) fprintf(fp, " (%zu byte%s):\n", length, (length == 1) ? "" : "s");
     for (i = 0; i < length; i++) {
         if (i % LINELEN == 0) {
-            (void) fprintf(fp, "%.5" PRIsize "u | ", i);
+            (void) fprintf(fp, "%.5zu | ", i);
         }
         (void) fprintf(fp, "%.02x ", (uint8_t) src[i]);
         line[i % LINELEN] = (isprint(src[i])) ? src[i] : '.';

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -172,6 +172,8 @@ struct pgp_key_t {
     pgp_key_t(const pgp_key_t &src, bool pubonly = false);
     pgp_key_t(const pgp_transferable_key_t &src);
     pgp_key_t(const pgp_transferable_subkey_t &src, pgp_key_t *primary);
+    pgp_key_t &operator=(const pgp_key_t &) = default;
+    pgp_key_t &operator=(pgp_key_t &&) = default;
 
     size_t              sig_count() const;
     pgp_subsig_t &      get_sig(size_t idx);

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -135,12 +135,6 @@ void         set_rnp_log_switch(int8_t);
 /* Formating helpers */
 #define PRItime "ll"
 
-#ifdef _WIN32
-#define PRIsize "I"
-#else
-#define PRIsize "z"
-#endif
-
 /* TODO: Review usage of this variable */
 #define RNP_BUFSIZ 8192
 

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -503,7 +503,7 @@ dst_hexdump(pgp_dest_t *dst, const uint8_t *src, size_t length)
 
     for (i = 0; i < length; i++) {
         if (i % LINELEN == 0) {
-            dst_printf(dst, "%.5" PRIsize "u | ", i);
+            dst_printf(dst, "%.5zu | ", i);
         }
         dst_printf(dst, "%.02x ", (uint8_t) src[i]);
         line[i % LINELEN] = (isprint(src[i])) ? src[i] : '.';

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -941,20 +941,14 @@ write_pgp_keys(pgp_key_sequence_t &keys, pgp_dest_t *dst, bool armor)
 rnp_result_t
 write_pgp_key(pgp_transferable_key_t &key, pgp_dest_t *dst, bool armor)
 {
-    pgp_key_sequence_t keys;
-
     try {
-        keys.keys.emplace_back();
+        pgp_key_sequence_t keys;
+        keys.keys.push_back(key);
+        return write_pgp_keys(keys, dst, armor);
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
         return RNP_ERROR_OUT_OF_MEMORY;
     }
-    /* temporary solution to not implement copy constructor */
-    pgp_transferable_key_t &front = keys.keys.front();
-    memcpy(&front, &key, sizeof(key));
-    rnp_result_t res = write_pgp_keys(keys, dst, armor);
-    memset(&front, 0, sizeof(front));
-    return res;
 }
 
 static rnp_result_t

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -387,52 +387,6 @@ stream_skip_packet(pgp_source_t *src)
     return stream_read_packet(src, NULL);
 }
 
-bool
-stream_write_sk_sesskey(const pgp_sk_sesskey_t *skey, pgp_dest_t *dst)
-{
-    try {
-        pgp_packet_body_t pktbody(PGP_PKT_SK_SESSION_KEY);
-        /* version and algorithm fields */
-        pktbody.add_byte(skey->version);
-        pktbody.add_byte(skey->alg);
-        if (skey->version == PGP_SKSK_V5) {
-            pktbody.add_byte(skey->aalg);
-        }
-        /* S2K specifier */
-        pktbody.add_byte(skey->s2k.specifier);
-        pktbody.add_byte(skey->s2k.hash_alg);
-
-        switch (skey->s2k.specifier) {
-        case PGP_S2KS_SIMPLE:
-            break;
-        case PGP_S2KS_SALTED:
-            pktbody.add(skey->s2k.salt, sizeof(skey->s2k.salt));
-            break;
-        case PGP_S2KS_ITERATED_AND_SALTED:
-            pktbody.add(skey->s2k.salt, sizeof(skey->s2k.salt));
-            pktbody.add_byte(skey->s2k.iterations);
-            break;
-        default:
-            RNP_LOG("Unexpected s2k specifier: %d", (int) skey->s2k.specifier);
-            return false;
-        }
-        /* v5 : iv */
-        if (skey->version == PGP_SKSK_V5) {
-            pktbody.add(skey->iv, skey->ivlen);
-        }
-        /* encrypted key and auth tag for v5 */
-        if (skey->enckeylen > 0) {
-            pktbody.add(skey->enckey, skey->enckeylen);
-        }
-        /* write packet */
-        pktbody.write(*dst);
-        return true;
-    } catch (const std::exception &e) {
-        RNP_LOG("%s", e.what());
-        return false;
-    }
-}
-
 rnp_result_t
 stream_parse_marker(pgp_source_t &src)
 {

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1586,7 +1586,7 @@ pgp_signature_t::parse_v4(pgp_packet_body_t &pkt)
     /* hashed subpackets length */
     uint16_t splen = read_uint16(&buf[3]);
     /* hashed subpackets length + 2 bytes of length of unhashed subpackets */
-    if (pkt.left() < splen + 2) {
+    if (pkt.left() < (size_t)(splen + 2)) {
         RNP_LOG("wrong packet or hashed subpackets length");
         return RNP_ERROR_BAD_FORMAT;
     }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1608,7 +1608,7 @@ conffile(const char *homedir, char *userid, size_t length)
         std::smatch result;
         std::string input = buf;
         if (std::regex_search(input, result, keyre)) {
-            (void) strncpy(userid, result[1].str().c_str(), length);
+            (void) strncpy(userid, result[1].str().c_str(), length - 1);
             userid[length - 1] = '\0';
 
             ERR_MSG("rnp: default key set to \"%s\"", userid);


### PR DESCRIPTION
It fixes the following warnings:
- `warning: implicitly-declared 'pgp_key_t& pgp_key_t::operator=(const pgp_key_t&)' is deprecated [-Wdeprecated-copy]`
- `warning: this statement may fall through [-Wimplicit-fallthrough=]`
- `warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'pgp_transferable_key_t' {aka 'struct pgp_transferable_key_t'} with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]`

