### PR TITLE
Workaround macOS CI issue related to homebrew and OpenSSL update.

### DIFF
--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -49,6 +49,8 @@ macos_install() {
   rm /usr/local/Cellar/openssl || true
   # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
   rm /usr/local/bin/2to3 || true
+  # homebrew fails to update openssl@1.1 1.1.1l to 1.1.1l_1 due to linking failure of nghttp2.h
+  brew unlink nghttp2 || true
   brew bundle
   ensure_automake
 }


### PR DESCRIPTION
Fixes the following error for macOS runner:
```
==> Upgrading curl
  7.79.1 -> 7.79.1_1 
==> Installing dependencies for curl: libnghttp2
==> Installing curl dependency: libnghttp2
==> Pouring libnghttp2--1.45.1.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink include/nghttp2/nghttp2.h
Target /usr/local/include/nghttp2/nghttp2.h
is a symlink belonging to nghttp2. You can unlink it:
  brew unlink nghttp2
To force the link and overwrite all conflicting files:
  brew link --overwrite libnghttp2
To list all files that would be deleted:
  brew link --overwrite --dry-run libnghttp2
```