### PR TITLE
Workaround MSYS2 CI issue, failing to checkout googletest via CMake

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: windows-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 70
+    env:
+      GTEST_SOURCES: /home/runneradmin/googletest-download/googletest-src
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,6 +39,19 @@ jobs:
         run: |
           bash ci/install_noncacheable_dependencies.sh
           bash ci/install_cacheable_dependencies.sh
+      - name: download googletest
+        # This is workaround for the CMake or MSYS issue, failing to correctly checkout external project
+        #  Failed to get the hash for HEAD:  
+        #  fatal: ambiguous argument 'HEAD^commit': unknown revision or path not in the working tree.
+        shell: msys2 {0}
+        run: |
+          set -euxo pipefail
+          mkdir ${HOME}/googletest-download
+          pushd ${HOME}/googletest-download
+          git clone --no-checkout "https://github.com/google/googletest.git" "googletest-src"
+          cd googletest-src
+          git checkout c43f710 --
+          popd
       - name: tests
         shell: msys2 {0}
         run: bash ci/main.sh


### PR DESCRIPTION
Not sure whether this is correct solution, as we leave tests unbuildable on latest msys2/cmake combination without manual googletest sources download. However, this error seems to be on the CMake side and we'll just need to wait till they fix it.