### PR TITLE
Extract logging code to the separate file/header.

### DIFF
--- a/src/fuzzing/keyring_g10.cpp
+++ b/src/fuzzing/keyring_g10.cpp
@@ -24,6 +24,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <rnp/rnp.h>
 #include "../lib/pgp-key.h"
 #include "../librekey/key_store_g10.h"
 #include "../librepgp/stream-common.h"

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -128,6 +128,7 @@ add_library(librnp-obj OBJECT
   fingerprint.cpp
   generate-key.cpp
   key-provider.cpp
+  logging.cpp
   misc.cpp
   pass-provider.cpp
   pgp-key.cpp

--- a/src/lib/logging.cpp
+++ b/src/lib/logging.cpp
@@ -1,0 +1,56 @@
+/*-
+ * Copyright (c) 2017-2021 Ribose Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "string.h"
+#include "logging.h"
+
+/* -1 -- not initialized
+    0 -- logging is off
+    1 -- logging is on
+*/
+static int8_t _rnp_log_switch =
+#ifdef NDEBUG
+  -1 // lazy-initialize later
+#else
+  1 // always on in debug build
+#endif
+  ;
+
+void
+set_rnp_log_switch(int8_t value)
+{
+    _rnp_log_switch = value;
+}
+
+bool
+rnp_log_switch()
+{
+    if (_rnp_log_switch < 0) {
+        const char *var = getenv(RNP_LOG_CONSOLE);
+        _rnp_log_switch = (var && strcmp(var, "0")) ? 1 : 0;
+    }
+    return !!_rnp_log_switch;
+}

--- a/src/lib/logging.h
+++ b/src/lib/logging.h
@@ -1,0 +1,75 @@
+/*-
+ * Copyright (c) 2017-2021 Ribose Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RNP_LOGGING_H_
+#define RNP_LOGGING_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+
+/* environment variable name */
+static const char RNP_LOG_CONSOLE[] = "RNP_LOG_CONSOLE";
+
+bool rnp_log_switch();
+void set_rnp_log_switch(int8_t);
+
+#define RNP_LOG_FD(fd, ...)                                                  \
+    do {                                                                     \
+        if (!rnp_log_switch())                                               \
+            break;                                                           \
+        (void) fprintf((fd), "[%s() %s:%d] ", __func__, __FILE__, __LINE__); \
+        (void) fprintf((fd), __VA_ARGS__);                                   \
+        (void) fprintf((fd), "\n");                                          \
+    } while (0)
+
+#define RNP_LOG(...) RNP_LOG_FD(stderr, __VA_ARGS__)
+
+#define RNP_LOG_KEY(msg, key)                                                          \
+    do {                                                                               \
+        if (!(key)) {                                                                  \
+            RNP_LOG(msg, "(null)");                                                    \
+            break;                                                                     \
+        }                                                                              \
+        char                keyid[PGP_KEY_ID_SIZE * 2 + 1] = {0};                      \
+        const pgp_key_id_t &id = key->keyid();                                         \
+        rnp_hex_encode(id.data(), id.size(), keyid, sizeof(keyid), RNP_HEX_LOWERCASE); \
+        RNP_LOG(msg, keyid);                                                           \
+    } while (0)
+
+#define RNP_LOG_KEY_PKT(msg, key)                                                     \
+    do {                                                                              \
+        pgp_key_id_t keyid = {};                                                      \
+        if (pgp_keyid(keyid, (key))) {                                                \
+            RNP_LOG(msg, "unknown");                                                  \
+            break;                                                                    \
+        };                                                                            \
+        char keyidhex[PGP_KEY_ID_SIZE * 2 + 1] = {0};                                 \
+        rnp_hex_encode(                                                               \
+          keyid.data(), keyid.size(), keyidhex, sizeof(keyidhex), RNP_HEX_LOWERCASE); \
+        RNP_LOG(msg, keyidhex);                                                       \
+    } while (0)
+
+#endif

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -236,34 +236,6 @@ rnp_clear_debug()
     debugc = 0;
 }
 
