### PR TITLE
Fix adding recipients. Fixes #1500.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2461,6 +2461,14 @@ RNP_API rnp_result_t rnp_op_encrypt_create(rnp_op_encrypt_t *op,
                                            rnp_input_t       input,
                                            rnp_output_t      output);
 
+/**
+ * @brief Add recipient's public key to encrypting context.
+ *
+ * @param op opaque encrypting context. Must be allocated and initialized.
+ * @param key public key, used for encryption. Key is not checked for
+ *        validity or expiration.
+ * @return RNP_SUCCESS if operation succeeds or error code otherwise.
+ */
 RNP_API rnp_result_t rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_handle_t key);
 
 /**

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2317,6 +2317,9 @@ try {
                                        get_key_prefer_public(handle),
                                        &handle->ffi->key_provider,
                                        PGP_KF_ENCRYPT);
+    if (!key) {
+        key = get_key_prefer_public(handle);
+    }
     op->rnpctx.recipients.push_back(key);
     return RNP_SUCCESS;
 }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -2287,6 +2287,7 @@ cli_rnp_encrypt_and_sign(const rnp_cfg &cfg,
     std::vector<rnp_key_handle_t> enckeys;
     std::vector<rnp_key_handle_t> signkeys;
     bool                          res = false;
+    rnp_result_t                  ret;
 
     rnp_op_encrypt_set_armor(op, cfg.get_bool(CFG_ARMOR));
 
@@ -2371,7 +2372,11 @@ cli_rnp_encrypt_and_sign(const rnp_cfg &cfg,
     }
 
     /* execute encrypt or encrypt-and-sign operation */
-    res = !rnp_op_encrypt_execute(op);
+    ret = rnp_op_encrypt_execute(op);
+    res = (ret == RNP_SUCCESS);
+    if (ret != RNP_SUCCESS) {
+        ERR_MSG("Operation failed: %s", rnp_result_to_string(ret));
+    }
 done:
     clear_key_handles(signkeys);
     clear_key_handles(enckeys);


### PR DESCRIPTION
`rnp_op_encrypt_add_recipient()` did not check return value from `find_suitable_key()` so in some cases NULL pointer could have been added to recipients lists, which caused failures on later stages.

Let's discuss if we need to print rejection reason for each key, primary and subkeys.