### PR TITLE
ci: Make Cirrus CI skip CI also when 'skip ci' occurs elsewhere in the body of the commit message [skip ci]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@ freebsd_instance:
 task:
   name: build
   only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'release/.*' || $CIRRUS_PR != ''
+  skip: "changesIncludeOnly('docs/*', '.github/*') || $CIRRUS_CHANGE_MESSAGE =~ '.*skip ci.*'"
   # increase timeout since we use a single task for building cache and testing
   timeout_in: 90m
   env:


### PR DESCRIPTION

The doc at https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution
says that it would skip CI if 'skip ci' is on the first line of the
commit message, but this behaviour would not match configs found in
GitHub workflows.  GitHub workflows would skip if 'skip ci' is found in any part of the commit message, not just the first line / last line / whatever.

This commit tries to match their behaviours.

It would also skip Cirrus CI if the only changes are in .github
workflows.