### PR TITLE
CLI: return non-zero exit code on unrecognized command line options.

### DIFF
--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -716,6 +716,10 @@ rnp_main(int argc, char **argv)
                 cfg.set_str(CFG_KEYFILE, optarg);
                 cfg.set_bool(CFG_KEYSTORE_DISABLED, true);
                 break;
+            case '?':
+                print_usage(usage);
+                ret = EXIT_FAILURE;
+                goto finish;
             default:
                 cmd = CMD_HELP;
                 break;

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -101,6 +101,10 @@ rnpkeys_main(int argc, char **argv)
                     goto end;
                 }
                 break;
+            case '?':
+                print_usage(usage);
+                ret = EXIT_FAILURE;
+                goto end;
             default:
                 cmd = CMD_HELP;
                 break;

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -426,7 +426,7 @@ rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f)
     case CMD_HELP:
     default:
         print_usage(usage);
-        return false;
+        return true;
     }
 }
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1993,6 +1993,20 @@ class Misc(unittest.TestCase):
         if ret != 2:
             raise_err("failed to run without HOME env variable")
 
+    def test_exit_codes(self):
+        ret, _, _ = run_proc(RNP, ['--homedir', RNPDIR, '--help'])
+        if ret != 0:
+            raise_err("invalid exit code of 'rnp --help'")
+        ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--help'])
+        if ret != 0:
+            raise_err("invalid exit code of 'rnpkeys --help'")
+        ret, _, _ = run_proc(RNP, ['--homedir', RNPDIR, '--unknown-option', '--help'])
+        if ret == 0:
+            raise_err("rnp should return non-zero exit code for unknown command line options")
+        ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--unknown-option', '--help'])
+        if ret == 0:
+            raise_err("rnpkeys should return non-zero exit code for unknown command line options")
+
 class Encryption(unittest.TestCase):
     '''
         Things to try later:


### PR DESCRIPTION
Fixes #1548 