### PR TITLE
Fix cmake warning with sm2, fixes 7923ede

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -160,7 +160,7 @@ elseif(CRYPTO_BACKEND_BOTAN)
     crypto/cipher_botan.cpp
   )
   if(ENABLE_SM2)
-    list(APPEND CRYPTO_SOURCES crypto/sm2)
+    list(APPEND CRYPTO_SOURCES crypto/sm2.cpp)
   endif()
 else()
   message(FATAL_ERROR "Unknown crypto backend: ${CRYPTO_BACKEND}.")


### PR DESCRIPTION
Policy CMP0115 is not set: Source file extensions must be explicit.

@ni4 fixes #1550