### PR TITLE
CLI: make password request more verbose.

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -324,14 +324,16 @@ stdin_getpass(const char *prompt, char *buffer, size_t size, cli_rnp_t *rnp)
     // doesn't hurt
     *buffer = '\0';
 
+    if (!rnp->cfg().get_bool(CFG_NOTTY)) {
 #ifndef _WIN32
-    in = fopen("/dev/tty", "w+ce");
+        in = fopen("/dev/tty", "w+ce");
 #endif
+        out = in;
+    }
+
     if (!in) {
         in = userio_in;
-        out = stderr;
-    } else {
-        out = in;
+        out = (rnp && rnp->userio_out) ? rnp->userio_out : stdout;
     }
 
     // TODO: Implement alternative for hiding password entry on Windows

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -48,12 +48,15 @@ class cli_rnp_t {
     bool    check_cv25519_bits(rnp_key_handle_t key, char *prot_password, bool &tweaked);
 
   public:
-    rnp_ffi_t ffi{};
-    FILE *    resfp{};      /* where to put result messages, defaults to stdout */
-    FILE *    passfp{};     /* file pointer for password input */
-    FILE *    userio_in{};  /* file pointer for user's inputs */
-    FILE *    userio_out{}; /* file pointer for user's outputs */
-    int       pswdtries{};  /* number of password tries, -1 for unlimited */
+    rnp_ffi_t   ffi{};
+    FILE *      resfp{};      /* where to put result messages, defaults to stdout */
+    FILE *      passfp{};     /* file pointer for password input */
+    FILE *      userio_in{};  /* file pointer for user's inputs */
+    FILE *      userio_out{}; /* file pointer for user's outputs */
+    int         pswdtries{};  /* number of password tries, -1 for unlimited */
+    bool        reuse_password_for_subkey{};
+    std::string reuse_primary_fprint;
+    char *      reused_password{};
 
     bool init(const rnp_cfg &cfg);
     void end();

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2917,6 +2917,20 @@ class Misc(unittest.TestCase):
         self.assertEqual(ret, 1)
         self.assertRegex(err, r'(?s)^.*wrong packet version.*Failed to parse PKESK, skipping.*wrong packet version.*Failed to parse SKESK, skipping.*failed to obtain decrypting key or password.*')
 
+    def test_interactive_password(self):
+        # Reuse password for subkey, say "yes"
+        stdinstr = 'password\npassword\ny\n'
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--notty', '--generate-key'], stdinstr)
+        self.assertEqual(ret, 0)
+        # Do not reuse same password for subkey, say "no"
+        stdinstr = 'password\npassword\nN\nsubkeypassword\nsubkeypassword\n'
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--notty', '--generate-key'], stdinstr)
+        self.assertEqual(ret, 0)
+        # Set empty password and reuse it
+        stdinstr = '\n\ny\ny\n'
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--notty', '--generate-key'], stdinstr)
+        self.assertEqual(ret, 0)
+
 class Encryption(unittest.TestCase):
     '''
         Things to try later:


### PR DESCRIPTION
addresses p. 1 of #1518 

example output
```
Generating a new key...
Enter password for key 0x2D601CFF57E3C017 to perform the following operation: protect.
Password: 
Repeat password for key 0x2D601CFF57E3C017: 
Enter password for key 0x48A431A8DC901889 to perform the following operation: protect.
Password: 
Repeat password for key 0x48A431A8DC901889: 

sec   2048/RSA (Encrypt or Sign) 2d601cff57e3c017 2021-08-08 [SC]
      2b3a807bda7c0ea3ff1d19642d601cff57e3c017
uid           RSA (Encrypt or Sign) 2048-bit key <user@localhost>
ssb   2048/RSA (Encrypt or Sign) 48a431a8dc901889 2021-08-08 [E]
      fe11e06b6b55312b154dff9a48a431a8dc901889
```