### PR TITLE
CI performance improvements

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -55,7 +55,7 @@ jobs:
           yum -y install git
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Add rnpuser
         run: |
           useradd rnpuser
@@ -108,7 +108,7 @@ jobs:
           yum -y install git
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Test
         run: |
           set -euxo pipefail

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -61,7 +61,7 @@ jobs:
           yum -y install git
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Add rnpuser
         run: |
           useradd rnpuser
@@ -114,7 +114,7 @@ jobs:
           yum -y install git
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Test
         run: |
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup environment
         run: |
           . ci/gha/setup-env.inc.sh

--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -36,43 +36,45 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
+# I386: actions/checkout@V2,  actions/cache@V2 actions/cache@V2 
+#       give error about OCI container [https://github.com/actions/checkout/issues/334]
+#                                      [https://github.com/actions/runner/issues/1011]
         env:
           - CPU: i386
             IMAGE: "i386/debian:9"
     env: ${{ matrix.env }}
     continue-on-error: false
     steps:
-      - name: Installing prerequisites
+      - name: Install prerequisites
         run: |
           apt update
           apt -y install git sudo
-      #- uses: actions/checkout@v2 # XXX: actions/checkout give error about OCI container
-      #   with:
-      #     fetch-depth: 0
+      
       - name: Check out repository
-        run: |
-          cd $GITHUB_WORKSPACE
-          git init
-          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
-          git fetch origin $GITHUB_SHA
-          git reset --hard FETCH_HEAD
-      - name: Setup environment
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup noncacheable dependencies
         run: |
           . ci/gha/setup-env.inc.sh
           ci/install_noncacheable_dependencies.sh
         shell: bash
-      # - name: Cache
-      #   id: cache
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.CACHE_DIR }}
-      #     key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.CPU }}-gpg-${{ matrix.env.IMAGE }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
-      - name: Build cache
+
+#      - name: Cache 
+#        id: cache
+#        uses: actions/cache@v2
+#        with:
+#          path: ${{github.workspace}}/${{ env.CACHE_DIR }}
+#          key: ${{runner.os}}-${{ matrix.env.CPU }}-${{ matrix.env.IMAGE }}-v1
+
+      - name: Setup cacheable dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           set -euxo pipefail
           ci/install_cacheable_dependencies.sh
         shell: bash
+
       - name: Add rnpuser
         # it's only needed for rnpkeys_generatekey_verifykeyHomeDirNoPermission test
         run: |
@@ -80,12 +82,14 @@ jobs:
            printf "\nrnpuser\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/rnpuser
            printf "\nrnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf
            echo "SUDO=sudo" >> $GITHUB_ENV
-      - name: Building and Testing
+
+      - name: Build and Test
         run: |
           set -x
           chown -R rnpuser:rnpuser $PWD
           exec su rnpuser -c ci/run.sh
         shell: bash
+
       - name: Package
         run: |
           set -x

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup environment
         run: |
           . ci/gha/setup-env.inc.sh

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup environment
         run: |
           . ci/gha/setup-env.inc.sh
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup environment
         run: |
           . ci/gha/setup-env.inc.sh
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup environment
         run: |
           . ci/gha/setup-env.inc.sh
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup environment
         run: |
           . ci/gha/setup-env.inc.sh
@@ -171,13 +171,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           path: rnp
       - name: Download latest version.cmake
         uses: actions/checkout@v2
         with:
           repository: rnpgp/cmake-versioning
-          fetch-depth: 0
+          fetch-depth: 1
           path: cmake-versioning
       - name: Compare
         run: |

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           set -eux
-          vcpkg install --debug --triplet ${{ matrix.triplet }} $(cat vcpkg.txt)
+          vcpkg install --triplet ${{ matrix.triplet }} $(cat vcpkg.txt)
       - name: Configure
         env:
           VCPKG_DIR: '${{ matrix.vcpkg_dir }}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: msys2/setup-msys2@v2
         with:
           path-type: inherit

--- a/ci/lib/cacheable_install_functions.inc.sh
+++ b/ci/lib/cacheable_install_functions.inc.sh
@@ -80,7 +80,7 @@ install_jsonc() {
     autoreconf -ivf
     local cpuparam=()
     [[ -z "$CPU" ]] || cpuparam=(--build="$CPU")
-    env CFLAGS="-fno-omit-frame-pointer -Wno-implicit-fallthrough -g" ./configure ${cpuparam+"${cpuparam[@]}"} --prefix="${JSONC_INSTALL}"
+    env CFLAGS="-fPIC -fno-omit-frame-pointer -Wno-implicit-fallthrough -g" ./configure ${cpuparam+"${cpuparam[@]}"} --prefix="${JSONC_INSTALL}"
     ${MAKE} -j"${MAKE_PARALLEL}" install
     popd
   fi
@@ -149,8 +149,8 @@ _install_gpg() {
 
   local common_args=(
       --force-autogen
-      --verbose
-      --trace
+#      --verbose		commnted out to speed up recurring CI builds
+#      --trace                  uncomment if you are debugging CI
       --build-dir "${gpg_build}"
       --configure-opts "${configure_opts[*]}"
   )

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -16,10 +16,10 @@ prepare_build_prerequisites() {
   CMAKE=cmake
 
   case "${OS}-${CPU}" in
-    linux-i386)
-      build_and_install_python
-      ;;
-    linux-*)
+#    linux-i386)                                       #  For i386/Debian (the only 32 bit run) python3 is already installed by  
+#      build_and_install_python                        #  linux_install @ install_functions.inc.sh called from install_cacheable_dependencies.sh
+#      ;;                                              #  If there is a distribution that does not have python3 pre-apckeges (highly unlikely) 
+    linux-*)                                           #  it shall be implemented like ensure_cmake 
       PREFIX=/usr
       ensure_cmake
       ;;
@@ -78,7 +78,7 @@ main() {
   pushd "${LOCAL_BUILDS}/rnp-build"
 
   cmakeopts=(
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    -DCMAKE_BUILD_TYPE=Release   # RelWithDebInfo -- DebInfo commented out to speed up recurring CI runs. 
     -DBUILD_SHARED_LIBS=yes
     -DCMAKE_INSTALL_PREFIX="${RNP_INSTALL}"
     -DCMAKE_PREFIX_PATH="${BOTAN_INSTALL};${JSONC_INSTALL};${GPG_INSTALL}"
@@ -94,7 +94,7 @@ main() {
     cmakeopts+=(-G "MSYS Makefiles")
   fi
   build_rnp "${rnpsrc}"
-  make_install VERBOSE=1
+  make_install                  # VERBOSE=1 -- verbose flag commented out to speed up recurring CI runs. Uncomment if you are debugging CI
 
   prepare_tests
   build_tests


### PR DESCRIPTION
- Removed unnecessary python build for debian:9 job                                       [significant effect for debian9]
- Changed fetch depth from 0 (aka 'all') to 1                                                       [marginal effect for all jobs]
- Removed "debug", "trace", "verbose" for different commands and actions     [noticable effect for all affected jobs]
- Changed custom checkout to actions/checkout@v1 for debian:9 job             [marginal effect for  debian9]
- Added PIC ('position independed code') compilation flag                               

This PR shall bring total CI time down to something in between [1h 5m - 1h 10m]. Under "normal" load, of course.
#1571 