### PR TITLE
Produce more useful error reports if s2k_iteration_tuning test fails

### DIFF
--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -662,7 +662,7 @@ TEST_F(rnp_tests, s2k_iteration_tuning)
 
     // fprintf(stderr, "%d %d\n", iters_10, iters_100);
     // Test roughly linear cost, often skeyed by clock idle
-    assert_true(static_cast<double>(iters_100) / iters_10 > 6);
+    assert_greater_than(static_cast<double>(iters_100) / iters_10, 6);
 
     // Should not crash for unknown hash algorithm
     assert_int_equal(pgp_s2k_compute_iters(PGP_HASH_UNKNOWN, 1000, TRIAL_MSEC), 0);

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -444,6 +444,7 @@ void test_fuzz_verify_detached(void **state);
 #define assert_string_equal(a, b) EXPECT_STREQ((a), (b))
 #define assert_int_equal(a, b) EXPECT_EQ((a), (b))
 #define assert_int_not_equal(a, b) EXPECT_NE((a), (b))
+#define assert_greater_than(a, b) EXPECT_GT((a), (b))
 #define assert_non_null(a) EXPECT_NE((a), nullptr)
 #define assert_null(a) EXPECT_EQ((a), nullptr)
 #define assert_rnp_success(a) EXPECT_EQ((a), RNP_SUCCESS)


### PR DESCRIPTION
This doesn't necessarily solve the problem of a CPU core being
jittery, but it gives clearer detail if there is a failure.

Closes: #1418

An example failure is now:

```
15: Expected: ((static_cast<double>(iters_100) / iters_10)) > ((6)), actual: 5.93103 vs 6
15: [pgp_s2k_compute_iters() /home/dkg/src/rnp/rnp/src/lib/crypto/s2k.cpp:178] failed to create hash object
15: [  FAILED  ] rnp_tests.s2k_iteration_tuning (528 ms)
15: [----------] 1 test from rnp_tests (528 ms total)
15: 
15: [----------] Global test environment tear-down
15: [==========] 1 test from 1 test suite ran. (528 ms total)
15: [  PASSED  ] 0 tests.
15: [  FAILED  ] 1 test, listed below:
15: [  FAILED  ] rnp_tests.s2k_iteration_tuning
15: 
15:  1 FAILED TEST
````
