### PR TITLE
Manpage cleanup

### DIFF
--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -36,7 +36,7 @@
 .Sh LIBRARY
 .Lb librnp
 .Sh SYNOPSIS
-.In rnp.h
+.In rnp/rnp.h
 .Pp
 The following functions relate to initialisations and finalisations:
 .Ft int

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -34,6 +34,7 @@
 .Nm librnp
 .Nd digital signing and verification, encryption and decryption
 .Sh LIBRARY
+.ds doc-str-Lb-librnp    OpenPGP signing, verification, encryption, and decryption  (librnp, \-lrnp\-0)
 .Lb librnp
 .Sh SYNOPSIS
 .In rnp/rnp.h

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -31,7 +31,26 @@
 .Dt LIBRNP 3
 .Os
 .Sh NAME
-.Nm librnp
+.Nm librnp ,
+.Nm rnp_add_key ,
+.Nm rnp_end ,
+.Nm rnp_generate_key ,
+.Nm rnp_get_debug ,
+.Nm rnp_get_info ,
+.Nm rnp_get_key ,
+.Nm rnp_getvar ,
+.Nm rnp_incvar ,
+.Nm rnp_init ,
+.Nm rnp_key_export ,
+.Nm rnp_match_list_keys ,
+.Nm rnp_process_file ,
+.Nm rnp_process_mem ,
+.Nm rnp_protect_file ,
+.Nm rnp_protect_mem ,
+.Nm rnp_set_debug ,
+.Nm rnp_set_homedir ,
+.Nm rnp_set_key_store_format ,
+.Nm rnp_setvar
 .Nd digital signing and verification, encryption and decryption
 .Sh LIBRARY
 .ds doc-str-Lb-librnp    OpenPGP signing, verification, encryption, and decryption  (librnp, \-lrnp\-0)


### PR DESCRIPTION
This series improves the metadata in the manual page for librnp.

Note that with these changes, using a sensible manpage reader (like [man-db](https://nongnu.org/man-db/)), users can now do:

    man rnp_init

and it brings them to the correct page.