### PR TITLE
Allow empty keyrings for operations which do not require keys.

### DIFF
--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -39,6 +39,7 @@
 typedef struct cli_rnp_t {
   private:
     rnp_cfg cfg_{};
+    bool    load_keyring(bool secret);
 
   public:
     rnp_ffi_t ffi{};
@@ -50,6 +51,8 @@ typedef struct cli_rnp_t {
 
     bool init(const rnp_cfg &cfg);
     void end();
+
+    bool load_keyrings(bool loadsecret = false);
 
     const std::string &
     defkey()
@@ -125,7 +128,6 @@ rnp_input_t cli_rnp_input_from_specifier(cli_rnp_t &        rnp,
                                          const std::string &spec,
                                          bool *             is_path);
 
-bool cli_rnp_load_keyrings(cli_rnp_t *rnp, bool loadsecret);
 bool cli_rnp_save_keyrings(cli_rnp_t *rnp);
 void cli_rnp_print_key_info(
   FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -37,13 +37,57 @@
 #include "json.h"
 
 typedef struct cli_rnp_t {
+  private:
+    rnp_cfg cfg_{};
+
+  public:
     rnp_ffi_t ffi{};
-    rnp_cfg   cfg{};
     FILE *    resfp{};      /* where to put result messages, defaults to stdout */
     FILE *    passfp{};     /* file pointer for password input */
     FILE *    userio_in{};  /* file pointer for user's inputs */
     FILE *    userio_out{}; /* file pointer for user's outputs */
     int       pswdtries{};  /* number of password tries, -1 for unlimited */
+
+    bool init(const rnp_cfg &cfg);
+    void end();
+
+    const std::string &
+    defkey()
+    {
+        return cfg_.get_str(CFG_KR_DEF_KEY);
+    }
+
+    void set_defkey();
+
+    const std::string &
+    pubpath()
+    {
+        return cfg_.get_str(CFG_KR_PUB_PATH);
+    }
+
+    const std::string &
+    secpath()
+    {
+        return cfg_.get_str(CFG_KR_SEC_PATH);
+    }
+
+    const std::string &
+    pubformat()
+    {
+        return cfg_.get_str(CFG_KR_PUB_FORMAT);
+    }
+
+    const std::string &
+    secformat()
+    {
+        return cfg_.get_str(CFG_KR_SEC_FORMAT);
+    }
+
+    rnp_cfg &
+    cfg()
+    {
+        return cfg_;
+    }
 } cli_rnp_t;
 
 typedef enum cli_search_flags_t {
@@ -65,12 +109,6 @@ typedef enum cli_search_flags_t {
  */
 bool cli_cfg_set_keystore_info(rnp_cfg &cfg);
 
-rnp_cfg &         cli_rnp_cfg(cli_rnp_t &rnp);
-const std::string cli_rnp_defkey(cli_rnp_t *rnp);
-const std::string cli_rnp_pubpath(cli_rnp_t *rnp);
-const std::string cli_rnp_secpath(cli_rnp_t *rnp);
-const std::string cli_rnp_pubformat(cli_rnp_t *rnp);
-const std::string cli_rnp_secformat(cli_rnp_t *rnp);
 /**
  * @brief Create input object from the specifier, which may represent:
  *        - path
@@ -87,12 +125,8 @@ rnp_input_t cli_rnp_input_from_specifier(cli_rnp_t &        rnp,
                                          const std::string &spec,
                                          bool *             is_path);
 
-bool cli_rnp_init(cli_rnp_t *, const rnp_cfg &);
-bool cli_rnp_baseinit(cli_rnp_t *);
-void cli_rnp_end(cli_rnp_t *);
 bool cli_rnp_load_keyrings(cli_rnp_t *rnp, bool loadsecret);
 bool cli_rnp_save_keyrings(cli_rnp_t *rnp);
-void cli_rnp_set_default_key(cli_rnp_t *rnp);
 void cli_rnp_print_key_info(
   FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);
 bool cli_rnp_set_generate_params(rnp_cfg &cfg);

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -236,7 +236,7 @@ rnp_cmd(cli_rnp_t *rnp)
 {
     bool ret = false;
 
-    switch (cli_rnp_cfg(*rnp).get_int(CFG_COMMAND)) {
+    switch (rnp->cfg().get_int(CFG_COMMAND)) {
     case CMD_PROTECT:
         ret = cli_rnp_protect_file(rnp);
         break;
@@ -748,21 +748,19 @@ rnp_main(int argc, char **argv)
         goto finish;
     }
 
-    if (!cli_rnp_init(&rnp, cfg)) {
+    if (!rnp.init(cfg)) {
         ERR_MSG("fatal: cannot initialise");
         goto finish;
     }
 
-    disable_ks = cli_rnp_cfg(rnp).get_bool(CFG_KEYSTORE_DISABLED);
-    if (!disable_ks &&
-        !cli_rnp_load_keyrings(&rnp, cli_rnp_cfg(rnp).get_bool(CFG_NEEDSSECKEY))) {
+    disable_ks = rnp.cfg().get_bool(CFG_KEYSTORE_DISABLED);
+    if (!disable_ks && !cli_rnp_load_keyrings(&rnp, rnp.cfg().get_bool(CFG_NEEDSSECKEY))) {
         ERR_MSG("fatal: failed to load keys");
         goto finish;
     }
 
     /* load the keyfile if any */
-    if (disable_ks && !cli_rnp_cfg(rnp).get_str(CFG_KEYFILE).empty() &&
-        !cli_rnp_add_key(&rnp)) {
+    if (disable_ks && !rnp.cfg().get_str(CFG_KEYFILE).empty() && !cli_rnp_add_key(&rnp)) {
         ERR_MSG("fatal: failed to load key(s) from the file");
         goto finish;
     }
@@ -778,14 +776,14 @@ rnp_main(int argc, char **argv)
             ret = EXIT_FAILURE;
     } else {
         for (int i = optind; i < argc; i++) {
-            cli_rnp_cfg(rnp).set_str(CFG_INFILE, argv[i]);
+            rnp.cfg().set_str(CFG_INFILE, argv[i]);
             if (!rnp_cmd(&rnp)) {
                 ret = EXIT_FAILURE;
             }
         }
     }
 finish:
-    cli_rnp_end(&rnp);
+    rnp.end();
 #if !defined(RNP_RUN_TESTS) && defined(_WIN32)
     if (args_are_substituted) {
         rnp_win_clear_args(argc, argv);

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -754,7 +754,7 @@ rnp_main(int argc, char **argv)
     }
 
     disable_ks = rnp.cfg().get_bool(CFG_KEYSTORE_DISABLED);
-    if (!disable_ks && !cli_rnp_load_keyrings(&rnp, rnp.cfg().get_bool(CFG_NEEDSSECKEY))) {
+    if (!disable_ks && !rnp.load_keyrings(rnp.cfg().get_bool(CFG_NEEDSSECKEY))) {
         ERR_MSG("fatal: failed to load keys");
         goto finish;
     }

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -137,7 +137,7 @@ rnpkeys_main(int argc, char **argv)
     }
 
 end:
-    cli_rnp_end(&rnp);
+    rnp.end();
 #if !defined(RNP_RUN_TESTS) && defined(_WIN32)
     if (args_are_substituted) {
         rnp_win_clear_args(argc, argv);

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -698,7 +698,7 @@ rnpkeys_init(cli_rnp_t *rnp, const rnp_cfg &cfg)
         goto end;
     }
     /* TODO: at some point we should check for error here */
-    (void) cli_rnp_load_keyrings(rnp, true);
+    (void) rnp->load_keyrings(true);
     ret = true;
 end:
     if (!ret) {

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -132,8 +132,8 @@ struct option options[] = {
 static bool
 print_keys_info(cli_rnp_t *rnp, FILE *fp, const char *filter)
 {
-    bool psecret = cli_rnp_cfg(*rnp).get_bool(CFG_SECRET);
-    bool psigs = cli_rnp_cfg(*rnp).get_bool(CFG_WITH_SIGS);
+    bool psecret = rnp->cfg().get_bool(CFG_SECRET);
+    bool psigs = rnp->cfg().get_bool(CFG_WITH_SIGS);
     int  flags = CLI_SEARCH_SUBKEYS_AFTER | (psecret ? CLI_SEARCH_SECRET : 0);
     std::vector<rnp_key_handle_t> keys;
 
@@ -173,7 +173,7 @@ import_keys(cli_rnp_t *rnp, rnp_input_t input, const std::string &inname)
     uint32_t flags =
       RNP_LOAD_SAVE_PUBLIC_KEYS | RNP_LOAD_SAVE_SECRET_KEYS | RNP_LOAD_SAVE_SINGLE;
 
-    bool permissive = cli_rnp_cfg(*rnp).get_bool(CFG_PERMISSIVE);
+    bool permissive = rnp->cfg().get_bool(CFG_PERMISSIVE);
     if (permissive) {
         flags |= RNP_LOAD_SAVE_PERMISSIVE;
     }
@@ -224,8 +224,8 @@ import_keys(cli_rnp_t *rnp, rnp_input_t input, const std::string &inname)
 
     if (updated) {
         // set default key if we didn't have one
-        if (cli_rnp_defkey(rnp).empty()) {
-            cli_rnp_set_default_key(rnp);
+        if (rnp->defkey().empty()) {
+            rnp->set_defkey();
         }
 
         // save public and secret keyrings
@@ -356,14 +356,14 @@ rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f)
 
     switch (cmd) {
     case CMD_LIST_KEYS:
-        if (!f && cli_rnp_cfg(*rnp).get_count(CFG_USERID)) {
-            fs = cli_rnp_cfg(*rnp).get_str(CFG_USERID, 0);
+        if (!f && rnp->cfg().get_count(CFG_USERID)) {
+            fs = rnp->cfg().get_str(CFG_USERID, 0);
             f = fs.c_str();
         }
         return print_keys_info(rnp, stdout, f);
     case CMD_EXPORT_KEY: {
-        if (!f && cli_rnp_cfg(*rnp).get_count(CFG_USERID)) {
-            fs = cli_rnp_cfg(*rnp).get_str(CFG_USERID, 0);
+        if (!f && rnp->cfg().get_count(CFG_USERID)) {
+            fs = rnp->cfg().get_str(CFG_USERID, 0);
             f = fs.c_str();
         }
         if (!f) {
@@ -378,9 +378,9 @@ rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f)
         return import(rnp, f ? f : "", cmd);
     case CMD_GENERATE_KEY: {
         if (!f) {
-            size_t count = cli_rnp_cfg(*rnp).get_count(CFG_USERID);
+            size_t count = rnp->cfg().get_count(CFG_USERID);
             if (count == 1) {
-                fs = cli_rnp_cfg(*rnp).get_str(CFG_USERID, 0);
+                fs = rnp->cfg().get_str(CFG_USERID, 0);
                 f = fs.c_str();
             } else if (count > 1) {
                 ERR_MSG("Only single userid is supported for generated keys");
@@ -693,7 +693,7 @@ rnpkeys_init(cli_rnp_t *rnp, const rnp_cfg &cfg)
         ERR_MSG("fatal: cannot set keystore info");
         goto end;
     }
-    if (!cli_rnp_init(rnp, rnpcfg)) {
+    if (!rnp->init(rnpcfg)) {
         ERR_MSG("fatal: failed to initialize rnpkeys");
         goto end;
     }
@@ -702,7 +702,7 @@ rnpkeys_init(cli_rnp_t *rnp, const rnp_cfg &cfg)
     ret = true;
 end:
     if (!ret) {
-        cli_rnp_end(rnp);
+        rnp->end();
     }
     return ret;
 }

--- a/src/tests/exportkey.cpp
+++ b/src/tests/exportkey.cpp
@@ -39,7 +39,7 @@ TEST_F(rnp_tests, rnpkeys_exportkey_verifyUserId)
     /* Initialize the rnp structure. */
     assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
     /* Generate the key */
-    cli_set_default_rsa_key_desc(cli_rnp_cfg(rnp), "SHA256");
+    cli_set_default_rsa_key_desc(rnp.cfg(), "SHA256");
     assert_true(cli_rnp_generate_key(&rnp, NULL));
 
     /* Loading keyrings and checking whether they have correct key */
@@ -65,5 +65,5 @@ TEST_F(rnp_tests, rnpkeys_exportkey_verifyUserId)
     if (pipefd[0] != -1) {
         close(pipefd[0]);
     }
-    cli_rnp_end(&rnp); // Free memory and other allocated resources.
+    rnp.end(); // Free memory and other allocated resources.
 }

--- a/src/tests/exportkey.cpp
+++ b/src/tests/exportkey.cpp
@@ -43,7 +43,7 @@ TEST_F(rnp_tests, rnpkeys_exportkey_verifyUserId)
     assert_true(cli_rnp_generate_key(&rnp, NULL));
 
     /* Loading keyrings and checking whether they have correct key */
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
     size_t keycount = 0;
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -62,7 +62,7 @@ generate_test_key(const char *keystore, const char *userid, const char *hash, co
         goto done;
     }
 
-    if (!cli_rnp_load_keyrings(&rnp, true)) {
+    if (!rnp.load_keyrings(true)) {
         goto done;
     }
     if (rnp_get_public_key_count(rnp.ffi, &keycount) || (keycount != 2)) {
@@ -141,7 +141,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_testSignature)
                 /* Setup password input and rnp structure */
                 assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
                 /* Load keyring */
-                assert_true(cli_rnp_load_keyrings(&rnp, true));
+                assert_true(rnp.load_keyrings(true));
                 size_t seccount = 0;
                 assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &seccount));
                 assert_true(seccount > 0);
@@ -246,7 +246,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_testEncryption)
             /* Set up rnp and encrypt the dataa */
             assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, NULL));
             /* Load keyring */
-            assert_true(cli_rnp_load_keyrings(&rnp, false));
+            assert_true(rnp.load_keyrings(false));
             size_t seccount = 0;
             assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &seccount));
             assert_true(seccount == 0);
@@ -271,7 +271,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_testEncryption)
             /* Set up rnp again and decrypt the file */
             assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
             /* Load the keyrings */
-            assert_true(cli_rnp_load_keyrings(&rnp, true));
+            assert_true(rnp.load_keyrings(true));
             assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &seccount));
             assert_true(seccount > 0);
             /* Setup the decryption context and decrypt */
@@ -331,7 +331,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_verifySupportedHashAlg)
         /* Load and check key */
         assert_true(setup_cli_rnp_common(&rnp, keystore, NULL, NULL));
         /* Loading the keyrings */
-        assert_true(cli_rnp_load_keyrings(&rnp, true));
+        assert_true(rnp.load_keyrings(true));
         /* Some minor checks */
         size_t keycount = 0;
         assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
@@ -373,7 +373,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_verifyUserIdOption)
         /* Initialize the basic RNP structure. */
         assert_true(setup_cli_rnp_common(&rnp, keystore, NULL, NULL));
         /* Load the newly generated rnp key*/
-        assert_true(cli_rnp_load_keyrings(&rnp, true));
+        assert_true(rnp.load_keyrings(true));
         size_t keycount = 0;
         assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
         assert_true(keycount > 0);
@@ -410,7 +410,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_verifykeyHomeDirOption)
     assert_true(path_rnp_file_exists(".rnp/secring.gpg", NULL));
 
     /* Loading keyrings and checking whether they have correct key */
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
     size_t keycount = 0;
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
@@ -447,7 +447,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_verifykeyHomeDirOption)
     assert_true(path_rnp_file_exists(newhome.c_str(), "secring.gpg", NULL));
 
     /* Loading keyrings and checking whether they have correct key */
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
     keycount = 0;
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
@@ -486,7 +486,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_verifykeyKBXHomeDirOption)
     assert_false(path_rnp_file_exists(".rnp/secring.gpg", NULL));
 
     /* Loading keyrings and checking whether they have correct key */
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
     size_t keycount = 0;
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
@@ -519,7 +519,7 @@ TEST_F(rnp_tests, rnpkeys_generatekey_verifykeyKBXHomeDirOption)
     assert_false(path_rnp_file_exists(newhome, "pubring.gpg", NULL));
     assert_false(path_rnp_file_exists(newhome, "secring.gpg", NULL));
     /* Loading keyrings and checking whether they have correct key */
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
     keycount = 0;
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);

