### PR TITLE
Fix Cirrus CI failure : /lib/libthr.so.3: version FBSD_1.6 not found

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-0-release-amd64
+  image: freebsd-12-2-release-amd64
 
 task:
   name: build


### PR DESCRIPTION
Fix Cirrus CI failure : ld-elf.so.1: /lib/libthr.so.3: version FBSD_1.6 required by /usr/local/lib/libruby25.so.25 not found