### PR TITLE
Update man pages and packaging/bugreport email for the version 15.0

### DIFF
--- a/cmake/info.cmake
+++ b/cmake/info.cmake
@@ -26,7 +26,7 @@
 set(PACKAGE_VENDOR "Ribose Inc.")
 set(PACKAGE_URL "https://github.com/rnpgp/rnp")
 
-set(PACKAGING_EMAIL "Ribose Inc. <packaging@ribose.com>")
+set(PACKAGING_EMAIL "Ribose Inc. <rnpgp@ribose.com>")
 set(BUGREPORT_EMAIL "${PACKAGING_EMAIL}")
 
 set(PACKAGE_DESCRIPTION [=[

--- a/src/lib/librnp.3.adoc
+++ b/src/lib/librnp.3.adoc
@@ -1,7 +1,7 @@
 = librnp(3)
 RNP
 :doctype: manpage
-:release-version: 0.14.0
+:release-version: 0.15.0
 :man manual: RNP Manual
 :man source: RNP {release-version}
 

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -1,7 +1,7 @@
 = rnp(1)
 RNP
 :doctype: manpage
-:release-version: 0.14.0
+:release-version: 0.15.0
 :man manual: RNP Manual
 :man source: RNP {release-version}
 

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -1,7 +1,7 @@
 = rnpkeys(1)
 RNP
 :doctype: manpage
-:release-version: 0.14.0
+:release-version: 0.15.0
 :man manual: RNP Manual
 :man source: RNP {release-version}
 


### PR DESCRIPTION
We forgot to update rnp version in man pages, as well as packaging email in v0.15.0 release.
This PR is aimed to fix it (and probably we should then cherry pick it to the release branch/re-push tag?).