### PR TITLE
Add input specifiers to read data from stdin or env variable.

### DIFF
--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -71,6 +71,21 @@ const std::string cli_rnp_pubpath(cli_rnp_t *rnp);
 const std::string cli_rnp_secpath(cli_rnp_t *rnp);
 const std::string cli_rnp_pubformat(cli_rnp_t *rnp);
 const std::string cli_rnp_secformat(cli_rnp_t *rnp);
+/**
+ * @brief Create input object from the specifier, which may represent:
+ *        - path
+ *        - stdin (if `-` or empty string is passed)
+ *        - environment variable contents, if path looks like `env:VARIABLE_NAME`
+ * @param rnp initialized CLI rnp object
+ * @param spec specifier
+ * @param is_path optional parameter. If specifier is path (not stdin, env variable), then true
+ *                will be stored here, false otherwise. May be NULL if this information is not
+ *                needed.
+ * @return rnp_input_t object or NULL if operation failed.
+ */
+rnp_input_t cli_rnp_input_from_specifier(cli_rnp_t &        rnp,
+                                         const std::string &spec,
+                                         bool *             is_path);
 
 bool cli_rnp_init(cli_rnp_t *, const rnp_cfg &);
 bool cli_rnp_baseinit(cli_rnp_t *);

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -27,6 +27,10 @@ please use _rnpkeys(1)_ for that purpose.
 
 By default, *rnp* will apply a _COMMAND_, additionally configured with _OPTIONS_,
 to all _INPUT_FILE_(s) or _stdin_ if no _INPUT_FILE_ is given.
+There are some special cases for _INPUT_FILE_ :
+
+* _-_ (dash) substitutes to _stdin_
+* env:VARIABLE_NAME substitutes to the contents of environment variable VARIABLE_NAME
 
 Depending on the input, output may be written:
 
@@ -353,6 +357,11 @@ so *any* of these may be used to decrypt the resulting file.
 
 Additionally, the message will be signed with key _0x44616E69656C2057_.
 
+=== EXAMPLE 5
+
+*printf* _"Message"_ | *rnp* *--keyfile* _env:PGP_ENCRYPTION_KEY_ *-e* *-* *--armor*
+
+Encrypt message, passed via stdin, using the key, stored in environment variable *PGP_ENCRYPTION_KEY*, add ascii armoring, and print result to the stdout.
 
 == BUGS
 

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -28,6 +28,10 @@ provides OpenPGP key management functionality, including:
 
 By default, *rnp* will apply a _COMMAND_, additionally configured with _OPTIONS_,
 to all _INPUT_FILE_(s) or _stdin_ if no _INPUT_FILE_ is given.
+There are some special cases for _INPUT_FILE_ :
+
+* _-_ (dash) substitutes to _stdin_
+* env:VARIABLE_NAME substitutes to the contents of environment variable VARIABLE_NAME
 
 Depending on the input, output may be written:
 

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -164,16 +164,10 @@ imported_key_changed(json_object *key)
 }
 
 static bool
-import_keys(cli_rnp_t *rnp, const char *file)
+import_keys(cli_rnp_t *rnp, rnp_input_t input, const std::string &inname)
 {
-    rnp_input_t input = NULL;
-    bool        res = false;
-    bool        updated = false;
-
-    if (rnp_input_from_path(&input, file)) {
-        ERR_MSG("failed to open file %s", file);
-        return false;
-    }
+    bool res = false;
+    bool updated = false;
 
     uint32_t flags =
       RNP_LOAD_SAVE_PUBLIC_KEYS | RNP_LOAD_SAVE_SECRET_KEYS | RNP_LOAD_SAVE_SINGLE;
@@ -192,7 +186,7 @@ import_keys(cli_rnp_t *rnp, const char *file)
             break;
         }
         if (ret) {
-            ERR_MSG("failed to import key(s), from file %s, stopping.", file);
+            ERR_MSG("failed to import key(s) from %s, stopping.", inname.c_str());
             break;
         }
 
@@ -238,21 +232,13 @@ import_keys(cli_rnp_t *rnp, const char *file)
             ERR_MSG("failed to save keyrings");
         }
     }
-    rnp_input_destroy(input);
     return res;
 }
 
 static bool
-import_sigs(cli_rnp_t *rnp, const char *file)
+import_sigs(cli_rnp_t *rnp, rnp_input_t input, const std::string &inname)
 {
-    rnp_input_t input = NULL;
-    bool        res = false;
-
-    if (rnp_input_from_path(&input, file)) {
-        ERR_MSG("Failed to open file %s", file);
-        return false;
-    }
-
+    bool         res = false;
     char *       results = NULL;
     json_object *jso = NULL;
     json_object *sigs = NULL;
@@ -261,7 +247,7 @@ import_sigs(cli_rnp_t *rnp, const char *file)
     int          old_sigs = 0;
 
     if (rnp_import_signatures(rnp->ffi, input, 0, &results)) {
-        ERR_MSG("Failed to import signatures from file %s", file);
+        ERR_MSG("Failed to import signatures from %s", inname.c_str());
         goto done;
     }
     // print information about imported signature(s)
@@ -306,40 +292,43 @@ import_sigs(cli_rnp_t *rnp, const char *file)
 done:
     json_object_put(jso);
     rnp_buffer_destroy(results);
-    rnp_input_destroy(input);
     return res;
 }
 
 static bool
