### PR TITLE
Run less redundant cli_tests

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2373,17 +2373,16 @@ class Compression(unittest.TestCase):
         clear_workfiles()
 
     def test_rnp_compression(self):
-        levels = [None, 0, 2, 4, 6, 9]
-        algosrnp = [None, 'zip', 'zlib', 'bzip2']
-        sizes = [20, 1000, 5000, 20000, 150000, 1000000]
+        runs = 30
+        levels = list_upto([None, 0, 2, 4, 6, 9], runs)
+        algosrnp = list_upto([None, 'zip', 'zlib', 'bzip2'], runs)
+        sizes = list_upto([20, 1000, 5000, 15000, 250000], runs)
 
-        for size in sizes:
-            for algo in [0, 1, 2]:
-                for level in levels:
-                    z = [algosrnp[algo], level]
-                    gpg_to_rnp_encryption(size, None, z)
-                    file_encryption_rnp_to_gpg(size, z)
-                    rnp_signing_gpg_to_rnp(size, z)
+        for level, algo, size in zip(levels, algosrnp, sizes):
+            z = [algo, level]
+            gpg_to_rnp_encryption(size, None, z)
+            file_encryption_rnp_to_gpg(size, z)
+            rnp_signing_gpg_to_rnp(size, z)
 
 class SignDefault(unittest.TestCase):
     '''

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2115,11 +2115,11 @@ class Encryption(unittest.TestCase):
     # Ciphers list tro try during encryption. None will use default
     CIPHERS = [None, 'AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128', 'CAMELLIA192',
                'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
-    SIZES = [20, 40, 120, 600, 1000, 5000, 20000, 150000, 1000000]
+    SIZES = [20, 40, 120, 600, 1000, 5000, 20000, 250000]
     # Compression parameters to try during encryption(s)
     Z = [[None, 0], ['zip'], ['zlib'], ['bzip2'], [None, 1], [None, 9]]
     # Number of test runs - each run picks next encryption algo and size, wrapping on array
-    RUNS = 60
+    RUNS = 20
 
     @classmethod
     def setUpClass(cls):

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1570,7 +1570,7 @@ class Misc(unittest.TestCase):
 
     def test_encryption_s2k(self):
         src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
-        random_text(src, 64000)
+        random_text(src, 1000)
 
         ciphers = ['AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128', 'CAMELLIA192',
                    'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
@@ -1597,7 +1597,7 @@ class Misc(unittest.TestCase):
             compare_files(src, dec, 'rnp decrypted data differs')
             remove_files(dst, dec)
 
-        for i in range(0, 80):
+        for i in range(0, 20):
             rnp_encryption_s2k_gpg(ciphers[i % len(ciphers)], hashes[
                                 i % len(hashes)], s2kmodes[i % len(s2kmodes)])
 


### PR DESCRIPTION
Such massive test runs were needed initially to check random failures against GnuPG, now this is overkill.