-/* -1 -- not initialized
-    0 -- logging is off
-    1 -- logging is on
-*/
-int8_t _rnp_log_switch =
-#ifdef NDEBUG
-  -1 // lazy-initialize later
-#else
-  1 // always on in debug build
-#endif
-  ;
-
-void
-set_rnp_log_switch(int8_t value)
-{
-    _rnp_log_switch = value;
-}
-
-bool
-rnp_log_switch()
-{
-    if (_rnp_log_switch < 0) {
-        const char *var = getenv(RNP_LOG_CONSOLE);
-        _rnp_log_switch = (var && strcmp(var, "0")) ? 1 : 0;
-    }
-    return !!_rnp_log_switch;
-}
-
 /* portable replacement for strcasecmp(3) */
 int
 rnp_strcasecmp(const char *s1, const char *s2)

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -29,50 +29,9 @@
 #include <stdio.h>
 #include "types.h"
 #include <limits.h>
-#include <rnp/rnp_export.h>
+#include "logging.h"
 
 #define RNP_MSG(msg) (void) fprintf(stdout, msg);
-
-// TODO: It is currently necessary to mark this with RNP_API, but this should
-// be removed at some point since it is not part of the public API.
-RNP_API bool rnp_log_switch();
-void         set_rnp_log_switch(int8_t);
-
-#define RNP_LOG_FD(fd, ...)                                                  \
-    do {                                                                     \
-        if (!rnp_log_switch())                                               \
-            break;                                                           \
-        (void) fprintf((fd), "[%s() %s:%d] ", __func__, __FILE__, __LINE__); \
-        (void) fprintf((fd), __VA_ARGS__);                                   \
-        (void) fprintf((fd), "\n");                                          \
-    } while (0)
-
-#define RNP_LOG(...) RNP_LOG_FD(stderr, __VA_ARGS__)
-
-#define RNP_LOG_KEY(msg, key)                                                          \
-    do {                                                                               \
-        if (!(key)) {                                                                  \
-            RNP_LOG(msg, "(null)");                                                    \
-            break;                                                                     \
-        }                                                                              \
-        char                keyid[PGP_KEY_ID_SIZE * 2 + 1] = {0};                      \
-        const pgp_key_id_t &id = key->keyid();                                         \
-        rnp_hex_encode(id.data(), id.size(), keyid, sizeof(keyid), RNP_HEX_LOWERCASE); \
-        RNP_LOG(msg, keyid);                                                           \
-    } while (0)
-
-#define RNP_LOG_KEY_PKT(msg, key)                                                     \
-    do {                                                                              \
-        pgp_key_id_t keyid = {};                                                      \
-        if (pgp_keyid(keyid, (key))) {                                                \
-            RNP_LOG(msg, "unknown");                                                  \
-            break;                                                                    \
-        };                                                                            \
-        char keyidhex[PGP_KEY_ID_SIZE * 2 + 1] = {0};                                 \
-        rnp_hex_encode(                                                               \
-          keyid.data(), keyid.size(), keyidhex, sizeof(keyidhex), RNP_HEX_LOWERCASE); \
-        RNP_LOG(msg, keyidhex);                                                       \
-    } while (0)
 
 #define RNP_DLOG(...)                    \
     if (rnp_get_debug(__FILE__)) {       \
@@ -161,9 +120,6 @@ const char *pgp_str_from_map(int, pgp_map_t *);
 bool rnp_set_debug(const char *);
 bool rnp_get_debug(const char *);
 void rnp_clear_debug();
-
-/* environment variable name */
-static const char RNP_LOG_CONSOLE[] = "RNP_LOG_CONSOLE";
 
 /* Portable way to convert bits to bytes */
 

--- a/src/rnp/CMakeLists.txt
+++ b/src/rnp/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(rnp
   rnp.cpp
   fficli.cpp
   ../rnpkeys/tui.cpp
+  ../lib/logging.cpp
   rnpcfg.cpp
   $<TARGET_OBJECTS:rnp-common>
 )

--- a/src/rnpkeys/CMakeLists.txt
+++ b/src/rnpkeys/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(rnpkeys
   main.cpp
   ../rnp/rnpcfg.cpp
   ../rnp/fficli.cpp
+  ../lib/logging.cpp
   $<TARGET_OBJECTS:rnp-common>
 )
 


### PR DESCRIPTION
This PR is based on PR #1416 by @dkg and additionally extracts all logging code to the separate code (this would be needed in later PR, which gets rid of lib includes for `rnpcfg.cpp` and `tui.cpp`).

See this comment for more details: https://github.com/rnpgp/rnp/pull/1416#issue-572227080