-import(cli_rnp_t *rnp, const char *file, int cmd)
+import(cli_rnp_t *rnp, const std::string &spec, int cmd)
 {
-    if (!file) {
-        ERR_MSG("Import file isn't specified");
+    if (spec.empty()) {
+        ERR_MSG("Import path isn't specified");
         return false;
     }
-
-    if (cmd == CMD_IMPORT_KEYS) {
-        return import_keys(rnp, file);
-    }
-    if (cmd == CMD_IMPORT_SIGS) {
-        return import_sigs(rnp, file);
-    }
-
-    rnp_input_t input = NULL;
-    if (rnp_input_from_path(&input, file)) {
-        ERR_MSG("Failed to open file %s", file);
+    rnp_input_t input = cli_rnp_input_from_specifier(*rnp, spec, NULL);
+    if (!input) {
+        ERR_MSG("Failed to create input for %s", spec.c_str());
         return false;
     }
+    if (cmd == CMD_IMPORT) {
+        char *contents = NULL;
+        if (rnp_guess_contents(input, &contents)) {
+            ERR_MSG("Warning! Failed to guess content type to import. Assuming keys.");
+        }
+        cmd = (contents && !strcmp(contents, "signature")) ? CMD_IMPORT_SIGS : CMD_IMPORT_KEYS;
+        rnp_buffer_destroy(contents);
+    }
 
-    char *contents = NULL;
-    if (rnp_guess_contents(input, &contents)) {
-        ERR_MSG("Warning! Failed to guess content type to import. Assuming keys.");
+    bool res = false;
+    switch (cmd) {
+    case CMD_IMPORT_KEYS:
+        res = import_keys(rnp, input, spec);
+        break;
+    case CMD_IMPORT_SIGS:
+        res = import_sigs(rnp, input, spec);
+        break;
+    default:
+        ERR_MSG("Unexpected command: %d", cmd);
     }
     rnp_input_destroy(input);
-    bool signature = contents && !strcmp(contents, "signature");
-    rnp_buffer_destroy(contents);
-
-    return signature ? import_sigs(rnp, file) : import_keys(rnp, file);
+    return res;
 }
 
 void
@@ -385,7 +374,7 @@ rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f)
     case CMD_IMPORT:
     case CMD_IMPORT_KEYS:
     case CMD_IMPORT_SIGS:
-        return import(rnp, f, cmd);
+        return import(rnp, f ? f : "", cmd);
     case CMD_GENERATE_KEY: {
         if (!f) {
             size_t count = cli_rnp_cfg(*rnp).get_count(CFG_USERID);

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1452,7 +1452,7 @@ class Keystore(unittest.TestCase):
         # Check that keyring is empty
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
         if not re.match(r'Key\(s\) not found\.', out):
-            raise_err('Failed to remove public keys');
+            raise_err('Failed to remove public keys')
         # Import secret keyring
         ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import', data_path('keyrings/1/secring.gpg')])
         if ret != 0:
@@ -1464,7 +1464,7 @@ class Keystore(unittest.TestCase):
         # Check that keyring is empty
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
         if not re.match(r'Key\(s\) not found\.', out):
-            raise_err('Failed to remove secret keys');
+            raise_err('Failed to remove secret keys')
         # Import public keyring
         ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import', data_path('keyrings/1/pubring.gpg')])
         if ret != 0:
@@ -1477,7 +1477,7 @@ class Keystore(unittest.TestCase):
         # Check that subkeys are removed
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
         if (ret != 0) or not re.match(r'2 keys found', out) or re.search('326ef111425d14a5|54505a936a4a970e|8a05b89fad5aded1|1d7e8a5393c997a8|1ed63ee56fadc34d', out):
-            raise_err('Failed to remove subkeys');
+            raise_err('Failed to remove subkeys')
         # Remove remaining public keys
         ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--remove-key', '7bc6709b15c23a4a', '2fcadf05ffa501bb'])
         if (ret != 0):
@@ -1489,7 +1489,7 @@ class Keystore(unittest.TestCase):
         # Check that keyring is empty
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
         if not re.match(r'Key\(s\) not found\.', out):
-            raise_err('Failed to remove keys');
+            raise_err('Failed to remove keys')
         # Import public keyring
         ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import', data_path('keyrings/1/pubring.gpg')])
         if ret != 0:
@@ -1505,7 +1505,7 @@ class Keystore(unittest.TestCase):
         # Check that keyring is empty
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
         if not re.match(r'Key\(s\) not found\.', out):
-            raise_err('Failed to remove keys');
+            raise_err('Failed to remove keys')
 
 class Misc(unittest.TestCase):
 


### PR DESCRIPTION
This PR extends CLI with possibility to read data (key, signature, or any other sort of input) via the path specifiers: `-` for the stdin, `env:VAR_NAME` for env variable.

Fixes #1562 
Fixes #1561 