--- a/src/tests/issues/1030.cpp
+++ b/src/tests/issues/1030.cpp
@@ -40,7 +40,7 @@ test_issue_1030(const char *keystore)
     cli_set_default_rsa_key_desc(rnp.cfg(), "SHA256");
     assert_true(cli_rnp_generate_key(&rnp, userid));
 
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
     assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
     assert_int_equal(keycount, 2);
     assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));

--- a/src/tests/issues/1030.cpp
+++ b/src/tests/issues/1030.cpp
@@ -37,7 +37,7 @@ test_issue_1030(const char *keystore)
 
     char *home = make_temp_dir();
     assert_true(setup_cli_rnp_common(&rnp, keystore, home, pipefd));
-    cli_set_default_rsa_key_desc(cli_rnp_cfg(rnp), "SHA256");
+    cli_set_default_rsa_key_desc(rnp.cfg(), "SHA256");
     assert_true(cli_rnp_generate_key(&rnp, userid));
 
     assert_true(cli_rnp_load_keyrings(&rnp, true));
@@ -65,7 +65,7 @@ test_issue_1030(const char *keystore)
     if (pipefd[0] != -1) {
         close(pipefd[0]);
     }
-    cli_rnp_end(&rnp);
+    rnp.end();
     free(home);
 }
 

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -47,7 +47,7 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
                                    "326ef111425d14a5"};
 
     assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, "data/keyrings/1/", NULL));
