### PR TITLE
CLI: allow to use dash as stdout output specifier

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1821,19 +1821,12 @@ cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key)
         clear_key_handles(keys);
         return false;
     }
-    const std::string &file = rnp->cfg().get_str(CFG_OUTFILE);
-    rnp_result_t       ret = RNP_ERROR_GENERIC;
-    rnp_output_t       output = NULL;
-    rnp_output_t       armored = NULL;
-    bool               result = false;
+    rnp_output_t output = NULL;
+    rnp_output_t armored = NULL;
+    bool         result = false;
 
-    if (!file.empty()) {
-        uint32_t flags = rnp->cfg().get_bool(CFG_FORCE) ? RNP_OUTPUT_FILE_OVERWRITE : 0;
-        ret = rnp_output_to_file(&output, file.c_str(), flags);
-    } else {
-        ret = rnp_output_to_callback(&output, stdout_writer, NULL, NULL);
-    }
-    if (ret) {
+    output = cli_rnp_output_to_specifier(*rnp, rnp->cfg().get_str(CFG_OUTFILE));
+    if (!output) {
         goto done;
     }
 

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -455,19 +455,23 @@ ffi_pass_callback_string(rnp_ffi_t        ffi,
 bool
 cli_rnp_t::init(const rnp_cfg &cfg)
 {
-    bool coredumps = true;
+    cfg_.copy(cfg);
 
     /* Configure user's io streams. */
-    userio_in = (isatty(fileno(stdin)) ? stdin : fopen("/dev/tty", "r"));
-    userio_in = (userio_in ? userio_in : stdin);
-    userio_out = (isatty(fileno(stdout)) ? stdout : fopen("/dev/tty", "a+"));
-    userio_out = (userio_out ? userio_out : stdout);
-
-    cfg_.copy(cfg);
+    if (!cfg_.get_bool(CFG_NOTTY)) {
+        userio_in = (isatty(fileno(stdin)) ? stdin : fopen("/dev/tty", "r"));
+        userio_in = (userio_in ? userio_in : stdin);
+        userio_out = (isatty(fileno(stdout)) ? stdout : fopen("/dev/tty", "a+"));
+        userio_out = (userio_out ? userio_out : stdout);
+    } else {
+        userio_in = stdin;
+        userio_out = stdout;
+    }
 
     /* If system resource constraints are in effect then attempt to
      * disable core dumps.
      */
+    bool coredumps = true;
     if (!cfg_.get_bool(CFG_COREDUMPS)) {
 #ifdef HAVE_SYS_RESOURCE_H
         coredumps = !disable_core_dumps();

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -128,6 +128,20 @@ rnp_input_t cli_rnp_input_from_specifier(cli_rnp_t &        rnp,
                                          const std::string &spec,
                                          bool *             is_path);
 
+/**
+ * @brief Create output object from the specifier, which may represent:
+ *        - path
+ *        - stdout (if `-` or empty string is passed)
+ *
+ * @param rnp initialized CLI rnp object
+ * @param spec specifier
+ * @param discard just discard output
+ * @return rnp_output_t  or NULL if operation failed.
+ */
+rnp_output_t cli_rnp_output_to_specifier(cli_rnp_t &        rnp,
+                                         const std::string &spec,
+                                         bool               discard = false);
+
 bool cli_rnp_save_keyrings(cli_rnp_t *rnp);
 void cli_rnp_print_key_info(
   FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -303,6 +303,13 @@ RNP automatically detects the keystore format. +
 +
 This option allows the auto-detection behavior to be overridden.
 
+*--notty*::
+Disable use of tty. +
++
+By default RNP would detect whether TTY is attached and use it for user prompts. +
++
+This option overrides default behaviour so user input may be passed in batch mode.
+
 *--debug* _FILENAME.CPP_::
 Enable debug output for the source file specified. For development use only.
 

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -34,8 +34,9 @@ There are some special cases for _INPUT_FILE_ :
 
 Depending on the input, output may be written:
 
-* to the specified file with a removed or added file extension (_.pgp_, _.asc_, _.sig_); or
-* to _stdout_.
+* if *--output* option is given output is written to the path specified (or to the *stdout* if *-* is used)
+* to the _INPUT_FILE_ with a removed or added file extension (_.pgp_, _.asc_, _.sig_); or
+* to the _stdout_ if input was read from the _stdin_.
 
 Without the *--armor* option, output will be in binary.
 

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -83,6 +83,7 @@ static const char *usage = "-h, --help OR\n"
                            "\t[--aead[=EAX, OCB]] AND/OR\n"
                            "\t[--aead-chunk-bits=0..56] AND/OR\n"
                            "\t[--coredumps] AND/OR\n"
+                           "\t[--notty] AND/OR\n"
                            "\t[--homedir=<homedir>] AND/OR\n"
                            "\t[-f, --keyfile=<path to key] AND/OR\n"
                            "\t[--keyring=<keyring>] AND/OR\n"
@@ -142,6 +143,7 @@ enum optdefs {
     OPT_GRIPS,
     OPT_MPIS,
     OPT_RAW,
+    OPT_NOTTY,
 
     /* debug */
     OPT_DEBUG
@@ -210,6 +212,7 @@ static struct option options[] = {
   {"grips", no_argument, NULL, OPT_GRIPS},
   {"mpi", no_argument, NULL, OPT_MPIS},
   {"raw", no_argument, NULL, OPT_RAW},
+  {"notty", no_argument, NULL, OPT_NOTTY},
 
   {NULL, 0, NULL, 0},
 };
@@ -548,6 +551,9 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         return true;
     case OPT_RAW:
         cfg.set_bool(CFG_RAW, true);
+        return true;
+    case OPT_NOTTY:
+        cfg.set_bool(CFG_NOTTY, true);
         return true;
     case OPT_DEBUG:
         return rnp_enable_debug(arg);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -86,6 +86,7 @@
 #define CFG_REV_TYPE "rev-type"     /* revocation reason code */
 #define CFG_REV_REASON "rev-reason" /* revocation reason human-readable string */
 #define CFG_PERMISSIVE "permissive" /* ignore bad packets during key import */
+#define CFG_NOTTY "notty" /* disable tty usage and do input/output via stdin/stdout */
 
 /* rnp keyring setup variables */
 #define CFG_KR_PUB_FORMAT "kr-pub-format"

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -342,6 +342,12 @@ would take _NUMBER_ of milliseconds on the current system. +
 For example, setting it to _2000_ would mean that each secret key
 decryption operation would take around 2 seconds (on the current machine).
 
+*--notty*::
+Disable use of tty. +
++
+By default RNP would detect whether TTY is attached and use it for user prompts. +
++
+This option overrides default behaviour so user input may be passed in batch mode.
 
 == EXIT STATUS
 

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -239,7 +239,11 @@ The default homedir is _~/.rnp_ .
 *--output* _PATH_::
 Write data processing related output to the file specified. +
 +
-Combine it with *--force* to overwrite file if it already exists.
+Combine it with *--overwrite* to overwrite file if it already exists.
+
+*--overwrite*::
+Overwrite output file if it already exists. +
++
 
 *--userid* _USERID_::
 Use the specified _userid_ during key generation and in some
@@ -300,7 +304,7 @@ Print signature information when listing keys via the *-l* command.
 *--force*::
 Force actions to happen without prompting the user. +
 +
-This applies to cases such as output file overwrite, secret key removal, and revoking an already revoked key.
+This applies to cases such as secret key removal, revoking an already revoked key and so on.
 
 *--permissive*::
 Skip malformed or unknown keys/signatures during key import. +

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -70,6 +70,7 @@ const char *usage = "-h, --help OR\n"
                     "\t[--pass-fd=<fd>] OR\n"
                     "\t[--password=<password>] AND/OR\n"
                     "\t[--permissive] AND/OR\n"
+                    "\t[--notty] AND/OR\n"
                     "\t[--output=file] file OR\n"
                     "\t[--keystore-format=<format>] AND/OR\n"
                     "\t[--userid=<userid>] AND/OR\n"
@@ -125,6 +126,7 @@ struct option options[] = {
   {"rev-type", required_argument, NULL, OPT_REV_TYPE},
   {"rev-reason", required_argument, NULL, OPT_REV_REASON},
   {"permissive", no_argument, NULL, OPT_PERMISSIVE},
+  {"notty", no_argument, NULL, OPT_NOTTY},
   {NULL, 0, NULL, 0},
 };
 
@@ -610,6 +612,9 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     case OPT_PERMISSIVE:
         cfg.set_bool(CFG_PERMISSIVE, true);
+        return true;
+    case OPT_NOTTY:
+        cfg.set_bool(CFG_NOTTY, true);
         return true;
     default:
         *cmd = CMD_HELP;

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -63,6 +63,7 @@ const char *usage = "-h, --help OR\n"
                     "\t[--expert] AND/OR\n"
                     "\t[--with-sigs] AND/OR\n"
                     "\t[--force] AND/OR\n"
+                    "\t[--overwrite] AND/OR\n"
                     "\t[--secret] AND/OR\n"
                     "\t[--hash=<hash alg>] AND/OR\n"
                     "\t[--homedir=<homedir>] AND/OR\n"
@@ -121,6 +122,7 @@ struct option options[] = {
   {"cipher", required_argument, NULL, OPT_CIPHER},
   {"expert", no_argument, NULL, OPT_EXPERT},
   {"output", required_argument, NULL, OPT_OUTPUT},
+  {"overwrite", no_argument, NULL, OPT_OVERWRITE},
   {"force", no_argument, NULL, OPT_FORCE},
   {"secret", no_argument, NULL, OPT_SECRET},
   {"rev-type", required_argument, NULL, OPT_REV_TYPE},
@@ -575,6 +577,9 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
             return false;
         }
         cfg.set_str(CFG_OUTFILE, arg);
+        return true;
+    case OPT_OVERWRITE:
+        cfg.set_bool(CFG_OVERWRITE, true);
         return true;
     case OPT_FORCE:
         cfg.set_bool(CFG_FORCE, true);

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -50,6 +50,7 @@ typedef enum {
     OPT_REV_TYPE,
     OPT_REV_REASON,
     OPT_PERMISSIVE,
+    OPT_NOTTY,
 
     /* debug */
     OPT_DEBUG

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -41,6 +41,7 @@ typedef enum {
     OPT_FORMAT,
     OPT_EXPERT,
     OPT_OUTPUT,
+    OPT_OVERWRITE,
     OPT_FORCE,
     OPT_SECRET,
     OPT_S2K_ITER,

--- a/src/tests/gnupg.py
+++ b/src/tests/gnupg.py
@@ -51,6 +51,11 @@ class GnuPG(object):
         retcode, _, _ = run_proc(cmd, params, batch_input)
         return retcode == 0
 
+    def list_keys(self, secret = False):
+        params = ['--list-secret-keys'] if secret else ['--list-keys']
+        params = params + self.common_params
+        return self._run(self.__gpg, params)
+
     def generate_key_batch(self, batch_input):
         params = ['--gen-key', '--expert', '--batch',
                   '--pinentry-mode', 'loopback'] + self.common_params
@@ -86,6 +91,7 @@ class GnuPG(object):
         params += ['--passphrase', self.password]
         params += ['--batch']
         params += ['--pinentry-mode', 'loopback']
+        params += ['-u', self.userid]
         params += ['-o', out]
         params += ['--sign', input]
         if self.hash:

--- a/src/tests/rnp.py
+++ b/src/tests/rnp.py
@@ -76,7 +76,7 @@ class Rnp(object):
         params = self.common_params
         params += ["--output", output]
         params += ["--userid", self.userid]
-        params += ["--force"]
+        params += ["--overwrite"]
         params += ["--export-key"]
         if secure:
             params += ["--secret"]

--- a/src/tests/rnp.py
+++ b/src/tests/rnp.py
@@ -58,6 +58,11 @@ class Rnp(object):
         retcode, _, _ = run_proc(cmd, params, batch_input)
         return retcode == 0
 
+    def list_keys(self, secret = False):
+        params = ['--list-keys', '--secret'] if secret else ['--list-keys']
+        params = params + self.common_params
+        return self._run(self.key_mgm_bin, params)
+
     def generate_key_batch(self, batch_input):
         pipe = pswd_pipe(self.__password)
         params = self.common_params


### PR DESCRIPTION
This PR updates CLI with the following changes:
- allows to use `-` as stdout output marker
- adds `--notty` option to read/write data from stdin/stdout only (useful in batch processing and tests)
- adds option `--overwrite` and changes behaviour of key/revocation export to use it instead of `--force` in case file already exists.
- partially refactors cli_tests to use `self.assertEqual()` and so on.

Fixes #1314 