### PR TITLE
Fix one implicit fallthrough warning, and consistent attribute.

### DIFF
--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -134,7 +134,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto,
             seckey->material.ec.curve = crypto->ecc.curve;
             break;
         }
-    /* FALLS THROUGH for non-x25519 curves */
+        [[fallthrough]];
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
         if (!curve_supported(crypto->ecc.curve)) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7508,7 +7508,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
             return RNP_ERROR_OUT_OF_MEMORY;
         }
         json_object_object_add(jso, "key wrap cipher", jsocipher);
-    } // fall through
+    }
+        [[fallthrough]];
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2: {

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1712,7 +1712,7 @@ pgp_signature_t::parse_material(pgp_signature_material_t &material) const
         if (version < PGP_V4) {
             RNP_LOG("Warning! v3 EdDSA signature.");
         }
-        /* FALLTHROUGH */
+        [[fallthrough]];
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
     case PGP_PKA_ECDH:

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -287,7 +287,7 @@ setcmd(rnp_cfg &cfg, int cmd, const char *arg)
         break;
     case CMD_CLEARSIGN:
         cfg.set_bool(CFG_CLEARTEXT, true);
-    /* FALLTHROUGH */
+        [[fallthrough]];
     case CMD_SIGN:
         cfg.set_bool(CFG_NEEDSSECKEY, true);
         cfg.set_bool(CFG_SIGN_NEEDED, true);
@@ -304,7 +304,7 @@ setcmd(rnp_cfg &cfg, int cmd, const char *arg)
     case CMD_VERIFY:
         /* single verify will discard output, decrypt will not */
         cfg.set_bool(CFG_NO_OUTPUT, true);
-    /* FALLTHROUGH */
+        [[fallthrough]];
     case CMD_VERIFY_CAT:
         newcmd = CMD_PROCESS;
         break;


### PR DESCRIPTION
Fix one implicit fallthrough warning, and consistent attribute. `[[fallthrough]]` is supported in clang, gcc since their C++11
implementations which we require. It is standard since C++17.

Fixes c177ea6c7568d5aa1a191cdee953b40b1d0178e5 from #1393