-    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    assert_true(rnp.load_keyrings(true));
 
     for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
         rnp_key_handle_t handle = NULL;

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -67,7 +67,7 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     // try signing with a failing password provider (should fail)
     assert_rnp_success(
       rnp_ffi_set_pass_provider(rnp.ffi, ffi_failing_password_provider, NULL));
-    rnp_cfg &cfg = cli_rnp_cfg(rnp);
+    rnp_cfg &cfg = rnp.cfg();
     cfg.load_defaults();
     cfg.set_bool(CFG_SIGN_NEEDED, true);
     cfg.set_str(CFG_HASH, "SHA1");
@@ -217,6 +217,6 @@ TEST_F(rnp_tests, test_key_unlock_pgp)
     // cleanup
     assert_rnp_success(rnp_key_handle_destroy(key));
     assert_rnp_success(rnp_key_handle_destroy(subkey));
-    cli_rnp_end(&rnp);
+    rnp.end();
     assert_int_equal(rnp_unlink("dummyfile.dat"), 0);
 }

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -779,7 +779,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, ".rnp", NULL));
 
     /* import just the public key */
-    rnp_cfg &cfg = cli_rnp_cfg(rnp);
+    rnp_cfg &cfg = rnp.cfg();
     cfg.set_str(CFG_KEYFILE, MERGE_PATH "key-pub-just-key.pgp");
     assert_true(cli_rnp_add_key(&rnp));
     assert_true(cli_rnp_save_keyrings(&rnp));
