### PR TITLE
Add CMake option to disable Googletest download.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,4 +41,36 @@ jobs:
         run: |
           set -x
           ./ci/run.sh
-
+  cmake-offline-googletest:
+    env:
+      DOWNLOAD_GTEST: Off
+      RNP_TESTS: rnp_tests
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup environment
+        run: |
+          . ci/gha/setup-env.inc.sh
+      - name: Build
+        run: |
+          set -x
+          ci/before_install.sh
+          sudo apt-get -y install googletest
+          mkdir -p "${LOCAL_BUILDS}/googletest-build"
+          pushd "${LOCAL_BUILDS}/googletest-build"
+          cmake /usr/src/googletest
+          sudo make -j2 install
+          popd
+          . ci/env.inc.sh
+          ./ci/install.sh
+      - name: tests
+        run: |
+          set -x
+          ./ci/run.sh
+          [ -d "${LOCAL_BUILDS}/rnp-build/src/tests" ]
+          [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-build" ]
+          [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-src" ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ project(RNP
 option(ENABLE_COVERAGE "Enable code coverage testing.")
 option(ENABLE_SANITIZERS "Enable ASan and other sanitizers.")
 option(ENABLE_FUZZERS "Enable fuzz targets.")
+option(DOWNLOAD_GTEST "Download Googletest" On)
 
 # so we can use our bundled finders
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -24,6 +24,7 @@ cmakeopts=(
 )
 [ "$BUILD_MODE" = "coverage" ] && cmakeopts+=("-DENABLE_COVERAGE=yes")
 [ "$BUILD_MODE" = "sanitize" ] && cmakeopts+=("-DENABLE_SANITIZERS=yes")
+[ -v "DOWNLOAD_GTEST" ] && cmakeopts+=("-DDOWNLOAD_GTEST=$DOWNLOAD_GTEST")
 
 if [[ "$(get_os)" = "msys" ]]; then
   cmakeopts+=("-G" "MSYS Makefiles")

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -36,26 +36,33 @@ set_tests_properties(setupTestData PROPERTIES FIXTURES_SETUP testdata)
 
 # rnp_tests
 include(GoogleTest)
-# download and build googletest
-configure_file(gtest-CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+if (NOT DOWNLOAD_GTEST)
+  # use preinstalled googletest
+  find_package(GTest REQUIRED)
+  set(GTestMain GTest::Main)
+else()
+  # download and build googletest
+  configure_file(gtest-CMakeLists.txt.in googletest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
+  # maintain compiler/linker settings on Windows
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  # add to our build (provides gtest_main target)
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                  EXCLUDE_FROM_ALL)
+  set(GTestMain gtest_main)
 endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
-endif()
-# maintain compiler/linker settings on Windows
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-# add to our build (provides gtest_main target)
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-                 EXCLUDE_FROM_ALL)
 
 find_package(JSON-C 0.11 REQUIRED)
 add_executable(rnp_tests
@@ -152,7 +159,7 @@ target_link_libraries(rnp_tests
   PRIVATE
     librnp-static
     JSON-C::JSON-C
-    gtest_main
+    ${GTestMain}
 )
 if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_libraries(rnp_tests PRIVATE regex)

--- a/src/tests/gtest-CMakeLists.txt.in
+++ b/src/tests/gtest-CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.14)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
This PR adds CMake option DOWNLOAD_GTEST, which is On by default.
Setting it to Off will search for preinstalled Googletest.

Fixes #1410 