### PR TITLE
Allow NULL as a hash argument in rnp_key_add_uid().

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1388,7 +1388,8 @@ RNP_API rnp_result_t rnp_key_get_curve(rnp_key_handle_t key, char **curve);
  *  @param key the key to add - must be a secret key
  *  @param uid the UID to add
  *  @param hash name of the hash function to use for the uid binding
- *         signature (eg "SHA256")
+ *         signature (eg "SHA256"). If NULL, default hash algorithm
+ *         will be used.
  *  @param expiration time when this user id expires
  *  @param key_flags usage flags, see section 5.2.3.21 of RFC 4880
  *         or just provide zero to indicate no special handling.

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -5568,8 +5568,12 @@ try {
     pgp_key_pkt_t *         seckey = NULL;
     pgp_key_pkt_t *         decrypted_seckey = NULL;
 
-    if (!handle || !uid || !hash) {
+    if (!handle || !uid) {
         return RNP_ERROR_NULL_POINTER;
+    }
+
+    if (!hash) {
+        hash = DEFAULT_HASH_ALG;
     }
 
     if (!str_to_hash_alg(hash, &hash_alg)) {


### PR DESCRIPTION
Default hash algorithm will be used in this case.
Closes #1530.