### PR TITLE
Separate CRC24 from the hashes.

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -486,7 +486,6 @@ typedef enum : uint8_t {
 
     /* Private range */
     PGP_HASH_SM3 = 105,
-    PGP_HASH_CRC24 = 106
 } pgp_hash_alg_t;
 
 typedef enum pgp_key_store_format_t {

--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -94,7 +94,6 @@ static const struct hash_alg_map_t {
                     {PGP_HASH_SHA512, "SHA512", "SHA-512", 64},
                     {PGP_HASH_SHA224, "SHA224", "SHA-224", 28},
                     {PGP_HASH_SM3, "SM3", "SM3", 32},
-                    {PGP_HASH_CRC24, "CRC24", "CRC24", 3},
                     {PGP_HASH_SHA3_256, "SHA3-256", "SHA-3(256)", 32},
                     {PGP_HASH_SHA3_512, "SHA3-512", "SHA-3(512)", 64}};
 /**
@@ -146,18 +145,10 @@ pgp_str_to_hash_alg(const char *hash)
     return PGP_HASH_UNKNOWN;
 }
 
-/**
-\ingroup Core_Hashes
-\brief Setup hash for given hash algorithm
-\param hash Hash to set up
-\param alg Hash algorithm to use
-*/
-bool
-pgp_hash_create(pgp_hash_t *hash, pgp_hash_alg_t alg)
+static bool
+botan_hash_create(pgp_hash_t *hash, const char *hash_name)
 {
-    const char *hash_name = pgp_hash_name_botan(alg);
-
-    if (hash_name == NULL) {
+    if (!hash_name) {
         return false;
     }
 
@@ -178,8 +169,35 @@ pgp_hash_create(pgp_hash_t *hash, pgp_hash_alg_t alg)
         return false;
     }
 
-    hash->_alg = alg;
     hash->handle = hash_fn.release();
+    return true;
+}
+
+/**
+\ingroup Core_Hashes
+\brief Setup hash for given hash algorithm
+\param hash Hash to set up
+\param alg Hash algorithm to use
+*/
+bool
+pgp_hash_create(pgp_hash_t *hash, pgp_hash_alg_t alg)
+{
+    if (!botan_hash_create(hash, pgp_hash_name_botan(alg))) {
+        return false;
+    }
+
+    hash->_alg = alg;
+    return true;
+}
+
+bool
+pgp_hash_create_crc24(pgp_hash_t *hash)
+{
+    if (!botan_hash_create(hash, "CRC24")) {
+        return false;
+    }
+
+    hash->_alg = PGP_HASH_UNKNOWN;
     return true;
 }
 

--- a/src/lib/crypto/hash.h
+++ b/src/lib/crypto/hash.h
@@ -51,6 +51,7 @@ typedef struct pgp_hash_t {
 const char *pgp_hash_name_botan(const pgp_hash_alg_t alg);
 
 bool   pgp_hash_create(pgp_hash_t *hash, pgp_hash_alg_t alg);
+bool   pgp_hash_create_crc24(pgp_hash_t *hash);
 bool   pgp_hash_copy(pgp_hash_t *dst, const pgp_hash_t *src);
 int    pgp_hash_add(pgp_hash_t *hash, const void *buf, size_t len);
 size_t pgp_hash_finish(pgp_hash_t *hash, uint8_t *output);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -198,8 +198,7 @@ static const pgp_map_t hash_alg_map[] = {{PGP_HASH_MD5, RNP_ALGNAME_MD5},
                                          {PGP_HASH_SHA224, RNP_ALGNAME_SHA224},
                                          {PGP_HASH_SHA3_256, RNP_ALGNAME_SHA3_256},
                                          {PGP_HASH_SHA3_512, RNP_ALGNAME_SHA3_512},
-                                         {PGP_HASH_SM3, RNP_ALGNAME_SM3},
-                                         {PGP_HASH_CRC24, RNP_ALGNAME_CRC24}};
+                                         {PGP_HASH_SM3, RNP_ALGNAME_SM3}};
 
 static const pgp_map_t s2k_type_map[] = {
   {PGP_S2KS_SIMPLE, "Simple"},
@@ -973,7 +972,7 @@ try {
         *supported = str_to_pubkey_alg(name, &alg);
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_HASH_ALG)) {
         pgp_hash_alg_t alg = PGP_HASH_UNKNOWN;
-        *supported = str_to_hash_alg(name, &alg) && (alg != PGP_HASH_CRC24);
+        *supported = str_to_hash_alg(name, &alg);
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_COMP_ALG)) {
         pgp_compression_type_t alg = PGP_C_UNKNOWN;
         *supported = str_to_compression_alg(name, &alg);

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -714,7 +714,7 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc)
     param = (pgp_source_armored_param_t *) src->param;
     param->readsrc = readsrc;
 
-    if (!pgp_hash_create(&param->crc_ctx, PGP_HASH_CRC24)) {
+    if (!pgp_hash_create_crc24(&param->crc_ctx)) {
         RNP_LOG("Internal error");
         return RNP_ERROR_GENERIC;
     }
@@ -998,7 +998,7 @@ init_armored_dst(pgp_dest_t *dst, pgp_dest_t *writedst, pgp_armored_msg_t msgtyp
     dst->writeb = 0;
     dst->clen = 0;
 
-    if (!pgp_hash_create(&param->crc_ctx, PGP_HASH_CRC24)) {
+    if (!pgp_hash_create_crc24(&param->crc_ctx)) {
         RNP_LOG("Internal error");
         return RNP_ERROR_GENERIC;
     }


### PR DESCRIPTION
As it is used only for armoring/dearmoring.