@@ -944,7 +944,7 @@ TEST_F(rnp_tests, test_key_import)
     assert_int_equal(tskey->subkey.tag, PGP_PKT_SECRET_SUBKEY);
     assert_rnp_success(decrypt_secret_key(&tskey->subkey, "password"));
 
-    cli_rnp_end(&rnp);
+    rnp.end();
 }
 
 TEST_F(rnp_tests, test_load_subkey)

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1166,9 +1166,9 @@ TEST_F(rnp_tests, test_stream_verify_no_key)
     cfg.set_str(CFG_KR_SEC_PATH, "");
     cfg.set_str(CFG_KR_PUB_FORMAT, RNP_KEYSTORE_GPG);
     cfg.set_str(CFG_KR_SEC_FORMAT, RNP_KEYSTORE_GPG);
-    assert_true(cli_rnp_init(&rnp, cfg));
+    assert_true(rnp.init(cfg));
 
-    rnp_cfg &rnpcfg = cli_rnp_cfg(rnp);
+    rnp_cfg &rnpcfg = rnp.cfg();
     /* setup cfg for verification */
     rnpcfg.set_str(CFG_INFILE, "data/test_stream_verification/verify_encrypted_no_key.pgp");
     rnpcfg.set_str(CFG_OUTFILE, "output.dat");
