### PR TITLE
#1654 replace '[ -v' with '[ -n'

### DIFF
--- a/ci/main.sh
+++ b/ci/main.sh
@@ -89,10 +89,10 @@ main() {
   [[ ${SKIP_TESTS} = 1 ]] && cmakeopts+=(-DBUILD_TESTING=OFF)
   [[ "${BUILD_MODE}" = "coverage" ]] && cmakeopts+=(-DENABLE_COVERAGE=yes)
   [[ "${BUILD_MODE}" = "sanitize" ]] && cmakeopts+=(-DENABLE_SANITIZERS=yes)
-  [ -v "GTEST_SOURCES" ] && cmakeopts+=(-DGTEST_SOURCES="${GTEST_SOURCES}")
-  [ -v "DOWNLOAD_GTEST" ] && cmakeopts+=(-DDOWNLOAD_GTEST="${DOWNLOAD_GTEST}")
-  [ -v "DOWNLOAD_RUBYRNP" ] && cmakeopts+=(-DDOWNLOAD_RUBYRNP="${DOWNLOAD_RUBYRNP}")
-  [ -v "CRYPTO_BACKEND" ] && cmakeopts+=(-DCRYPTO_BACKEND="${CRYPTO_BACKEND}")
+  [ -n "${GTEST_SOURCES:-}" ] && cmakeopts+=(-DGTEST_SOURCES="${GTEST_SOURCES}")
+  [ -n "${DOWNLOAD_GTEST:-}" ] && cmakeopts+=(-DDOWNLOAD_GTEST="${DOWNLOAD_GTEST}")
+  [ -n "${DOWNLOAD_RUBYRNP:-}" ] && cmakeopts+=(-DDOWNLOAD_RUBYRNP="${DOWNLOAD_RUBYRNP}")
+  [ -n "${CRYPTO_BACKEND:-}" ] && cmakeopts+=(-DCRYPTO_BACKEND="${CRYPTO_BACKEND}")
 
   if [[ "${OS}" = "msys" ]]; then
     cmakeopts+=(-G "MSYS Makefiles")


### PR DESCRIPTION
 - #1654

According to https://stackoverflow.com/a/39296723/902217 

> Note that the -v option was introduced in Bash 4.2

This may look minor but it's important for https://github.com/rnpgp/ruby-rnp to not repeat itself