### PR TITLE
Respect timezone in key expiration time calculations, used in CLI.

### DIFF
--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -286,6 +286,7 @@ Set signature expiration time, counting from the creation time. +
 By default, signatures do not expire. +
 +
 A specific expiration time can be specified as:
+
 *** expiration date in the ISO 8601:2019 date format (_yyyy-mm-dd_); or
 *** hours/days/months/years since creation time with the syntax of _20h_/_30d_/_1m_/_1y_;
 *** number of seconds.

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -109,6 +109,17 @@ Additional options:
 *--numbits*:::
 Overrides the default RSA key size of *2048* bits.
 
+*--expiration* _TIME_:::
+Set key and subkey expiration time, counting from the creation time. +
++
+By default generated keys do not expire. +
++
+Expiration time can be specified as:
+
+* expiration date in the ISO 8601:2019 date format (_yyyy-mm-dd_); or
+* hours/days/months/years since creation time with the syntax of _20h_/_30d_/_1m_/_1y_;
+* number of seconds.
+
 *--expert*:::
 Select key algorithms interactively and override default settings.
 

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -680,10 +680,13 @@ TEST_F(rnp_tests, test_cli_rnpkeys_genkey)
         auto diff_to_y2k38 = y2k38time - basetime;
         expected_diff_beyond2038_absolute = diff_to_y2k38;
     } else {
-        struct tm tm2100 {
-            0
-        };
+        time_t    now = time(NULL);
+        struct tm tm2100 = *localtime(&now);
+        tm2100.tm_hour = 0;
+        tm2100.tm_min = 0;
+        tm2100.tm_sec = 0;
         tm2100.tm_mday = 1;
+        tm2100.tm_mon = 0;
         tm2100.tm_year = 200;
         expected_diff_beyond2038_absolute = mktime(&tm2100) - basetime;
     }

--- a/src/tests/utils-rnpcfg.cpp
+++ b/src/tests/utils-rnpcfg.cpp
@@ -111,3 +111,36 @@ TEST_F(rnp_tests, test_rnpcfg)
     /* unset value */
     cfg1.unset("key_int");
 }
+
+TEST_F(rnp_tests, test_rnpcfg_get_expiration)
+{
+    time_t     basetime = time(NULL);
+    time_t     rawtime = basetime + 604800;
+    struct tm *timeinfo = localtime(&rawtime);
+    // clear hours, minutes and seconds
+    timeinfo->tm_hour = 0;
+    timeinfo->tm_min = 0;
+    timeinfo->tm_sec = 0;
+    rawtime = mktime(timeinfo);
+    auto exp =
+      fmt("%d-%02d-%02d", timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday);
+    uint32_t raw_expiry = 0;
+    assert_int_equal(get_expiration(exp.c_str(), &raw_expiry), 0);
+    assert_int_equal(raw_expiry, rawtime - basetime);
+    assert_int_equal(get_expiration("2100-01-01", &raw_expiry), 0);
+    assert_int_equal(get_expiration("2024-02-29", &raw_expiry), 0);
+    /* date in a past */
+    assert_int_not_equal(get_expiration("2000-02-29", &raw_expiry), 0);
+    if ((sizeof(time_t) > 4)) {
+        /* date is correct, but overflows 32 bits */
+        assert_int_not_equal(get_expiration("2400-02-29", &raw_expiry), 0);
+    } else {
+        /* for 32-bit time_t we return INT32_MAX for all dates beyond the y2038 */
+        assert_int_equal(get_expiration("2400-02-29", &raw_expiry), 0);
+        assert_int_equal(raw_expiry, INT32_MAX - basetime);
+    }
+    assert_int_not_equal(get_expiration("2100-02-29", &raw_expiry), 0);
+    assert_int_not_equal(get_expiration("4294967296", &raw_expiry), 0);
+    assert_int_not_equal(get_expiration("2037-02-29", &raw_expiry), 0);
+    assert_int_not_equal(get_expiration("2037-13-01", &raw_expiry), 0);
+}


### PR DESCRIPTION
This PR fixes possible issues with key expiration calculations when timezone is different from UTC (and fixes some incorrect types usage as well).
I got those issues locally, and this was not covered by tests as it looks like all CI runners are in UTC.
Will file a separate issue to run some tests in non-UTC timezone.

P.S. Also it updates man page for rnpkeys, and fixes minor issue in rnp.1.adoc.