### PR TITLE
Avoid exposing rnp_log_switch in the dynamically-linked library

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -128,6 +128,7 @@ add_library(librnp-obj OBJECT
   fingerprint.cpp
   generate-key.cpp
   key-provider.cpp
+  log-switch.cpp
   misc.cpp
   pass-provider.cpp
   pgp-key.cpp

--- a/src/lib/log-switch.cpp
+++ b/src/lib/log-switch.cpp
@@ -1,0 +1,30 @@
+#include <stdlib.h>
+#include "utils.h"
+
+/* -1 -- not initialized
+    0 -- logging is off
+    1 -- logging is on
+*/
+int8_t _rnp_log_switch =
+#ifdef NDEBUG
+  -1 // lazy-initialize later
+#else
+  1 // always on in debug build
+#endif
+  ;
+
+void
+set_rnp_log_switch(int8_t value)
+{
+    _rnp_log_switch = value;
+}
+
+bool
+rnp_log_switch()
+{
+    if (_rnp_log_switch < 0) {
+        const char *var = getenv(RNP_LOG_CONSOLE);
+        _rnp_log_switch = (var && strcmp(var, "0")) ? 1 : 0;
+    }
+    return !!_rnp_log_switch;
+}

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -236,34 +236,6 @@ rnp_clear_debug()
     debugc = 0;
 }
 
-/* -1 -- not initialized
-    0 -- logging is off
-    1 -- logging is on
-*/
-int8_t _rnp_log_switch =
-#ifdef NDEBUG
-  -1 // lazy-initialize later
-#else
-  1 // always on in debug build
-#endif
-  ;
-
-void
-set_rnp_log_switch(int8_t value)
-{
-    _rnp_log_switch = value;
-}
-
-bool
-rnp_log_switch()
-{
-    if (_rnp_log_switch < 0) {
-        const char *var = getenv(RNP_LOG_CONSOLE);
-        _rnp_log_switch = (var && strcmp(var, "0")) ? 1 : 0;
-    }
-    return !!_rnp_log_switch;
-}
-
 /* portable replacement for strcasecmp(3) */
 int
 rnp_strcasecmp(const char *s1, const char *s2)

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -33,9 +33,7 @@
 
 #define RNP_MSG(msg) (void) fprintf(stdout, msg);
 
-// TODO: It is currently necessary to mark this with RNP_API, but this should
-// be removed at some point since it is not part of the public API.
-RNP_API bool rnp_log_switch();
+bool rnp_log_switch();
 void         set_rnp_log_switch(int8_t);
 
 #define RNP_LOG_FD(fd, ...)                                                  \

--- a/src/rnp/CMakeLists.txt
+++ b/src/rnp/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(rnp
   rnp.cpp
   fficli.cpp
   ../rnpkeys/tui.cpp
+  ../lib/log-switch.cpp
   rnpcfg.cpp
   $<TARGET_OBJECTS:rnp-common>
 )

--- a/src/rnpkeys/CMakeLists.txt
+++ b/src/rnpkeys/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(rnpkeys
   rnpkeys.cpp
   tui.cpp
   main.cpp
+  ../lib/log-switch.cpp
   ../rnp/rnpcfg.cpp
   ../rnp/fficli.cpp
   $<TARGET_OBJECTS:rnp-common>


### PR DESCRIPTION
rnp_log_switch is only used internally to librnp, and in the binaries
rnp and rnpkeys.

It deals with some internal state so that it can initialize lazily,
and so that a developer can tweak it manually with set_rnp_log_switch,
but this isn't intended for public functionality.

We solve this by exposing the functionality for handling
rnp_log_switch directly in its own compilation unit, and then
including that compilation unit in the objects that need it.

This means that set_rnp_log_switch will now be available to anyone who
includes that compilation unit, but it won't affect other copies of
that compilation unit in a dynamically-assembled executable.  However,
this is no loss compared to before: set_rnp_log_switch wasn't
accessible *at all* to a dynamically-linked rnp and rnpkeys before
this change, as it is not part of the public API.

Other situations may come up like this in the future: utility
functions that are used within librnp *and* directly by binaries like
rnp or rnpkeys, but are not (and should not) be exposed in the library
interface.  If this becomes more prevalent, the right thing to do is
to assemble a static object (maybe rnp-utils-private.a), which
comprises the compilation units that offer these utilities.  Link that
object into all the relevant places.

This will result in a slightly larger executable (one copy of the
private static lib on both sides of the shared object interface), but
it permits the compiler to inline small utility functions (rather than
calling into the dynamic library), and it exposes less in the library
interface.

If you want an example of another project that does something similar
with a private utility library included in both a shared object and a
binary that links against the shared object, take a look at
https://notmuchmail.org/