### PR TITLE
tests: Avoid concurrent test failures in /tmp

### DIFF
--- a/src/tests/cli_perf.py
+++ b/src/tests/cli_perf.py
@@ -43,10 +43,9 @@ def setup(workdir):
     RNP = rnp_file_path('src/rnp/rnp')
     RNPK = rnp_file_path('src/rnpkeys/rnpkeys')
     GPG = find_utility('gpg')
-    WORKDIR = os.getcwd()
     if workdir:
         WORKDIR = workdir
-    elif not '/tmp/' in WORKDIR:
+    else:
         WORKDIR = tempfile.mkdtemp(prefix = 'rnpptmp')
         RMWORKDIR = True
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -747,10 +747,8 @@ def setup(loglvl):
     global RMWORKDIR, WORKDIR, RNPDIR, RNP, RNPK, GPG, GPGDIR, GPGHOME, GPGCONF
     logging.basicConfig(stream=sys.stderr, format="%(message)s")
     logging.getLogger().setLevel(loglvl)
-    WORKDIR = os.getcwd()
-    if not '/tmp/' in WORKDIR:
-        WORKDIR = tempfile.mkdtemp(prefix='rnpctmp')
-        RMWORKDIR = True
+    WORKDIR = tempfile.mkdtemp(prefix='rnpctmp')
+    RMWORKDIR = True
 
     logging.info('Running in ' + WORKDIR)
 


### PR DESCRIPTION
When built in /tmp with a parallel run of the test suite, the same
filename can be clobbered by different tests.

As long as any tests might be run in parallel, we want each test to
have its own workdir.

Closes: #1408