### PR TITLE
Run cli_tests under MSVC in a single thread to avoid timeouts.

### DIFF
--- a/ci/test.msvc.sh
+++ b/ci/test.msvc.sh
@@ -10,7 +10,8 @@ mkdir -p "build/Testing/Temporary"
 cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
 
 cd build
-ctest -j"${CTEST_PARALLEL}" -C Debug --output-on-failure
+ctest -j"${CTEST_PARALLEL}" -R rnp_tests -C Debug --output-on-failure
+ctest -R cli_tests -C Debug --output-on-failure
 cd ..
 
 exit 0


### PR DESCRIPTION
This would work as a workaround until issue #1394 is fixed.