### PR TITLE
CLI: remove support for unused command -o someoption=somevalue

### DIFF
--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -76,7 +76,7 @@ rnpkeys_main(int argc, char **argv)
     }
 #endif
 
-    while ((ch = getopt_long(argc, argv, "Vglo:", options, &optindex)) != -1) {
+    while ((ch = getopt_long(argc, argv, "Vgl", options, &optindex)) != -1) {
         if (ch >= CMD_LIST_KEYS) {
             /* getopt_long returns 0 for long options */
             if (!setoption(cfg, &cmd, options[optindex].val, optarg)) {
@@ -94,12 +94,6 @@ rnpkeys_main(int argc, char **argv)
                 break;
             case 'l':
                 cmd = CMD_LIST_KEYS;
-                break;
-            case 'o':
-                if (!parse_option(cfg, &cmd, optarg)) {
-                    ERR_MSG("Bad parse_option");
-                    goto end;
-                }
                 break;
             case '?':
                 print_usage(usage);

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -39,13 +39,6 @@
 #include <stdarg.h>
 #include "rnpkeys.h"
 
-// must be placed after include "utils.h"
-#ifndef RNP_USE_STD_REGEX
-#include <regex.h>
-#else
-#include <regex>
-#endif
-
 extern const char *rnp_keys_progname;
 
 const char *usage = "-h, --help OR\n"
@@ -652,67 +645,6 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         *cmd = CMD_HELP;
         return true;
     }
-}
-
-/* we have -o option=value -- parse, and process */
-bool
-parse_option(rnp_cfg &cfg, optdefs_t *cmd, const char *s)
-{
-#ifndef RNP_USE_STD_REGEX
-    static regex_t opt;
-    struct option *op;
-    static int     compiled;
-    regmatch_t     matches[10];
-    char           option[128];
-    char           value[128];
-
-    if (!compiled) {
-        compiled = 1;
-        if (regcomp(&opt, "([^=]{1,128})(=(.*))?", REG_EXTENDED) != 0) {
-            ERR_MSG("Can't compile regex");
-            return false;
-        }
-    }
-    if (regexec(&opt, s, 10, matches, 0) == 0) {
-        (void) snprintf(option,
-                        sizeof(option),
-                        "%.*s",
-                        (int) (matches[1].rm_eo - matches[1].rm_so),
-                        &s[matches[1].rm_so]);
-        if (matches[2].rm_so > 0) {
-            (void) snprintf(value,
-                            sizeof(value),
-                            "%.*s",
-                            (int) (matches[3].rm_eo - matches[3].rm_so),
-                            &s[matches[3].rm_so]);
-        } else {
-            value[0] = 0x0;
-        }
-        for (op = options; op->name; op++) {
-            if (strcmp(op->name, option) == 0) {
-                return setoption(cfg, cmd, op->val, value);
-            }
-        }
-    }
-#else
-    static std::regex re("([^=]{1,128})(=(.*))?", std::regex_constants::extended);
-    std::string       input = s;
-    std::smatch       result;
-
-    if (std::regex_match(input, result, re)) {
-        std::string option = result[1];
-        std::string value;
-        if (result.size() >= 4) {
-            value = result[3];
-        }
-        for (struct option *op = options; op->name; op++) {
-            if (strcmp(op->name, option.c_str()) == 0) {
-                return setoption(cfg, cmd, op->val, value.c_str());
-            }
-        }
-    }
-#endif
-    return false;
 }
 
 bool

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -64,7 +64,6 @@ bool rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f);
 bool setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg);
 void print_praise(void);
 void print_usage(const char *usagemsg);
-bool parse_option(rnp_cfg &cfg, optdefs_t *cmd, const char *s);
 
 /**
  * @brief Initializes rnpkeys. Function allocates memory dynamically for


### PR DESCRIPTION
This was used historically, but is not used in RNP CLI anymore, and doesn't make sense as we have `--option=value` syntax.