### PR TITLE
Avoid embedding major version number in library name

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -134,7 +134,7 @@ jobs:
             fi
           fi
           # build an example using pkg-config
-          gcc "${rnpsrc}/src/examples/generate.c" -ogenerate $(pkg-config --cflags --libs $pkgflags librnp-0) $gccflags
+          gcc "${rnpsrc}/src/examples/generate.c" -ogenerate $(pkg-config --cflags --libs $pkgflags librnp) $gccflags
           ./generate
           readelf -d generate
           if [ $BUILD_SHARED_LIBS == "yes" ]; then

--- a/cmake/librnp.pc.in
+++ b/cmake/librnp.pc.in
@@ -1,7 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include/@LIBRNP_INCLUDEDIR@
 
 Name: rnp
 Description: @PACKAGE_DESCRIPTION_SHORT@

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -109,5 +109,5 @@ cmake -DBUILD_SHARED_LIBS=yes -G "MSYS Makefiles" ../rnp
 make && make install
 ----
 
-Depending on how do you run rnp.exe and rnpkeys.exe you'll need to make sure that librnp-0.dll is on path or in the same folder as well as all dependencies.
+Depending on how do you run rnp.exe and rnpkeys.exe you'll need to make sure that librnp.dll is on path or in the same folder as well as all dependencies.
 You may check dependenices and their pathes via ntldd.exe in MSYS command prompt. 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -170,7 +170,7 @@ set_target_properties(librnp
     VERSION "${RNP_VERSION}"
     SOVERSION "${RNP_VERSION_MAJOR}"
     PREFIX "lib"
-    OUTPUT_NAME "rnp-${RNP_VERSION_MAJOR}"
+    OUTPUT_NAME "rnp"
 )
 
 if (BUILD_SHARED_LIBS)
@@ -200,8 +200,6 @@ if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
   file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/version.h")
 endif()
 
-set(LIBRNP_INCLUDEDIR "rnp-${PROJECT_VERSION_MAJOR}")
-
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
   set(namelink_component NAMELINK_COMPONENT development)
 else()
@@ -216,7 +214,6 @@ install(TARGETS librnp
     COMPONENT runtime
     ${namelink_component}
   ARCHIVE DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
-  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRNP_INCLUDEDIR}"
 )
 
 # install dll only for windows
@@ -235,7 +232,7 @@ install(
   COMPONENT
     development
   DESTINATION
-    "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRNP_INCLUDEDIR}/rnp"
+    "${CMAKE_INSTALL_INCLUDEDIR}/rnp"
   RENAME
     rnp.h
 )
@@ -245,7 +242,7 @@ install(
   COMPONENT
     development
   DESTINATION
-    "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRNP_INCLUDEDIR}/rnp"
+    "${CMAKE_INSTALL_INCLUDEDIR}/rnp"
   RENAME
     rnp_err.h
 )
@@ -255,7 +252,7 @@ install(
   COMPONENT
     development
   DESTINATION
-    "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRNP_INCLUDEDIR}/rnp"
+    "${CMAKE_INSTALL_INCLUDEDIR}/rnp"
   RENAME
     rnp_export.h
 )
@@ -338,11 +335,11 @@ if (PKG_CONFIG_FOUND)
   get_target_property(LIBRNP_OUTPUT_NAME librnp OUTPUT_NAME)
   configure_file(
     "${PROJECT_SOURCE_DIR}/cmake/librnp.pc.in"
-    "${PROJECT_BINARY_DIR}/librnp-${PROJECT_VERSION_MAJOR}.pc"
+    "${PROJECT_BINARY_DIR}/librnp.pc"
     @ONLY
   )
   install(
-    FILES "${PROJECT_BINARY_DIR}/librnp-${PROJECT_VERSION_MAJOR}.pc"
+    FILES "${PROJECT_BINARY_DIR}/librnp.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     COMPONENT development
   )


### PR DESCRIPTION
The indication of API and ABI stability for a C library is the SONAME,
which already includes the necessary versioning information.

We don't want users of librnp to try to build against two versions of
the library at once, so there isn't a strong reason to have two copies
of devel info (headers/pkg-config/etc) installed at once.

Two different binary shared objects with SONAMEs should already be
able to be installed concurrently, so this doesn't affect the
situation with multiple distinct tools on a system that are built
against different API or ABIs.

Closes: #1406