### PR TITLE
Make tests pass after 2024

### DIFF
--- a/src/tests/utils-rnpcfg.cpp
+++ b/src/tests/utils-rnpcfg.cpp
@@ -128,7 +128,7 @@ TEST_F(rnp_tests, test_rnpcfg_get_expiration)
     assert_int_equal(get_expiration(exp.c_str(), &raw_expiry), 0);
     assert_int_equal(raw_expiry, rawtime - basetime);
     assert_int_equal(get_expiration("2100-01-01", &raw_expiry), 0);
-    assert_int_equal(get_expiration("2024-02-29", &raw_expiry), 0);
+    assert_int_equal(get_expiration("2124-02-29", &raw_expiry), 0);
     /* date in a past */
     assert_int_not_equal(get_expiration("2000-02-29", &raw_expiry), 0);
     if ((sizeof(time_t) > 4)) {


### PR DESCRIPTION
Make tests pass after 2024

Tested on i586 and x86_64

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.
This showed up 1 failing test in our `rnp` package build.
See https://reproducible-builds.org/ for why this matters.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).