### PR TITLE
Add CMake option to disable automatic ruby-rnp installation

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -74,3 +74,31 @@ jobs:
           [ -d "${LOCAL_BUILDS}/rnp-build/src/tests" ]
           [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-build" ]
           [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-src" ]
+  cmake-disable-rubyrnp:
+    env:
+      DOWNLOAD_RUBYRNP: Off
+      RNP_TESTS: rnp_tests.hash_test_success
+      BUILD_SHARED_LIBS: yes
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup environment
+        run: |
+          . ci/gha/setup-env.inc.sh
+      - name: Build
+        run: |
+          set -x
+          ci/before_install.sh
+          . ci/env.inc.sh
+          ./ci/install.sh
+      - name: tests
+        run: |
+          set -x
+          ./ci/run.sh
+          ls -la "${RNP_INSTALL}/lib/"librnp*.so
+          ! ctest -N | grep 'ruby' > /dev/null
+          ! ls -la src/tests/ | grep 'ruby' > /dev/null

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(ENABLE_COVERAGE "Enable code coverage testing.")
 option(ENABLE_SANITIZERS "Enable ASan and other sanitizers.")
 option(ENABLE_FUZZERS "Enable fuzz targets.")
 option(DOWNLOAD_GTEST "Download Googletest" On)
+option(DOWNLOAD_RUBYRNP "Download ruby-rnp and run related tests." On)
 
 # so we can use our bundled finders
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -25,6 +25,7 @@ cmakeopts=(
 [ "$BUILD_MODE" = "coverage" ] && cmakeopts+=("-DENABLE_COVERAGE=yes")
 [ "$BUILD_MODE" = "sanitize" ] && cmakeopts+=("-DENABLE_SANITIZERS=yes")
 [ -v "DOWNLOAD_GTEST" ] && cmakeopts+=("-DDOWNLOAD_GTEST=$DOWNLOAD_GTEST")
+[ -v "DOWNLOAD_RUBYRNP" ] && cmakeopts+=("-DDOWNLOAD_RUBYRNP=$DOWNLOAD_RUBYRNP")
 
 if [[ "$(get_os)" = "msys" ]]; then
   cmakeopts+=("-G" "MSYS Makefiles")
@@ -48,9 +49,10 @@ make -j${MAKE_PARALLEL} VERBOSE=1 install
 
 # workaround macOS SIP
 if [ "$(get_os)" != "msys" ] && \
-   [ "$BUILD_MODE" != "sanitize" ]; then
+   [ "$BUILD_MODE" != "sanitize" ] && \
+   [ "$(get_os)" = "macos" ]; then
   pushd "$RUBY_RNP_INSTALL"
-  [[ "$(get_os)" = "macos" ]] && cp "${RNP_INSTALL}/lib"/librnp* /usr/local/lib
+  cp "${RNP_INSTALL}/lib"/librnp* /usr/local/lib
   popd
 fi
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -180,7 +180,7 @@ gtest_discover_tests(rnp_tests
 
 # ruby-rnp
 # cruby does not currently play nice with ASaN et al.
-if (NOT ENABLE_SANITIZERS AND BUILD_SHARED_LIBS AND NOT WIN32)
+if (DOWNLOAD_RUBYRNP AND NOT ENABLE_SANITIZERS AND BUILD_SHARED_LIBS AND NOT WIN32)
   include(ExternalProject)
   set(_sourcedir "${CMAKE_BINARY_DIR}/ruby-rnp")
   if (DEFINED ENV{RUBY_RNP_INSTALL})


### PR DESCRIPTION
Fixes #1267 in a simple way.