@@ -1207,7 +1207,7 @@ TEST_F(rnp_tests, test_stream_verify_no_key)
     assert_int_equal(file_size("output.dat"), -1);
 
     /* cleanup */
-    cli_rnp_end(&rnp);
+    rnp.end();
 }
 
 static bool
@@ -1275,16 +1275,16 @@ TEST_F(rnp_tests, test_y2k38)
     cfg.set_str(CFG_KR_PUB_FORMAT, RNP_KEYSTORE_GPG);
     cfg.set_str(CFG_KR_SEC_FORMAT, RNP_KEYSTORE_GPG);
     cfg.set_str(CFG_IO_RESS, "stderr.dat");
-    assert_true(cli_rnp_init(&rnp, cfg));
+    assert_true(rnp.init(cfg));
 
-    rnp_cfg &rnpcfg = cli_rnp_cfg(rnp);
+    rnp_cfg &rnpcfg = rnp.cfg();
     /* verify */
     rnpcfg.set_str(CFG_INFILE, "data/test_messages/future.pgp");
     rnpcfg.set_bool(CFG_OVERWRITE, true);
     assert_true(cli_rnp_process_file(&rnp));
 
     /* clean up and flush the file */
-    cli_rnp_end(&rnp);
+    rnp.end();
 
     /* check the file for presense of correct dates */
     auto        output = file_to_str("stderr.dat");

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -605,7 +605,7 @@ setup_cli_rnp_common(cli_rnp_t *rnp, const char *ks_format, const char *homedir,
     }
 
     /*initialize the basic RNP structure. */
-    return cli_rnp_init(rnp, cfg);
+    return rnp->init(cfg);
 }
 
 void


### PR DESCRIPTION
Previous behaviour was to fail if keyrings are not found or they are empty.
This PR relaxes this approach by allowing absence of keys when ones are not required for the operation (say, symmetric decryption).
Fixes #974 