### PR TITLE
Move secure memory handling to the crypto folder.

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -124,6 +124,7 @@ add_library(librnp-obj OBJECT
   crypto/sm2.cpp
   crypto/symmetric.cpp
   crypto/signatures.cpp
+  crypto/mem.cpp
   crypto.cpp
   fingerprint.cpp
   generate-key.cpp

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -29,6 +29,7 @@
 #include "ec.h"
 #include "types.h"
 #include "utils.h"
+#include "mem.h"
 
 /**
  * EC Curves definition used by implementation
@@ -242,7 +243,8 @@ x25519_generate(rng_t *rng, pgp_ec_key_t *key)
     botan_privkey_t pr_key = NULL;
     botan_pubkey_t  pu_key = NULL;
     rnp_result_t    ret = RNP_ERROR_KEY_GENERATION;
-    uint8_t         keyle[32] = {0};
+
+    rnp::secure_array<uint8_t, 32> keyle;
 
     if (botan_privkey_create(&pr_key, "Curve25519", "", rng_handle(rng))) {
         goto end;
@@ -253,7 +255,7 @@ x25519_generate(rng_t *rng, pgp_ec_key_t *key)
     }
 
     /* botan returns key in little-endian, while mpi is big-endian */
-    if (botan_privkey_x25519_get_privkey(pr_key, keyle)) {
+    if (botan_privkey_x25519_get_privkey(pr_key, keyle.data())) {
         goto end;
     }
     for (int i = 0; i < 32; i++) {
@@ -269,7 +271,6 @@ x25519_generate(rng_t *rng, pgp_ec_key_t *key)
 
     ret = RNP_SUCCESS;
 end:
-    pgp_forget(&keyle, sizeof(keyle));
     botan_privkey_destroy(pr_key);
     botan_pubkey_destroy(pu_key);
     return ret;

--- a/src/lib/crypto/mem.cpp
+++ b/src/lib/crypto/mem.cpp
@@ -1,0 +1,33 @@
+/*-
+ * Copyright (c) 2021 Ribose Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem.h"
+
+void
+secure_clear(void *vp, size_t size)
+{
+    botan_scrub_mem(vp, size);
+}

--- a/src/lib/crypto/mem.h
+++ b/src/lib/crypto/mem.h
@@ -1,0 +1,81 @@
+/*-
+ * Copyright (c) 2021 Ribose Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CRYPTO_MEM_H_
+#define CRYPTO_MEM_H_
+
+#include <array>
+#include <botan/secmem.h>
+#include <botan/ffi.h>
+
+namespace rnp {
+
+template <typename T> using secure_vector = Botan::secure_vector<T>;
+
+template <typename T, std::size_t N> struct secure_array {
+  private:
+    static_assert(std::is_integral<T>::value, "T must be integer type");
+    std::array<T, N> data_;
+
+  public:
+    secure_array() : data_({0})
+    {
+    }
+
+    T *
+    data()
+    {
+        return &data_[0];
+    }
+
+    std::size_t
+    size() const
+    {
+        return data_.size();
+    }
+
+    T
+    operator[](size_t idx) const
+    {
+        return data_[idx];
+    }
+
+    T &
+    operator[](size_t idx)
+    {
+        return data_[idx];
+    }
+
+    ~secure_array()
+    {
+        botan_scrub_mem(&data_[0], sizeof(data_));
+    }
+};
+} // namespace rnp
+
+void secure_clear(void *vp, size_t size);
+
+#endif // CRYPTO_MEM_H_

--- a/src/lib/crypto/mpi.cpp
+++ b/src/lib/crypto/mpi.cpp
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include "mpi.h"
 #include "hash.h"
+#include "mem.h"
 #include "utils.h"
 
 bignum_t *
@@ -174,6 +175,6 @@ mpi_hash(const pgp_mpi_t *val, pgp_hash_t *hash)
 void
 mpi_forget(pgp_mpi_t *val)
 {
-    pgp_forget(val, sizeof(*val));
+    secure_clear(val, sizeof(*val));
     val->len = 0;
 }

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -29,6 +29,7 @@
 #include <json.h>
 #include "utils.h"
 #include <list>
+#include <crypto/mem.h>
 
 struct rnp_key_handle_st {
     rnp_ffi_t        ffi;
@@ -105,7 +106,7 @@ struct rnp_op_generate_st {
     pgp_key_t *gen_sec{};
     pgp_key_t *gen_pub{};
     /* password used to encrypt the key, if specified */
-    char *password{};
+    rnp::secure_vector<char> password;
     /* request password for key encryption via ffi's password provider */
     bool request_password{};
     /* we don't use top-level keygen action here for easier fields access */
@@ -113,8 +114,6 @@ struct rnp_op_generate_st {
     rnp_key_protection_params_t protection{};
     rnp_selfsig_cert_info_t     cert{};
     rnp_selfsig_binding_info_t  binding{};
-
-    ~rnp_op_generate_st();
 };
 
 struct rnp_op_sign_signature_st {

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -92,13 +92,6 @@ __RCSID("$NetBSD: misc.c,v 1.41 2012/03/05 02:20:18 christos Exp $");
 #define vsnprintf _vsnprintf
 #endif
 
-/* utility function to zero out memory */
-void
-pgp_forget(void *vp, size_t size)
-{
-    botan_scrub_mem(vp, size);
-}
-
 /**
  * Searches the given map for the given type.
  * Returns a human-readable descriptive string if found,

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -107,8 +107,6 @@ char *rnp_strlwr(char *s);
 
 bool hex2bin(const char *hex, size_t hexlen, uint8_t *bin, size_t len, size_t *out);
 
-void pgp_forget(void *, size_t);
-
 /* debugging helpers*/
 void hexdump(FILE *, const char *, const uint8_t *, size_t);
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -36,6 +36,7 @@
 #include "key_store_g10.h"
 
 #include "crypto/common.h"
+#include "crypto/mem.h"
 #include "pgp-key.h"
 
 #define G10_CBC_IV_SIZE 16
@@ -752,7 +753,7 @@ done:
     if (!ret) {
         destroy_s_exp(r_s_exp);
     }
-    pgp_forget(decrypted_data, decrypted_data_len);
+    secure_clear(decrypted_data, decrypted_data_len);
     free(decrypted_data);
     botan_cipher_destroy(decrypt);
     return ret;
@@ -1436,7 +1437,7 @@ write_protected_seckey(s_exp_t *s_exp, pgp_key_pkt_t *seckey, const char *passwo
     ret = true;
 
 done:
-    pgp_forget(derived_key, sizeof(derived_key));
+    secure_clear(derived_key, sizeof(derived_key));
     free(encrypted_data);
     destroy_s_exp(&raw_s_exp);
     dst_close(&raw, true);

--- a/src/librepgp/stream-ctx.cpp
+++ b/src/librepgp/stream-ctx.cpp
@@ -72,7 +72,7 @@ rnp_ctx_add_encryption_password(rnp_ctx_t &    ctx,
      * An alternative would be to keep a list of actual passwords and s2k params,
      * and save the key derivation for later.
      */
-    if (!pgp_s2k_derive_key(&info.s2k, password, info.key, sizeof(info.key))) {
+    if (!pgp_s2k_derive_key(&info.s2k, password, info.key.data(), info.key.size())) {
         return RNP_ERROR_GENERIC;
     }
     try {
@@ -82,9 +82,4 @@ rnp_ctx_add_encryption_password(rnp_ctx_t &    ctx,
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     return RNP_SUCCESS;
-}
-
-rnp_symmetric_pass_info_t::~rnp_symmetric_pass_info_t()
-{
-    pgp_forget(key, sizeof(key));
 }

--- a/src/librepgp/stream-ctx.h
+++ b/src/librepgp/stream-ctx.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <list>
 #include "pgp-key.h"
+#include "crypto/mem.h"
 
 typedef enum rnp_operation_t {
     RNP_OP_UNKNOWN = 0,
@@ -53,9 +54,8 @@ typedef struct rnp_signer_info_t {
 typedef struct rnp_symmetric_pass_info_t {
     pgp_s2k_t      s2k{};
     pgp_symm_alg_t s2k_cipher{};
-    uint8_t        key[PGP_MAX_KEY_SIZE]{};
 
-    ~rnp_symmetric_pass_info_t();
+    rnp::secure_array<uint8_t, PGP_MAX_KEY_SIZE> key;
 } rnp_symmetric_pass_info_t;
 
 /** rnp operation context : contains configuration data about the currently ongoing operation.

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -38,6 +38,7 @@
 #include <rnp/rnp_def.h>
 #include "types.h"
 #include "crypto.h"
+#include "crypto/mem.h"
 #include "stream-packet.h"
 #include "stream-key.h"
 #include <algorithm>
@@ -487,7 +488,7 @@ pgp_packet_body_t::pgp_packet_body_t(const uint8_t *data, size_t len)
 pgp_packet_body_t::~pgp_packet_body_t()
 {
     if (secure_) {
-        pgp_forget(data_.data(), data_.size());
+        secure_clear(data_.data(), data_.size());
     }
 }
 

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -149,7 +149,7 @@ typedef struct pgp_packet_body_t {
      *  @param hdr write packet's header or not
      **/
     void write(pgp_dest_t &dst, bool hdr = true) noexcept;
-    /** @brief mark contents as secure, so pgp_forget() must be called in the destructor */
+    /** @brief mark contents as secure, so secure_clear() must be called in the destructor */
     void mark_secure(bool secure = true) noexcept;
 } pgp_packet_body_t;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -71,6 +71,8 @@ else()
 endif()
 
 find_package(JSON-C 0.11 REQUIRED)
+# We do not link against Botan, but need headers.
+find_package(Botan2 2.14.0 REQUIRED)
 add_executable(rnp_tests
   ../rnp/rnpcfg.cpp
   ../rnp/fficli.cpp
@@ -160,6 +162,7 @@ target_include_directories(rnp_tests
   PRIVATE
     "${PROJECT_SOURCE_DIR}/src"
     "${PROJECT_SOURCE_DIR}/src/lib"
+    "${BOTAN2_INCLUDE_DIRS}"
 )
 target_link_libraries(rnp_tests
   PRIVATE


### PR DESCRIPTION
This PR adds secure_array type, which will be automatically cleared in the destructor, and replaces pgp_forget function with secure_clear. Also it moves all these functions to the crypto folder.