### PR TITLE
doc: Add link to rnpgp.org for hosted signing key

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,6 +38,8 @@ Upcoming supported platforms:
 
 == link:docs/c-usage.adoc[Using the RNP C API in your projects]
 
+== link:docs/signing-keys.adoc[PGP keys used for signing source code]
+
 == Versioning
 
 RNP follows the http://semver.org/[semantic versioning] syntax.

--- a/docs/signing-keys.adoc
+++ b/docs/signing-keys.adoc
@@ -1,0 +1,5 @@
+
+= PGP keys used for signing source code
+
+The current OpenPGP key used for signing source code for RNP is hosted at
+https://www.rnpgp.org/openpgp_keys/[rnpgp.org^].


### PR DESCRIPTION
Fixes #1586 