### PR TITLE
Make rnp_log_switch a C function, not C++

### DIFF
--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -31,6 +31,10 @@
 #include <limits.h>
 #include <rnp/rnp_export.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RNP_MSG(msg) (void) fprintf(stdout, msg);
 
 // TODO: It is currently necessary to mark this with RNP_API, but this should
@@ -221,5 +225,9 @@ getenv_logname(void)
     }
     return name;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This avoids exporting a C++-mangled symbol in the librnp shared object.

This addresses part of #1414.