### PR TITLE
ci: Fix `is_version_at_least()` to compare patch number

### DIFF
--- a/ci/env-linux.inc.sh
+++ b/ci/env-linux.inc.sh
@@ -60,6 +60,9 @@ post_build_tool_install_set_env() {
 
       # use rh-ruby25 if installed
       if rpm --quiet -q rh-ruby25 && [[ "$PATH" != */opt/rh/rh-ruby25/root/usr/bin* ]]; then
+        # TODO: Modify rh-ruby25's enable script to be more lenient towards
+        # missing MANPATH.
+        export MANPATH="${MANPATH:-}"
         . /opt/rh/rh-ruby25/enable
         PATH=$HOME/bin:$PATH
         export PATH

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -674,21 +674,45 @@ is_version_at_least() {
     installed_version_major="${installed_version%%.*}"
     installed_version_minor="${installed_version#*.}"
     installed_version_minor="${installed_version_minor%%.*}"
+    installed_version_minor="${installed_version_minor:-0}"
+    installed_version_patch="${installed_version#${installed_version_major}.}"
+    installed_version_patch="${installed_version_patch#${installed_version_minor}}"
+    installed_version_patch="${installed_version_patch#.}"
+    installed_version_patch="${installed_version_patch%%.*}"
+    installed_version_patch="${installed_version_patch:-0}"
 
     local need_version_major
     need_version_major="${version_constraint%%.*}"
     need_version_minor="${version_constraint#*.}"
     need_version_minor="${need_version_minor%%.*}"
+    need_version_minor="${need_version_minor:-0}"
+    need_version_patch="${version_constraint##*.}"
+    need_version_patch="${version_constraint#${need_version_major}.}"
+    need_version_patch="${need_version_patch#${need_version_minor}}"
+    need_version_patch="${need_version_patch#.}"
+    need_version_patch="${need_version_patch%%.*}"
+    need_version_patch="${need_version_patch:-0}"
+
+    >&2 echo "
+    -> installed_version_major=${installed_version_major}
+    -> installed_version_minor=${installed_version_minor}
+    -> installed_version_patch=${installed_version_patch}
+    -> need_version_major=${need_version_major}
+    -> need_version_minor=${need_version_minor}
+    -> need_version_patch=${need_version_patch}"
 
     # Naive semver comparison
     if [[ "${installed_version_major}" -lt "${need_version_major}" ]] || \
-       [[ "${installed_version_major}" = "${need_version_major}" && "${installed_version_minor}" -lt "${need_version_minor}" ]]; then
+       [[ "${installed_version_major}" = "${need_version_major}" && "${installed_version_minor}" -lt "${need_version_minor}" ]] || \
+       [[ "${installed_version_major}.${installed_version_minor}" = "${need_version_major}.${need_version_minor}" && "${installed_version_patch}" -lt "${need_version_patch}" ]]; then
       need_to_build=1
     fi
   fi
 
   if [[ 1 = "${need_to_build}" ]]; then
     >&2 echo "Warning: Need to build ${bin_name} since version constraint ${version_constraint} not met."
+  else
+    >&2 echo "No need to build ${bin_name} since version constraint ${version_constraint} is met."
   fi
 
   return "${need_to_build}"

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -417,6 +417,22 @@ ensure_automake() {
 
   build_and_install_automake
 
+  # Disable automake116 from Ribose's repository as that may be too old.
+  case "${DIST}" in
+    centos)
+      if [[ -r /opt/ribose/ribose-automake116/disable ]]; then
+        >&2 echo "ribose-automake116 will be disabled."
+        . /opt/ribose/ribose-automake116/disable
+      fi
+
+      if rpm --quiet -q ribose-automake116; then
+        >&2 echo "ribose-automake116 is installed.  Removing."
+        # "${SUDO}" "${YUM}" remove -y ribose-automake116
+        "${SUDO}" rpm -e ribose-automake116
+      fi
+      ;;
+  esac
+
   command -v automake
 
   popd


### PR DESCRIPTION
Fixes #1613

Related to #1599 

[See here for test results](https://github.com/ribose-jeffreylau/rnp/runs/3398161264?check_suite_focus=true) (focusing on GnuPG 2.3.1 on CentOS 8) after rebasing on https://github.com/rnpgp/rnp/tree/ni4-1583-tests-support-gnupg-2.3 (https://github.com/rnpgp/rnp/commit/52cbb433e3a62908e627be283020b58694694d05).

