### PR TITLE
Refactor usage of <id, str> pairs.

### DIFF
--- a/src/lib/crypto/cipher_botan.cpp
+++ b/src/lib/crypto/cipher_botan.cpp
@@ -30,13 +30,17 @@
 #include "utils.h"
 #include "types.h"
 
-static const pgp_map_t cipher_mode_map[] = {{PGP_CIPHER_MODE_CBC, "CBC"},
-                                            {PGP_CIPHER_MODE_OCB, "OCB"}};
+static const id_str_pair cipher_mode_map[] = {
+  {PGP_CIPHER_MODE_CBC, "CBC"},
+  {PGP_CIPHER_MODE_OCB, "OCB"},
+  {0, NULL},
+};
 
-static const pgp_map_t cipher_map[] = {
+static const id_str_pair cipher_map[] = {
   {PGP_SA_AES_128, "AES-128"},
   {PGP_SA_AES_256, "AES-256"},
   {PGP_SA_IDEA, "IDEA"},
+  {0, NULL},
 };
 
 Cipher_Botan *
@@ -54,11 +58,8 @@ Cipher_Botan::create(pgp_symm_alg_t alg, const std::string &name, bool encrypt)
 static std::string
 make_name(pgp_symm_alg_t cipher, pgp_cipher_mode_t mode, size_t tag_size, bool disable_padding)
 {
-    const char *cipher_string = NULL;
-    ARRAY_LOOKUP_BY_ID(cipher_map, type, string, cipher, cipher_string);
-    const char *mode_string = NULL;
-    ARRAY_LOOKUP_BY_ID(cipher_mode_map, type, string, mode, mode_string);
-
+    const char *cipher_string = id_str_pair::lookup(cipher_map, cipher, NULL);
+    const char *mode_string = id_str_pair::lookup(cipher_mode_map, mode, NULL);
     if (!cipher_string || !mode_string) {
         return "";
     }

--- a/src/lib/crypto/cipher_ossl.cpp
+++ b/src/lib/crypto/cipher_ossl.cpp
@@ -29,13 +29,17 @@
 #include "types.h"
 #include <openssl/err.h>
 
-static const pgp_map_t cipher_mode_map[] = {{PGP_CIPHER_MODE_CBC, "CBC"},
-                                            {PGP_CIPHER_MODE_OCB, "OCB"}};
+static const id_str_pair cipher_mode_map[] = {
+  {PGP_CIPHER_MODE_CBC, "CBC"},
+  {PGP_CIPHER_MODE_OCB, "OCB"},
+  {0, NULL},
+};
 
-static const pgp_map_t cipher_map[] = {
+static const id_str_pair cipher_map[] = {
   {PGP_SA_AES_128, "AES-128"},
   {PGP_SA_AES_256, "AES-256"},
   {PGP_SA_IDEA, "IDEA"},
+  {0, NULL},
 };
 
 EVP_CIPHER_CTX *
@@ -76,11 +80,8 @@ Cipher_OpenSSL::create(const std::string &name,
 static std::string
 make_name(pgp_symm_alg_t cipher, pgp_cipher_mode_t mode)
 {
-    const char *cipher_string = NULL;
-    ARRAY_LOOKUP_BY_ID(cipher_map, type, string, cipher, cipher_string);
-    const char *mode_string = NULL;
-    ARRAY_LOOKUP_BY_ID(cipher_mode_map, type, string, mode, mode_string);
-
+    const char *cipher_string = id_str_pair::lookup(cipher_map, cipher, NULL);
+    const char *mode_string = id_str_pair::lookup(cipher_mode_map, mode, NULL);
     if (!cipher_string || !mode_string) {
         return "";
     }

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -43,7 +43,7 @@ static const uint8_t DEFAULT_HASH_ALGS[] = {
 static const uint8_t DEFAULT_COMPRESS_ALGS[] = {
   PGP_C_ZLIB, PGP_C_BZIP2, PGP_C_ZIP, PGP_C_NONE};
 
-static pgp_map_t pubkey_alg_map[] = {
+static const id_str_pair pubkey_alg_map[] = {
   {PGP_PKA_RSA, "RSA (Encrypt or Sign)"},
   {PGP_PKA_RSA_ENCRYPT_ONLY, "RSA Encrypt-Only"},
   {PGP_PKA_RSA_SIGN_ONLY, "RSA Sign-Only"},
@@ -66,8 +66,7 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_PRIVATE08, "Private/Experimental"},
   {PGP_PKA_PRIVATE09, "Private/Experimental"},
   {PGP_PKA_PRIVATE10, "Private/Experimental"},
-  {0x00, NULL}, /* this is the end-of-array marker */
-};
+  {0, NULL}};
 
 static bool
 load_generated_g10_key(pgp_key_t *    dst,
@@ -312,7 +311,7 @@ set_default_user_prefs(pgp_user_prefs_t &prefs)
 static const char *
 pgp_show_pka(pgp_pubkey_alg_t pka)
 {
-    return pgp_str_from_map(pka, pubkey_alg_map);
+    return id_str_pair::lookup(pubkey_alg_map, pka);
 }
 
 static void
@@ -329,7 +328,7 @@ keygen_primary_merge_defaults(rnp_keygen_primary_desc_t &desc)
         snprintf((char *) desc.cert.userid,
                  sizeof(desc.cert.userid),
                  "%s %d-bit key <%s@localhost>",
-                 pgp_show_pka(desc.crypto.key_alg),
+                 id_str_pair::lookup(pubkey_alg_map, desc.crypto.key_alg),
                  get_numbits(&desc.crypto),
                  getenv_logname());
     }

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -92,44 +92,6 @@ __RCSID("$NetBSD: misc.c,v 1.41 2012/03/05 02:20:18 christos Exp $");
 #define vsnprintf _vsnprintf
 #endif
 
-/**
- * Searches the given map for the given type.
- * Returns a human-readable descriptive string if found,
- * returns NULL if not found
- *
- * It is the responsibility of the calling function to handle the
- * error case sensibly (i.e. don't just print out the return string.
- *
- */
-static const char *
-str_from_map_or_null(int type, pgp_map_t *map)
-{
-    pgp_map_t *row;
-
-    for (row = map; row->string != NULL; row++) {
-        if (row->type == type) {
-            return row->string;
-        }
-    }
-    return NULL;
-}
-
-/**
- * \ingroup Core_Print
- *
- * Searches the given map for the given type.
- * Returns a readable string if found, "Unknown" if not.
- */
-
-const char *
-pgp_str_from_map(int type, pgp_map_t *map)
-{
-    const char *str;
-
-    str = str_from_map_or_null(type, map);
-    return (str) ? str : "Unknown";
-}
-
 #define LINELEN 16
 
 /* show hexadecimal/ascii dump */
@@ -310,4 +272,41 @@ array_add_element_json(json_object *obj, json_object *val)
         return false;
     }
     return true;
+}
+
+const char *
+id_str_pair::lookup(const id_str_pair pair[], int id, const char *notfound)
+{
+    while (pair && pair->str) {
+        if (pair->id == id) {
+            return pair->str;
+        }
+        pair++;
+    }
+    return notfound;
+}
+
+int
+id_str_pair::lookup(const id_str_pair pair[], const char *str, int notfound)
+{
+    while (pair && pair->str) {
+        if (!rnp_strcasecmp(str, pair->str)) {
+            return pair->id;
+        }
+        pair++;
+    }
+    return notfound;
+}
+
+int
+id_str_pair::lookup(const id_str_pair pair[], const std::vector<uint8_t> &bytes, int notfound)
+{
+    while (pair && pair->str) {
+        if ((strlen(pair->str) == bytes.size()) &&
+            !memcmp(pair->str, bytes.data(), bytes.size())) {
+            return pair->id;
+        }
+        pair++;
+    }
+    return notfound;
 }

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -177,13 +177,13 @@ pgp_sig_get_signer(const pgp_subsig_t &sig, rnp_key_store_t *keyring, pgp_key_pr
     return pgp_request_key(prov, &ctx);
 }
 
-static pgp_map_t ss_rr_code_map[] = {
+static const id_str_pair ss_rr_code_map[] = {
   {PGP_REVOCATION_NO_REASON, "No reason specified"},
   {PGP_REVOCATION_SUPERSEDED, "Key is superseded"},
   {PGP_REVOCATION_COMPROMISED, "Key material has been compromised"},
   {PGP_REVOCATION_RETIRED, "Key is retired and no longer used"},
   {PGP_REVOCATION_NO_LONGER_VALID, "User ID information is no longer valid"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
 pgp_key_t *
@@ -887,7 +887,7 @@ pgp_revoke_t::pgp_revoke_t(pgp_subsig_t &sig)
         reason = sig.sig.revocation_reason();
     }
     if (reason.empty()) {
-        reason = pgp_str_from_map(code, ss_rr_code_map);
+        reason = id_str_pair::lookup(ss_rr_code_map, code);
     }
 }
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -137,23 +137,24 @@ rnp_ctx_init_ffi(rnp_ctx_t &ctx, rnp_ffi_t ffi)
     ctx.ealg = DEFAULT_PGP_SYMM_ALG;
 }
 
-static const pgp_map_t sig_type_map[] = {{PGP_SIG_BINARY, "binary"},
-                                         {PGP_SIG_TEXT, "text"},
-                                         {PGP_SIG_STANDALONE, "standalone"},
-                                         {PGP_CERT_GENERIC, "certification (generic)"},
-                                         {PGP_CERT_PERSONA, "certification (persona)"},
-                                         {PGP_CERT_CASUAL, "certification (casual)"},
-                                         {PGP_CERT_POSITIVE, "certification (positive)"},
-                                         {PGP_SIG_SUBKEY, "subkey binding"},
-                                         {PGP_SIG_PRIMARY, "primary key binding"},
-                                         {PGP_SIG_DIRECT, "direct"},
-                                         {PGP_SIG_REV_KEY, "key revocation"},
-                                         {PGP_SIG_REV_SUBKEY, "subkey revocation"},
-                                         {PGP_SIG_REV_CERT, "certification revocation"},
-                                         {PGP_SIG_TIMESTAMP, "timestamp"},
-                                         {PGP_SIG_3RD_PARTY, "third-party"}};
+static const id_str_pair sig_type_map[] = {{PGP_SIG_BINARY, "binary"},
+                                           {PGP_SIG_TEXT, "text"},
+                                           {PGP_SIG_STANDALONE, "standalone"},
+                                           {PGP_CERT_GENERIC, "certification (generic)"},
+                                           {PGP_CERT_PERSONA, "certification (persona)"},
+                                           {PGP_CERT_CASUAL, "certification (casual)"},
+                                           {PGP_CERT_POSITIVE, "certification (positive)"},
+                                           {PGP_SIG_SUBKEY, "subkey binding"},
+                                           {PGP_SIG_PRIMARY, "primary key binding"},
+                                           {PGP_SIG_DIRECT, "direct"},
+                                           {PGP_SIG_REV_KEY, "key revocation"},
+                                           {PGP_SIG_REV_SUBKEY, "subkey revocation"},
+                                           {PGP_SIG_REV_CERT, "certification revocation"},
+                                           {PGP_SIG_TIMESTAMP, "timestamp"},
+                                           {PGP_SIG_3RD_PARTY, "third-party"},
+                                           {0, NULL}};
 
-static const pgp_map_t pubkey_alg_map[] = {
+static const id_str_pair pubkey_alg_map[] = {
   {PGP_PKA_RSA, RNP_ALGNAME_RSA},
   {PGP_PKA_RSA_ENCRYPT_ONLY, RNP_ALGNAME_RSA},
   {PGP_PKA_RSA_SIGN_ONLY, RNP_ALGNAME_RSA},
@@ -163,47 +164,54 @@ static const pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_ECDH, RNP_ALGNAME_ECDH},
   {PGP_PKA_ECDSA, RNP_ALGNAME_ECDSA},
   {PGP_PKA_EDDSA, RNP_ALGNAME_EDDSA},
-  {PGP_PKA_SM2, RNP_ALGNAME_SM2}};
+  {PGP_PKA_SM2, RNP_ALGNAME_SM2},
+  {0, NULL}};
 
-static const pgp_map_t symm_alg_map[] = {{PGP_SA_IDEA, RNP_ALGNAME_IDEA},
-                                         {PGP_SA_TRIPLEDES, RNP_ALGNAME_TRIPLEDES},
-                                         {PGP_SA_CAST5, RNP_ALGNAME_CAST5},
-                                         {PGP_SA_BLOWFISH, RNP_ALGNAME_BLOWFISH},
-                                         {PGP_SA_AES_128, RNP_ALGNAME_AES_128},
-                                         {PGP_SA_AES_192, RNP_ALGNAME_AES_192},
-                                         {PGP_SA_AES_256, RNP_ALGNAME_AES_256},
-                                         {PGP_SA_TWOFISH, RNP_ALGNAME_TWOFISH},
-                                         {PGP_SA_CAMELLIA_128, RNP_ALGNAME_CAMELLIA_128},
-                                         {PGP_SA_CAMELLIA_192, RNP_ALGNAME_CAMELLIA_192},
-                                         {PGP_SA_CAMELLIA_256, RNP_ALGNAME_CAMELLIA_256},
-                                         {PGP_SA_SM4, RNP_ALGNAME_SM4}};
+static const id_str_pair symm_alg_map[] = {{PGP_SA_IDEA, RNP_ALGNAME_IDEA},
+                                           {PGP_SA_TRIPLEDES, RNP_ALGNAME_TRIPLEDES},
+                                           {PGP_SA_CAST5, RNP_ALGNAME_CAST5},
+                                           {PGP_SA_BLOWFISH, RNP_ALGNAME_BLOWFISH},
+                                           {PGP_SA_AES_128, RNP_ALGNAME_AES_128},
+                                           {PGP_SA_AES_192, RNP_ALGNAME_AES_192},
+                                           {PGP_SA_AES_256, RNP_ALGNAME_AES_256},
+                                           {PGP_SA_TWOFISH, RNP_ALGNAME_TWOFISH},
+                                           {PGP_SA_CAMELLIA_128, RNP_ALGNAME_CAMELLIA_128},
+                                           {PGP_SA_CAMELLIA_192, RNP_ALGNAME_CAMELLIA_192},
+                                           {PGP_SA_CAMELLIA_256, RNP_ALGNAME_CAMELLIA_256},
+                                           {PGP_SA_SM4, RNP_ALGNAME_SM4},
+                                           {0, NULL}};
 
-static const pgp_map_t aead_alg_map[] = {
-  {PGP_AEAD_NONE, "None"}, {PGP_AEAD_EAX, "EAX"}, {PGP_AEAD_OCB, "OCB"}};
+static const id_str_pair aead_alg_map[] = {
+  {PGP_AEAD_NONE, "None"}, {PGP_AEAD_EAX, "EAX"}, {PGP_AEAD_OCB, "OCB"}, {0, NULL}};
 
-static const pgp_map_t cipher_mode_map[] = {
-  {PGP_CIPHER_MODE_CFB, "CFB"}, {PGP_CIPHER_MODE_CBC, "CBC"}, {PGP_CIPHER_MODE_OCB, "OCB"}};
+static const id_str_pair cipher_mode_map[] = {{PGP_CIPHER_MODE_CFB, "CFB"},
+                                              {PGP_CIPHER_MODE_CBC, "CBC"},
+                                              {PGP_CIPHER_MODE_OCB, "OCB"},
+                                              {0, NULL}};
 
-static const pgp_map_t compress_alg_map[] = {{PGP_C_NONE, "Uncompressed"},
-                                             {PGP_C_ZIP, "ZIP"},
-                                             {PGP_C_ZLIB, "ZLIB"},
-                                             {PGP_C_BZIP2, "BZip2"}};
+static const id_str_pair compress_alg_map[] = {{PGP_C_NONE, "Uncompressed"},
+                                               {PGP_C_ZIP, "ZIP"},
+                                               {PGP_C_ZLIB, "ZLIB"},
+                                               {PGP_C_BZIP2, "BZip2"},
+                                               {0, NULL}};
 
-static const pgp_map_t hash_alg_map[] = {{PGP_HASH_MD5, RNP_ALGNAME_MD5},
-                                         {PGP_HASH_SHA1, RNP_ALGNAME_SHA1},
-                                         {PGP_HASH_RIPEMD, RNP_ALGNAME_RIPEMD160},
-                                         {PGP_HASH_SHA256, RNP_ALGNAME_SHA256},
-                                         {PGP_HASH_SHA384, RNP_ALGNAME_SHA384},
-                                         {PGP_HASH_SHA512, RNP_ALGNAME_SHA512},
-                                         {PGP_HASH_SHA224, RNP_ALGNAME_SHA224},
-                                         {PGP_HASH_SHA3_256, RNP_ALGNAME_SHA3_256},
-                                         {PGP_HASH_SHA3_512, RNP_ALGNAME_SHA3_512},
-                                         {PGP_HASH_SM3, RNP_ALGNAME_SM3}};
+static const id_str_pair hash_alg_map[] = {{PGP_HASH_MD5, RNP_ALGNAME_MD5},
+                                           {PGP_HASH_SHA1, RNP_ALGNAME_SHA1},
+                                           {PGP_HASH_RIPEMD, RNP_ALGNAME_RIPEMD160},
+                                           {PGP_HASH_SHA256, RNP_ALGNAME_SHA256},
+                                           {PGP_HASH_SHA384, RNP_ALGNAME_SHA384},
+                                           {PGP_HASH_SHA512, RNP_ALGNAME_SHA512},
+                                           {PGP_HASH_SHA224, RNP_ALGNAME_SHA224},
+                                           {PGP_HASH_SHA3_256, RNP_ALGNAME_SHA3_256},
+                                           {PGP_HASH_SHA3_512, RNP_ALGNAME_SHA3_512},
+                                           {PGP_HASH_SM3, RNP_ALGNAME_SM3},
+                                           {0, NULL}};
 
-static const pgp_map_t s2k_type_map[] = {
+static const id_str_pair s2k_type_map[] = {
   {PGP_S2KS_SIMPLE, "Simple"},
   {PGP_S2KS_SALTED, "Salted"},
-  {PGP_S2KS_ITERATED_AND_SALTED, "Iterated and salted"}};
+  {PGP_S2KS_ITERATED_AND_SALTED, "Iterated and salted"},
+  {0, NULL}};
 
 static const pgp_bit_map_t key_usage_map[] = {{PGP_KF_SIGN, "sign"},
                                               {PGP_KF_CERTIFY, "certify"},
@@ -213,37 +221,43 @@ static const pgp_bit_map_t key_usage_map[] = {{PGP_KF_SIGN, "sign"},
 static const pgp_bit_map_t key_flags_map[] = {{PGP_KF_SPLIT, "split"},
                                               {PGP_KF_SHARED, "shared"}};
 
-static const pgp_map_t identifier_type_map[] = {{PGP_KEY_SEARCH_USERID, "userid"},
-                                                {PGP_KEY_SEARCH_KEYID, "keyid"},
-                                                {PGP_KEY_SEARCH_FINGERPRINT, "fingerprint"},
-                                                {PGP_KEY_SEARCH_GRIP, "grip"}};
+static const id_str_pair identifier_type_map[] = {{PGP_KEY_SEARCH_USERID, "userid"},
+                                                  {PGP_KEY_SEARCH_KEYID, "keyid"},
+                                                  {PGP_KEY_SEARCH_FINGERPRINT, "fingerprint"},
+                                                  {PGP_KEY_SEARCH_GRIP, "grip"},
+                                                  {0, NULL}};
 
-static const pgp_map_t key_server_prefs_map[] = {{PGP_KEY_SERVER_NO_MODIFY, "no-modify"}};
+static const id_str_pair key_server_prefs_map[] = {{PGP_KEY_SERVER_NO_MODIFY, "no-modify"},
+                                                   {0, NULL}};
 
-static const pgp_map_t armor_type_map[] = {{PGP_ARMORED_MESSAGE, "message"},
-                                           {PGP_ARMORED_PUBLIC_KEY, "public key"},
-                                           {PGP_ARMORED_SECRET_KEY, "secret key"},
-                                           {PGP_ARMORED_SIGNATURE, "signature"},
-                                           {PGP_ARMORED_CLEARTEXT, "cleartext"}};
+static const id_str_pair armor_type_map[] = {{PGP_ARMORED_MESSAGE, "message"},
+                                             {PGP_ARMORED_PUBLIC_KEY, "public key"},
+                                             {PGP_ARMORED_SECRET_KEY, "secret key"},
+                                             {PGP_ARMORED_SIGNATURE, "signature"},
+                                             {PGP_ARMORED_CLEARTEXT, "cleartext"},
+                                             {0, NULL}};
 
-static const pgp_map_t key_import_status_map[] = {
+static const id_str_pair key_import_status_map[] = {
   {PGP_KEY_IMPORT_STATUS_UNKNOWN, "unknown"},
   {PGP_KEY_IMPORT_STATUS_UNCHANGED, "unchanged"},
   {PGP_KEY_IMPORT_STATUS_UPDATED, "updated"},
-  {PGP_KEY_IMPORT_STATUS_NEW, "new"}};
+  {PGP_KEY_IMPORT_STATUS_NEW, "new"},
+  {0, NULL}};
 
-static const pgp_map_t sig_import_status_map[] = {
+static const id_str_pair sig_import_status_map[] = {
   {PGP_SIG_IMPORT_STATUS_UNKNOWN, "unknown"},
   {PGP_SIG_IMPORT_STATUS_UNKNOWN_KEY, "unknown key"},
   {PGP_SIG_IMPORT_STATUS_UNCHANGED, "unchanged"},
-  {PGP_SIG_IMPORT_STATUS_NEW, "new"}};
+  {PGP_SIG_IMPORT_STATUS_NEW, "new"},
+  {0, NULL}};
 
-static const pgp_map_t revocation_code_map[] = {
+static const id_str_pair revocation_code_map[] = {
   {PGP_REVOCATION_NO_REASON, "no"},
   {PGP_REVOCATION_SUPERSEDED, "superseded"},
   {PGP_REVOCATION_COMPROMISED, "compromised"},
   {PGP_REVOCATION_RETIRED, "retired"},
-  {PGP_REVOCATION_NO_LONGER_VALID, "no longer valid"}};
+  {PGP_REVOCATION_NO_LONGER_VALID, "no longer valid"},
+  {0, NULL}};
 
 static bool
 curve_str_to_type(const char *str, pgp_curve_t *value)
@@ -266,8 +280,8 @@ curve_type_to_str(pgp_curve_t type, const char **str)
 static bool
 str_to_cipher(const char *str, pgp_symm_alg_t *cipher)
 {
-    pgp_symm_alg_t alg = PGP_SA_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(symm_alg_map, string, type, str, alg);
+    auto alg =
+      static_cast<pgp_symm_alg_t>(id_str_pair::lookup(symm_alg_map, str, PGP_SA_UNKNOWN));
     if (alg == PGP_SA_UNKNOWN) {
         return false;
     }
@@ -288,8 +302,8 @@ str_to_cipher(const char *str, pgp_symm_alg_t *cipher)
 static bool
 str_to_hash_alg(const char *str, pgp_hash_alg_t *hash_alg)
 {
-    pgp_hash_alg_t alg = PGP_HASH_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(hash_alg_map, string, type, str, alg);
+    auto alg =
+      static_cast<pgp_hash_alg_t>(id_str_pair::lookup(hash_alg_map, str, PGP_HASH_UNKNOWN));
     if (alg == PGP_HASH_UNKNOWN) {
         return false;
     }
@@ -305,8 +319,8 @@ str_to_hash_alg(const char *str, pgp_hash_alg_t *hash_alg)
 static bool
 str_to_aead_alg(const char *str, pgp_aead_alg_t *aead_alg)
 {
-    pgp_aead_alg_t alg = PGP_AEAD_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(aead_alg_map, string, type, str, alg);
+    pgp_aead_alg_t alg =
+      static_cast<pgp_aead_alg_t>(id_str_pair::lookup(aead_alg_map, str, PGP_AEAD_UNKNOWN));
     if (alg == PGP_AEAD_UNKNOWN) {
         return false;
     }
@@ -322,8 +336,8 @@ str_to_aead_alg(const char *str, pgp_aead_alg_t *aead_alg)
 static bool
 str_to_compression_alg(const char *str, pgp_compression_type_t *zalg)
 {
-    pgp_compression_type_t alg = PGP_C_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(compress_alg_map, string, type, str, alg);
+    pgp_compression_type_t alg = static_cast<pgp_compression_type_t>(
+      id_str_pair::lookup(compress_alg_map, str, PGP_C_UNKNOWN));
     if (alg == PGP_C_UNKNOWN) {
         return false;
     }
@@ -334,8 +348,8 @@ str_to_compression_alg(const char *str, pgp_compression_type_t *zalg)
 static bool
 str_to_revocation_type(const char *str, pgp_revocation_type_t *code)
 {
-    pgp_revocation_type_t rev = PGP_REVOCATION_NO_REASON;
-    ARRAY_LOOKUP_BY_STRCASE(revocation_code_map, string, type, str, rev);
+    pgp_revocation_type_t rev = static_cast<pgp_revocation_type_t>(
+      id_str_pair::lookup(revocation_code_map, str, PGP_REVOCATION_NO_REASON));
     if ((rev == PGP_REVOCATION_NO_REASON) && rnp_strcasecmp(str, "no")) {
         return false;
     }
@@ -346,8 +360,8 @@ str_to_revocation_type(const char *str, pgp_revocation_type_t *code)
 static bool
 str_to_cipher_mode(const char *str, pgp_cipher_mode_t *mode)
 {
-    pgp_cipher_mode_t c_mode = PGP_CIPHER_MODE_NONE;
-    ARRAY_LOOKUP_BY_STRCASE(cipher_mode_map, string, type, str, c_mode);
+    pgp_cipher_mode_t c_mode = static_cast<pgp_cipher_mode_t>(
+      id_str_pair::lookup(cipher_mode_map, str, PGP_CIPHER_MODE_NONE));
     if (c_mode == PGP_CIPHER_MODE_NONE) {
         return false;
     }
@@ -359,8 +373,8 @@ str_to_cipher_mode(const char *str, pgp_cipher_mode_t *mode)
 static bool
 str_to_pubkey_alg(const char *str, pgp_pubkey_alg_t *pub_alg)
 {
-    pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
-    ARRAY_LOOKUP_BY_STRCASE(pubkey_alg_map, string, type, str, alg);
+    pgp_pubkey_alg_t alg =
+      static_cast<pgp_pubkey_alg_t>(id_str_pair::lookup(pubkey_alg_map, str, PGP_PKA_NOTHING));
     if (alg == PGP_PKA_NOTHING) {
         return false;
     }
@@ -420,15 +434,9 @@ hex_encode_value(const uint8_t *   value,
 }
 
 static rnp_result_t
-get_map_value(const pgp_map_t *map, size_t msize, int val, char **res)
+get_map_value(const id_str_pair *map, int val, char **res)
 {
-    const char *str = NULL;
-    for (size_t i = 0; i < msize; i++) {
-        if (map[i].type == val) {
-            str = map[i].string;
-            break;
-        }
-    }
+    const char *str = id_str_pair::lookup(map, val, NULL);
     if (!str) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -1008,18 +1016,14 @@ try {
 FFI_GUARD
 
 static rnp_result_t
-json_array_add_map_str(json_object *arr, const pgp_map_t *map, int from, int to)
+json_array_add_id_str(json_object *arr, const id_str_pair *map, int from, int to)
 {
-    while (map->string) {
-        if (map->type < from) {
-            map++;
-            continue;
-        }
-        if (!array_add_element_json(arr, json_object_new_string(map->string))) {
+    while (map->str && (map->id < from)) {
+        map++;
+    }
+    while (map->str && (map->id <= to)) {
+        if (!array_add_element_json(arr, json_object_new_string(map->str))) {
             return RNP_ERROR_OUT_OF_MEMORY;
-        }
-        if (map->type >= to) {
-            break;
         }
         map++;
     }
@@ -1041,38 +1045,38 @@ try {
     rnp_result_t ret = RNP_ERROR_BAD_PARAMETERS;
 
     if (!rnp_strcasecmp(type, RNP_FEATURE_SYMM_ALG)) {
-        ret = json_array_add_map_str(features, symm_alg_map, PGP_SA_IDEA, PGP_SA_AES_256);
+        ret = json_array_add_id_str(features, symm_alg_map, PGP_SA_IDEA, PGP_SA_AES_256);
 #if defined(ENABLE_TWOFISH)
-        ret = json_array_add_map_str(features, symm_alg_map, PGP_SA_TWOFISH, PGP_SA_TWOFISH);
+        ret = json_array_add_id_str(features, symm_alg_map, PGP_SA_TWOFISH, PGP_SA_TWOFISH);
 #endif
-        ret = json_array_add_map_str(
+        ret = json_array_add_id_str(
           features, symm_alg_map, PGP_SA_CAMELLIA_128, PGP_SA_CAMELLIA_256);
 #if defined(ENABLE_SM2)
-        ret = json_array_add_map_str(features, symm_alg_map, PGP_SA_SM4, PGP_SA_SM4);
+        ret = json_array_add_id_str(features, symm_alg_map, PGP_SA_SM4, PGP_SA_SM4);
 #endif
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_AEAD_ALG)) {
 #if defined(ENABLE_AEAD)
-        ret = json_array_add_map_str(features, aead_alg_map, PGP_AEAD_NONE, PGP_AEAD_OCB);
+        ret = json_array_add_id_str(features, aead_alg_map, PGP_AEAD_NONE, PGP_AEAD_OCB);
 #else
-        ret = json_array_add_map_str(features, aead_alg_map, PGP_AEAD_NONE, PGP_AEAD_NONE);
+        ret = json_array_add_id_str(features, aead_alg_map, PGP_AEAD_NONE, PGP_AEAD_NONE);
 #endif
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_PROT_MODE)) {
-        ret = json_array_add_map_str(
+        ret = json_array_add_id_str(
           features, cipher_mode_map, PGP_CIPHER_MODE_CFB, PGP_CIPHER_MODE_CFB);
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_PK_ALG)) {
         // workaround to avoid duplicates, maybe there is a better solution
-        (void) json_array_add_map_str(features, pubkey_alg_map, PGP_PKA_RSA, PGP_PKA_RSA);
-        ret = json_array_add_map_str(features, pubkey_alg_map, PGP_PKA_DSA, PGP_PKA_EDDSA);
+        (void) json_array_add_id_str(features, pubkey_alg_map, PGP_PKA_RSA, PGP_PKA_RSA);
+        ret = json_array_add_id_str(features, pubkey_alg_map, PGP_PKA_DSA, PGP_PKA_EDDSA);
 #if defined(ENABLE_SM2)
-        ret = json_array_add_map_str(features, pubkey_alg_map, PGP_PKA_SM2, PGP_PKA_SM2);
+        ret = json_array_add_id_str(features, pubkey_alg_map, PGP_PKA_SM2, PGP_PKA_SM2);
 #endif
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_HASH_ALG)) {
-        ret = json_array_add_map_str(features, hash_alg_map, PGP_HASH_MD5, PGP_HASH_SHA3_512);
+        ret = json_array_add_id_str(features, hash_alg_map, PGP_HASH_MD5, PGP_HASH_SHA3_512);
 #if defined(ENABLE_SM2)
-        ret = json_array_add_map_str(features, hash_alg_map, PGP_HASH_SM3, PGP_HASH_SM3);
+        ret = json_array_add_id_str(features, hash_alg_map, PGP_HASH_SM3, PGP_HASH_SM3);
 #endif
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_COMP_ALG)) {
-        ret = json_array_add_map_str(features, compress_alg_map, PGP_C_NONE, PGP_C_BZIP2);
+        ret = json_array_add_id_str(features, compress_alg_map, PGP_C_NONE, PGP_C_BZIP2);
     } else if (!rnp_strcasecmp(type, RNP_FEATURE_CURVE)) {
         for (pgp_curve_t curve = PGP_CURVE_NIST_P_256; curve < PGP_CURVE_MAX;
              curve = (pgp_curve_t)(curve + 1)) {
@@ -1403,9 +1407,7 @@ key_status_to_str(pgp_key_import_status_t status)
     if (status == PGP_KEY_IMPORT_STATUS_UNKNOWN) {
         return "none";
     }
-    const char *str = "none";
-    ARRAY_LOOKUP_BY_ID(key_import_status_map, type, string, status, str);
-    return str;
+    return id_str_pair::lookup(key_import_status_map, status, "none");
 }
 
 static rnp_result_t
@@ -1578,9 +1580,7 @@ sig_status_to_str(pgp_sig_import_status_t status)
     if (status == PGP_SIG_IMPORT_STATUS_UNKNOWN) {
         return "none";
     }
-    const char *str = "none";
-    ARRAY_LOOKUP_BY_ID(sig_import_status_map, type, string, status, str);
-    return str;
+    return id_str_pair::lookup(sig_import_status_map, status, "none");
 }
 
 static rnp_result_t
@@ -2052,9 +2052,9 @@ try {
     }
     pgp_armored_msg_t msgtype = PGP_ARMORED_MESSAGE;
     if (type) {
-        msgtype = PGP_ARMORED_UNKNOWN;
-        ARRAY_LOOKUP_BY_STRCASE(armor_type_map, string, type, type, msgtype);
-        if (!msgtype) {
+        msgtype = static_cast<pgp_armored_msg_t>(
+          id_str_pair::lookup(armor_type_map, type, PGP_ARMORED_UNKNOWN));
+        if (msgtype == PGP_ARMORED_UNKNOWN) {
             RNP_LOG("Unsupported armor type: %s", type);
             return RNP_ERROR_BAD_PARAMETERS;
         }
@@ -3152,9 +3152,7 @@ get_protection_cipher(rnp_op_verify_t op)
     if (!op->encrypted) {
         return "none";
     }
-    const char *str = "unknown";
-    ARRAY_LOOKUP_BY_ID(symm_alg_map, type, string, op->salg, str);
-    return str;
+    return id_str_pair::lookup(symm_alg_map, op->salg);
 }
 
 rnp_result_t
@@ -3239,7 +3237,7 @@ try {
     if (!recipient || !alg) {
         return RNP_ERROR_NULL_POINTER;
     }
-    return get_map_value(pubkey_alg_map, ARRAY_SIZE(pubkey_alg_map), recipient->palg, alg);
+    return get_map_value(pubkey_alg_map, recipient->palg, alg);
 }
 FFI_GUARD
 
@@ -3285,7 +3283,7 @@ try {
     if (!symenc || !cipher) {
         return RNP_ERROR_NULL_POINTER;
     }
-    return get_map_value(symm_alg_map, ARRAY_SIZE(symm_alg_map), symenc->alg, cipher);
+    return get_map_value(symm_alg_map, symenc->alg, cipher);
 }
 FFI_GUARD
 
@@ -3295,7 +3293,7 @@ try {
     if (!symenc || !alg) {
         return RNP_ERROR_NULL_POINTER;
     }
-    return get_map_value(aead_alg_map, ARRAY_SIZE(aead_alg_map), symenc->aalg, alg);
+    return get_map_value(aead_alg_map, symenc->aalg, alg);
 }
 FFI_GUARD
 
@@ -3305,7 +3303,7 @@ try {
     if (!symenc || !alg) {
         return RNP_ERROR_NULL_POINTER;
     }
-    return get_map_value(hash_alg_map, ARRAY_SIZE(hash_alg_map), symenc->halg, alg);
+    return get_map_value(hash_alg_map, symenc->halg, alg);
 }
 FFI_GUARD
 
@@ -3315,7 +3313,7 @@ try {
     if (!symenc || !type) {
         return RNP_ERROR_NULL_POINTER;
     }
-    return get_map_value(s2k_type_map, ARRAY_SIZE(s2k_type_map), symenc->s2k_type, type);
+    return get_map_value(s2k_type_map, symenc->s2k_type, type);
 }
 FFI_GUARD
 
@@ -3391,7 +3389,7 @@ try {
     if (!sig || !hash) {
         return RNP_ERROR_NULL_POINTER;
     }
-    return get_map_value(hash_alg_map, ARRAY_SIZE(hash_alg_map), sig->sig_pkt.halg, hash);
+    return get_map_value(hash_alg_map, sig->sig_pkt.halg, hash);
 }
 FFI_GUARD
 
@@ -3487,8 +3485,8 @@ str_to_locator(rnp_ffi_t         ffi,
                const char *      identifier)
 {
     // parse the identifier type
-    locator->type = PGP_KEY_SEARCH_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(identifier_type_map, string, type, identifier_type, locator->type);
+    locator->type = static_cast<pgp_key_search_type_t>(
+      id_str_pair::lookup(identifier_type_map, identifier_type, PGP_KEY_SEARCH_UNKNOWN));
     if (locator->type == PGP_KEY_SEARCH_UNKNOWN) {
         FFI_LOG(ffi, "Invalid identifier type: %s", identifier_type);
         return RNP_ERROR_BAD_PARAMETERS;
@@ -3545,8 +3543,7 @@ locator_to_str(const pgp_key_search_t *locator,
                size_t                  identifier_size)
 {
     // find the identifier type string with the map
-    *identifier_type = NULL;
-    ARRAY_LOOKUP_BY_ID(identifier_type_map, type, string, locator->type, *identifier_type);
+    *identifier_type = id_str_pair::lookup(identifier_type_map, locator->type, NULL);
     if (!*identifier_type) {
         return false;
     }
@@ -5971,8 +5968,7 @@ try {
     if (!handle->sig) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    const char *sigtype = "unknown";
-    ARRAY_LOOKUP_BY_ID(sig_type_map, type, string, handle->sig->sig.type(), sigtype);
+    auto sigtype = id_str_pair::lookup(sig_type_map, handle->sig->sig.type());
     return ret_str_value(sigtype, type);
 }
 FFI_GUARD
@@ -5986,8 +5982,7 @@ try {
     if (!handle->sig) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    return get_map_value(
-      pubkey_alg_map, ARRAY_SIZE(pubkey_alg_map), handle->sig->sig.palg, alg);
+    return get_map_value(pubkey_alg_map, handle->sig->sig.palg, alg);
 }
 FFI_GUARD
 
@@ -6000,7 +5995,7 @@ try {
     if (!handle->sig) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    return get_map_value(hash_alg_map, ARRAY_SIZE(hash_alg_map), handle->sig->sig.halg, alg);
+    return get_map_value(hash_alg_map, handle->sig->sig.halg, alg);
 }
 FFI_GUARD
 
@@ -6334,7 +6329,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     pgp_key_t *key = get_key_prefer_public(handle);
-    return get_map_value(pubkey_alg_map, ARRAY_SIZE(pubkey_alg_map), key->alg(), alg);
+    return get_map_value(pubkey_alg_map, key->alg(), alg);
 }
 FFI_GUARD
 
@@ -6795,10 +6790,7 @@ try {
         return ret_str_value("Unknown", mode);
     }
 
-    return get_map_value(cipher_mode_map,
-                         ARRAY_SIZE(cipher_mode_map),
-                         key->sec->pkt().sec_protection.cipher_mode,
-                         mode);
+    return get_map_value(cipher_mode_map, key->sec->pkt().sec_protection.cipher_mode, mode);
 }
 FFI_GUARD
 
@@ -6822,8 +6814,7 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    return get_map_value(
-      symm_alg_map, ARRAY_SIZE(symm_alg_map), key->sec->pkt().sec_protection.symm_alg, cipher);
+    return get_map_value(symm_alg_map, key->sec->pkt().sec_protection.symm_alg, cipher);
 }
 FFI_GUARD
 
@@ -6840,10 +6831,7 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    return get_map_value(hash_alg_map,
-                         ARRAY_SIZE(hash_alg_map),
-                         key->sec->pkt().sec_protection.s2k.hash_alg,
-                         hash);
+    return get_map_value(hash_alg_map, key->sec->pkt().sec_protection.s2k.hash_alg, hash);
 }
 FFI_GUARD
 
@@ -7331,8 +7319,7 @@ add_json_user_prefs(json_object *jso, const pgp_user_prefs_t &prefs)
         }
         json_object_object_add(jso, "ciphers", jsoarr);
         for (auto alg : prefs.symm_algs) {
-            const char *name = "Unknown";
-            ARRAY_LOOKUP_BY_ID(symm_alg_map, type, string, alg, name);
+            const char * name = id_str_pair::lookup(symm_alg_map, alg, "Unknown");
             json_object *jsoname = json_object_new_string(name);
             if (!jsoname || json_object_array_add(jsoarr, jsoname)) {
                 return false;
@@ -7346,8 +7333,7 @@ add_json_user_prefs(json_object *jso, const pgp_user_prefs_t &prefs)
         }
         json_object_object_add(jso, "hashes", jsoarr);
         for (auto alg : prefs.hash_algs) {
-            const char *name = "Unknown";
-            ARRAY_LOOKUP_BY_ID(hash_alg_map, type, string, alg, name);
+            const char * name = id_str_pair::lookup(hash_alg_map, alg, "Unknown");
             json_object *jsoname = json_object_new_string(name);
             if (!jsoname || json_object_array_add(jsoarr, jsoname)) {
                 return false;
@@ -7361,8 +7347,7 @@ add_json_user_prefs(json_object *jso, const pgp_user_prefs_t &prefs)
         }
         json_object_object_add(jso, "compression", jsoarr);
         for (auto alg : prefs.z_algs) {
-            const char *name = "Unknown";
-            ARRAY_LOOKUP_BY_ID(compress_alg_map, type, string, alg, name);
+            const char * name = id_str_pair::lookup(compress_alg_map, alg, "Unknown");
             json_object *jsoname = json_object_new_string(name);
             if (!jsoname || json_object_array_add(jsoarr, jsoname)) {
                 return false;
@@ -7376,8 +7361,7 @@ add_json_user_prefs(json_object *jso, const pgp_user_prefs_t &prefs)
         }
         json_object_object_add(jso, "key server preferences", jsoarr);
         for (auto flag : prefs.ks_prefs) {
-            const char *name = "Unknown";
-            ARRAY_LOOKUP_BY_ID(key_server_prefs_map, type, string, flag, name);
+            const char * name = id_str_pair::lookup(key_server_prefs_map, flag, "Unknown");
             json_object *jsoname = json_object_new_string(name);
             if (!jsoname || json_object_array_add(jsoarr, jsoname)) {
                 return false;
@@ -7450,20 +7434,17 @@ add_json_subsig(json_object *jso, bool is_sub, uint32_t flags, const pgp_subsig_
     }
     json_object_object_add(jso, "version", jsoversion);
     // signature type
-    const char *type = "unknown";
-    ARRAY_LOOKUP_BY_ID(sig_type_map, type, string, sig->type(), type);
+    auto type = id_str_pair::lookup(sig_type_map, sig->type());
     if (!add_json_string_field(jso, "type", type)) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // signer key type
-    const char *key_type = "unknown";
-    ARRAY_LOOKUP_BY_ID(pubkey_alg_map, type, string, sig->palg, key_type);
+    const char *key_type = id_str_pair::lookup(pubkey_alg_map, sig->palg);
     if (!add_json_string_field(jso, "key type", key_type)) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // hash
-    const char *hash = "unknown";
-    ARRAY_LOOKUP_BY_ID(hash_alg_map, type, string, sig->halg, hash);
+    const char *hash = id_str_pair::lookup(hash_alg_map, sig->halg);
     if (!add_json_string_field(jso, "hash", hash)) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
@@ -7518,14 +7499,10 @@ add_json_subsig(json_object *jso, bool is_sub, uint32_t flags, const pgp_subsig_
 static rnp_result_t
 key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
 {
-    bool                      have_sec = handle->sec != NULL;
-    bool                      have_pub = handle->pub != NULL;
-    pgp_key_t *               key = get_key_prefer_public(handle);
-    const char *              str = NULL;
-    const pgp_key_material_t &material = key->material();
+    pgp_key_t *key = get_key_prefer_public(handle);
 
     // type
-    ARRAY_LOOKUP_BY_ID(pubkey_alg_map, type, string, key->alg(), str);
+    const char *str = id_str_pair::lookup(pubkey_alg_map, key->alg(), NULL);
     if (!str) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -7539,13 +7516,13 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     // curve / alg-specific items
     switch (key->alg()) {
     case PGP_PKA_ECDH: {
-        const char *hash_name = NULL;
-        ARRAY_LOOKUP_BY_ID(hash_alg_map, type, string, material.ec.kdf_hash_alg, hash_name);
+        const char *hash_name =
+          id_str_pair::lookup(hash_alg_map, key->material().ec.kdf_hash_alg, NULL);
         if (!hash_name) {
             return RNP_ERROR_BAD_PARAMETERS;
         }
-        const char *cipher_name = NULL;
-        ARRAY_LOOKUP_BY_ID(symm_alg_map, type, string, material.ec.key_wrap_alg, cipher_name);
+        const char *cipher_name =
+          id_str_pair::lookup(symm_alg_map, key->material().ec.key_wrap_alg, NULL);
         if (!cipher_name) {
             return RNP_ERROR_BAD_PARAMETERS;
         }
@@ -7565,7 +7542,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2: {
         const char *curve_name = NULL;
-        if (!curve_type_to_str(material.ec.curve, &curve_name)) {
+        if (!curve_type_to_str(key->material().ec.curve, &curve_name)) {
             return RNP_ERROR_BAD_PARAMETERS;
         }
         json_object *jsocurve = json_object_new_string(curve_name);
@@ -7665,6 +7642,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     if (!jsopublic) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
+    bool have_sec = handle->sec != NULL;
+    bool have_pub = handle->pub != NULL;
     json_object_object_add(jso, "public key", jsopublic);
     json_object_object_add(
       jsopublic, "present", json_object_new_boolean(have_pub ? true : false));
@@ -8063,8 +8042,8 @@ try {
     obj->keyp = new std::list<pgp_key_t>::iterator();
     obj->uididx = 0;
     // parse identifier type
-    obj->type = PGP_KEY_SEARCH_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(identifier_type_map, string, type, identifier_type, obj->type);
+    obj->type = static_cast<pgp_key_search_type_t>(
+      id_str_pair::lookup(identifier_type_map, identifier_type, PGP_KEY_SEARCH_UNKNOWN));
     if (obj->type == PGP_KEY_SEARCH_UNKNOWN) {
         ret = RNP_ERROR_BAD_PARAMETERS;
         goto done;
@@ -8168,9 +8147,8 @@ try {
     } else {
         msgtype = rnp_armor_guess_type(&input->src);
     }
-    const char *msg = "unknown";
-    ARRAY_LOOKUP_BY_ID(armor_type_map, type, string, msgtype, msg);
-    size_t len = strlen(msg);
+    const char *msg = id_str_pair::lookup(armor_type_map, msgtype);
+    size_t      len = strlen(msg);
     *contents = (char *) calloc(1, len + 1);
     if (!*contents) {
         return RNP_ERROR_OUT_OF_MEMORY;
@@ -8188,8 +8166,9 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
     if (type) {
-        ARRAY_LOOKUP_BY_STRCASE(armor_type_map, string, type, type, msgtype);
-        if (!msgtype) {
+        msgtype = static_cast<pgp_armored_msg_t>(
+          id_str_pair::lookup(armor_type_map, type, PGP_ARMORED_UNKNOWN));
+        if (msgtype == PGP_ARMORED_UNKNOWN) {
             RNP_LOG("Unsupported armor type: %s", type);
             return RNP_ERROR_BAD_PARAMETERS;
         }

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -73,12 +73,28 @@
 /* Maximum supported password length */
 #define MAX_PASSWORD_LENGTH 256
 
-/** pgp_map_t
- */
-typedef struct {
-    int         type;
-    const char *string;
-} pgp_map_t;
+class id_str_pair {
+  public:
+    int         id;
+    const char *str;
+
+    /**
+     * @brief Lookup constant pair array for the specified id or string value.
+     *        Note: array must be finished with NULL string to stop the lookup.
+     *
+     * @param pair pointer to the const array with pairs.
+     * @param id identifier to search for
+     * @param notfound value to return if identifier is not found.
+     * @return string, representing the identifier.
+     */
+    static const char *lookup(const id_str_pair pair[],
+                              int               id,
+                              const char *      notfound = "unknown");
+    static int         lookup(const id_str_pair pair[], const char *str, int notfound = 0);
+    static int         lookup(const id_str_pair           pair[],
+                              const std::vector<uint8_t> &bytes,
+                              int                         notfound = 0);
+};
 
 typedef struct {
     uint8_t     mask;

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -100,8 +100,6 @@ char *rnp_strhexdump_upper(char *dest, const uint8_t *src, size_t length, const 
 /* debugging helpers*/
 void hexdump(FILE *, const char *, const uint8_t *, size_t);
 
-const char *pgp_str_from_map(int, pgp_map_t *);
-
 /* debugging, reflection and information */
 bool rnp_set_debug(const char *);
 bool rnp_get_debug(const char *);

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -81,49 +81,65 @@ static const format_info formats[] = {{PGP_SA_AES_128,
                                        "openpgp-s2k3-ocb-aes",
                                        G10_OCB_NONCE_SIZE}};
 
-static const pgp_map_t g10_alg_aliases[] = {{PGP_PKA_RSA, "rsa"},
-                                            {PGP_PKA_RSA, "openpgp-rsa"},
-                                            {PGP_PKA_RSA, "oid.1.2.840.113549.1.1.1"},
-                                            {PGP_PKA_RSA, "oid.1.2.840.113549.1.1.1"},
-                                            {PGP_PKA_ELGAMAL, "elg"},
-                                            {PGP_PKA_ELGAMAL, "elgamal"},
-                                            {PGP_PKA_ELGAMAL, "openpgp-elg"},
-                                            {PGP_PKA_ELGAMAL, "openpgp-elg-sig"},
-                                            {PGP_PKA_DSA, "dsa"},
-                                            {PGP_PKA_DSA, "openpgp-dsa"},
-                                            {PGP_PKA_ECDSA, "ecc"},
-                                            {PGP_PKA_ECDSA, "ecdsa"},
-                                            {PGP_PKA_ECDH, "ecdh"},
-                                            {PGP_PKA_EDDSA, "eddsa"}};
+static const id_str_pair g10_alg_aliases[] = {
+  {PGP_PKA_RSA, "rsa"},
+  {PGP_PKA_RSA, "openpgp-rsa"},
+  {PGP_PKA_RSA, "oid.1.2.840.113549.1.1.1"},
+  {PGP_PKA_RSA, "oid.1.2.840.113549.1.1.1"},
+  {PGP_PKA_ELGAMAL, "elg"},
+  {PGP_PKA_ELGAMAL, "elgamal"},
+  {PGP_PKA_ELGAMAL, "openpgp-elg"},
+  {PGP_PKA_ELGAMAL, "openpgp-elg-sig"},
+  {PGP_PKA_DSA, "dsa"},
+  {PGP_PKA_DSA, "openpgp-dsa"},
+  {PGP_PKA_ECDSA, "ecc"},
+  {PGP_PKA_ECDSA, "ecdsa"},
+  {PGP_PKA_ECDH, "ecdh"},
+  {PGP_PKA_EDDSA, "eddsa"},
+  {0, NULL},
+};
 
-static const pgp_map_t g10_curve_aliases[] = {
-  {PGP_CURVE_NIST_P_256, "NIST P-256"},   {PGP_CURVE_NIST_P_256, "1.2.840.10045.3.1.7"},
-  {PGP_CURVE_NIST_P_256, "prime256v1"},   {PGP_CURVE_NIST_P_256, "secp256r1"},
+static const id_str_pair g10_curve_aliases[] = {
+  {PGP_CURVE_NIST_P_256, "NIST P-256"},
+  {PGP_CURVE_NIST_P_256, "1.2.840.10045.3.1.7"},
+  {PGP_CURVE_NIST_P_256, "prime256v1"},
+  {PGP_CURVE_NIST_P_256, "secp256r1"},
   {PGP_CURVE_NIST_P_256, "nistp256"},
+  {PGP_CURVE_NIST_P_384, "NIST P-384"},
+  {PGP_CURVE_NIST_P_384, "secp384r1"},
+  {PGP_CURVE_NIST_P_384, "1.3.132.0.34"},
+  {PGP_CURVE_NIST_P_384, "nistp384"},
+  {PGP_CURVE_NIST_P_521, "NIST P-521"},
+  {PGP_CURVE_NIST_P_521, "secp521r1"},
+  {PGP_CURVE_NIST_P_521, "1.3.132.0.35"},
+  {PGP_CURVE_NIST_P_521, "nistp521"},
+  {PGP_CURVE_25519, "Curve25519"},
+  {PGP_CURVE_25519, "1.3.6.1.4.1.3029.1.5.1"},
+  {PGP_CURVE_ED25519, "Ed25519"},
+  {PGP_CURVE_ED25519, "1.3.6.1.4.1.11591.15.1"},
+  {PGP_CURVE_BP256, "brainpoolP256r1"},
+  {PGP_CURVE_BP256, "1.3.36.3.3.2.8.1.1.7"},
+  {PGP_CURVE_BP384, "brainpoolP384r1"},
+  {PGP_CURVE_BP384, "1.3.36.3.3.2.8.1.1.11"},
+  {PGP_CURVE_BP512, "brainpoolP512r1"},
+  {PGP_CURVE_BP512, "1.3.36.3.3.2.8.1.1.13"},
+  {PGP_CURVE_P256K1, "secp256k1"},
+  {PGP_CURVE_P256K1, "1.3.132.0.10"},
+  {0, NULL},
+};
 
-  {PGP_CURVE_NIST_P_384, "NIST P-384"},   {PGP_CURVE_NIST_P_384, "secp384r1"},
-  {PGP_CURVE_NIST_P_384, "1.3.132.0.34"}, {PGP_CURVE_NIST_P_384, "nistp384"},
-
-  {PGP_CURVE_NIST_P_521, "NIST P-521"},   {PGP_CURVE_NIST_P_521, "secp521r1"},
-  {PGP_CURVE_NIST_P_521, "1.3.132.0.35"}, {PGP_CURVE_NIST_P_521, "nistp521"},
-
-  {PGP_CURVE_25519, "Curve25519"},        {PGP_CURVE_25519, "1.3.6.1.4.1.3029.1.5.1"},
-  {PGP_CURVE_ED25519, "Ed25519"},         {PGP_CURVE_ED25519, "1.3.6.1.4.1.11591.15.1"},
-
-  {PGP_CURVE_BP256, "brainpoolP256r1"},   {PGP_CURVE_BP256, "1.3.36.3.3.2.8.1.1.7"},
-  {PGP_CURVE_BP384, "brainpoolP384r1"},   {PGP_CURVE_BP384, "1.3.36.3.3.2.8.1.1.11"},
-  {PGP_CURVE_BP512, "brainpoolP512r1"},   {PGP_CURVE_BP512, "1.3.36.3.3.2.8.1.1.13"},
-  {PGP_CURVE_P256K1, "secp256k1"},        {PGP_CURVE_P256K1, "1.3.132.0.10"}};
-
-static const pgp_map_t g10_curve_names[] = {{PGP_CURVE_NIST_P_256, "NIST P-256"},
-                                            {PGP_CURVE_NIST_P_384, "NIST P-384"},
-                                            {PGP_CURVE_NIST_P_521, "NIST P-521"},
-                                            {PGP_CURVE_ED25519, "Ed25519"},
-                                            {PGP_CURVE_25519, "Curve25519"},
-                                            {PGP_CURVE_BP256, "brainpoolP256r1"},
-                                            {PGP_CURVE_BP384, "brainpoolP384r1"},
-                                            {PGP_CURVE_BP512, "brainpoolP512r1"},
-                                            {PGP_CURVE_P256K1, "secp256k1"}};
+static const id_str_pair g10_curve_names[] = {
+  {PGP_CURVE_NIST_P_256, "NIST P-256"},
+  {PGP_CURVE_NIST_P_384, "NIST P-384"},
+  {PGP_CURVE_NIST_P_521, "NIST P-521"},
+  {PGP_CURVE_ED25519, "Ed25519"},
+  {PGP_CURVE_25519, "Curve25519"},
+  {PGP_CURVE_BP256, "brainpoolP256r1"},
+  {PGP_CURVE_BP384, "brainpoolP384r1"},
+  {PGP_CURVE_BP512, "brainpoolP512r1"},
+  {PGP_CURVE_P256K1, "secp256k1"},
+  {0, NULL},
+};
 
 static const format_info *
 find_format(pgp_symm_alg_t cipher, pgp_cipher_mode_t mode, pgp_hash_alg_t hash_alg)
@@ -392,14 +408,11 @@ s_exp_t::read_curve(const std::string &name, pgp_ec_key_t &key) noexcept
     }
 
     const auto &bytes = data->bytes();
-    for (size_t i = 0; i < ARRAY_SIZE(g10_curve_aliases); i++) {
-        if (strlen(g10_curve_aliases[i].string) != bytes.size()) {
-            continue;
-        }
-        if (!memcmp(g10_curve_aliases[i].string, bytes.data(), bytes.size())) {
-            key.curve = (pgp_curve_t) g10_curve_aliases[i].type;
-            return true;
-        }
+    pgp_curve_t curve = static_cast<pgp_curve_t>(
+      id_str_pair::lookup(g10_curve_aliases, data->bytes(), PGP_CURVE_UNKNOWN));
+    if (curve != PGP_CURVE_UNKNOWN) {
+        key.curve = curve;
+        return true;
     }
     RNP_LOG("Unknown curve: %.*s", (int) bytes.size(), (char *) bytes.data());
     return false;
@@ -416,8 +429,7 @@ s_exp_t::add_mpi(const std::string &name, const pgp_mpi_t &val)
 void
 s_exp_t::add_curve(const std::string &name, const pgp_ec_key_t &key)
 {
-    const char *curve = NULL;
-    ARRAY_LOOKUP_BY_ID(g10_curve_names, type, string, key.curve, curve);
+    const char *curve = id_str_pair::lookup(g10_curve_names, key.curve, NULL);
     if (!curve) {
         RNP_LOG("unknown curve");
         throw rnp::rnp_exception(RNP_ERROR_BAD_PARAMETERS);
@@ -834,18 +846,9 @@ g10_parse_seckey(pgp_key_pkt_t &seckey,
         return false;
     }
 
-    pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
     auto &           alg_bt = (dynamic_cast<s_exp_block_t &>(alg_s_exp.at(0))).bytes();
-    for (size_t i = 0; i < ARRAY_SIZE(g10_alg_aliases); i++) {
-        if (strlen(g10_alg_aliases[i].string) != alg_bt.size()) {
-            continue;
-        }
-        if (!memcmp(g10_alg_aliases[i].string, alg_bt.data(), alg_bt.size())) {
-            alg = (pgp_pubkey_alg_t) g10_alg_aliases[i].type;
-            break;
-        }
-    }
-
+    pgp_pubkey_alg_t alg = static_cast<pgp_pubkey_alg_t>(
+      id_str_pair::lookup(g10_alg_aliases, alg_bt, PGP_PKA_NOTHING));
     if (alg == PGP_PKA_NOTHING) {
         RNP_LOG(
           "Unsupported algorithm: '%.*s'", (int) alg_bt.size(), (const char *) alg_bt.data());

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -50,7 +50,7 @@
 #include "json_utils.h"
 #include <algorithm>
 
-static pgp_map_t packet_tag_map[] = {
+static const id_str_pair packet_tag_map[] = {
   {PGP_PKT_RESERVED, "Reserved"},
   {PGP_PKT_PK_SESSION_KEY, "Public-Key Encrypted Session Key"},
   {PGP_PKT_SIGNATURE, "Signature"},
@@ -72,11 +72,10 @@ static pgp_map_t packet_tag_map[] = {
   {PGP_PKT_SE_IP_DATA, "Symmetric Encrypted and Integrity Protected Data"},
   {PGP_PKT_MDC, "Modification Detection Code"},
   {PGP_PKT_AEAD_ENCRYPTED, "AEAD Encrypted Data Packet"},
-
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t sig_type_map[] = {
+static const id_str_pair sig_type_map[] = {
   {PGP_SIG_BINARY, "Signature of a binary document"},
   {PGP_SIG_TEXT, "Signature of a canonical text document"},
   {PGP_SIG_STANDALONE, "Standalone signature"},
@@ -92,10 +91,10 @@ static pgp_map_t sig_type_map[] = {
   {PGP_SIG_REV_CERT, "Certification revocation signature"},
   {PGP_SIG_TIMESTAMP, "Timestamp signature"},
   {PGP_SIG_3RD_PARTY, "Third-Party Confirmation signature"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t sig_subpkt_type_map[] = {
+static const id_str_pair sig_subpkt_type_map[] = {
   {PGP_SIG_SUBPKT_CREATION_TIME, "signature creation time"},
   {PGP_SIG_SUBPKT_EXPIRATION_TIME, "signature expiration time"},
   {PGP_SIG_SUBPKT_EXPORT_CERT, "exportable certification"},
@@ -121,10 +120,10 @@ static pgp_map_t sig_subpkt_type_map[] = {
   {PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE, "embedded signature"},
   {PGP_SIG_SUBPKT_ISSUER_FPR, "issuer fingerprint"},
   {PGP_SIG_SUBPKT_PREFERRED_AEAD, "preferred AEAD algorithms"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t key_type_map[] = {
+static const id_str_pair key_type_map[] = {
   {PGP_PKT_SECRET_KEY, "Secret key"},
   {PGP_PKT_PUBLIC_KEY, "Public key"},
   {PGP_PKT_SECRET_SUBKEY, "Secret subkey"},
@@ -132,7 +131,7 @@ static pgp_map_t key_type_map[] = {
   {0x00, NULL},
 };
 
-static pgp_map_t pubkey_alg_map[] = {
+static const id_str_pair pubkey_alg_map[] = {
   {PGP_PKA_RSA, "RSA (Encrypt or Sign)"},
   {PGP_PKA_RSA_ENCRYPT_ONLY, "RSA (Encrypt-Only)"},
   {PGP_PKA_RSA_SIGN_ONLY, "RSA (Sign-Only)"},
@@ -144,10 +143,10 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_RESERVED_DH, "Reserved for DH (X9.42)"},
   {PGP_PKA_EDDSA, "EdDSA"},
   {PGP_PKA_SM2, "SM2"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t symm_alg_map[] = {
+static const id_str_pair symm_alg_map[] = {
   {PGP_SA_PLAINTEXT, "Plaintext"},
   {PGP_SA_IDEA, "IDEA"},
   {PGP_SA_TRIPLEDES, "TripleDES"},
@@ -161,10 +160,10 @@ static pgp_map_t symm_alg_map[] = {
   {PGP_SA_CAMELLIA_192, "Camellia-192"},
   {PGP_SA_CAMELLIA_256, "Camellia-256"},
   {PGP_SA_SM4, "SM4"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t hash_alg_map[] = {
+static const id_str_pair hash_alg_map[] = {
   {PGP_HASH_MD5, "MD5"},
   {PGP_HASH_SHA1, "SHA1"},
   {PGP_HASH_RIPEMD, "RIPEMD160"},
@@ -175,25 +174,25 @@ static pgp_map_t hash_alg_map[] = {
   {PGP_HASH_SM3, "SM3"},
   {PGP_HASH_SHA3_256, "SHA3-256"},
   {PGP_HASH_SHA3_512, "SHA3-512"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t z_alg_map[] = {
+static const id_str_pair z_alg_map[] = {
   {PGP_C_NONE, "Uncompressed"},
   {PGP_C_ZIP, "ZIP"},
   {PGP_C_ZLIB, "ZLib"},
   {PGP_C_BZIP2, "BZip2"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t aead_alg_map[] = {
+static const id_str_pair aead_alg_map[] = {
   {PGP_AEAD_NONE, "None"},
   {PGP_AEAD_EAX, "EAX"},
   {PGP_AEAD_OCB, "OCB"},
-  {0x00, NULL}, /* this is the end-of-array marker */
+  {0x00, NULL},
 };
 
-static pgp_map_t revoc_reason_map[] = {
+static const id_str_pair revoc_reason_map[] = {
   {PGP_REVOCATION_NO_REASON, "No reason"},
   {PGP_REVOCATION_SUPERSEDED, "Superseded"},
   {PGP_REVOCATION_COMPROMISED, "Compromised"},
@@ -324,7 +323,7 @@ dst_print_mpi(pgp_dest_t *dst, const char *name, pgp_mpi_t *mpi, bool dumpbin)
 static void
 dst_print_palg(pgp_dest_t *dst, const char *name, pgp_pubkey_alg_t palg)
 {
-    const char *palg_name = pgp_str_from_map(palg, pubkey_alg_map);
+    const char *palg_name = id_str_pair::lookup(pubkey_alg_map, palg, "Unknown");
     if (!name) {
         name = "public key algorithm";
     }
@@ -335,7 +334,7 @@ dst_print_palg(pgp_dest_t *dst, const char *name, pgp_pubkey_alg_t palg)
 static void
 dst_print_halg(pgp_dest_t *dst, const char *name, pgp_hash_alg_t halg)
 {
-    const char *halg_name = pgp_str_from_map(halg, hash_alg_map);
+    const char *halg_name = id_str_pair::lookup(hash_alg_map, halg, "Unknown");
     if (!name) {
         name = "hash algorithm";
     }
@@ -346,7 +345,7 @@ dst_print_halg(pgp_dest_t *dst, const char *name, pgp_hash_alg_t halg)
 static void
 dst_print_salg(pgp_dest_t *dst, const char *name, pgp_symm_alg_t salg)
 {
-    const char *salg_name = pgp_str_from_map(salg, symm_alg_map);
+    const char *salg_name = id_str_pair::lookup(symm_alg_map, salg, "Unknown");
     if (!name) {
         name = "symmetric algorithm";
     }
@@ -357,7 +356,7 @@ dst_print_salg(pgp_dest_t *dst, const char *name, pgp_symm_alg_t salg)
 static void
 dst_print_aalg(pgp_dest_t *dst, const char *name, pgp_aead_alg_t aalg)
 {
-    const char *aalg_name = pgp_str_from_map(aalg, aead_alg_map);
+    const char *aalg_name = id_str_pair::lookup(aead_alg_map, aalg, "Unknown");
     if (!name) {
         name = "aead algorithm";
     }
@@ -368,7 +367,7 @@ dst_print_aalg(pgp_dest_t *dst, const char *name, pgp_aead_alg_t aalg)
 static void
 dst_print_zalg(pgp_dest_t *dst, const char *name, pgp_compression_type_t zalg)
 {
-    const char *zalg_name = pgp_str_from_map(zalg, z_alg_map);
+    const char *zalg_name = id_str_pair::lookup(z_alg_map, zalg, "Unknown");
     if (!name) {
         name = "compression algorithm";
     }
@@ -385,7 +384,8 @@ dst_print_raw(pgp_dest_t *dst, const char *name, const void *data, size_t len)
 }
 
 static void
-dst_print_algs(pgp_dest_t *dst, const char *name, uint8_t *algs, size_t algc, pgp_map_t map[])
+dst_print_algs(
+  pgp_dest_t *dst, const char *name, uint8_t *algs, size_t algc, const id_str_pair map[])
 {
     if (!name) {
         name = "algorithms";
@@ -393,7 +393,8 @@ dst_print_algs(pgp_dest_t *dst, const char *name, uint8_t *algs, size_t algc, pg
 
     dst_printf(dst, "%s: ", name);
     for (size_t i = 0; i < algc; i++) {
-        dst_printf(dst, "%s%s", pgp_str_from_map(algs[i], map), i + 1 < algc ? ", " : "");
+        dst_printf(
+          dst, "%s%s", id_str_pair::lookup(map, algs[i], "Unknown"), i + 1 < algc ? ", " : "");
     }
     dst_printf(dst, " (");
     for (size_t i = 0; i < algc; i++) {
@@ -405,7 +406,7 @@ dst_print_algs(pgp_dest_t *dst, const char *name, uint8_t *algs, size_t algc, pg
 static void
 dst_print_sig_type(pgp_dest_t *dst, const char *name, pgp_sig_type_t sigtype)
 {
-    const char *sig_name = pgp_str_from_map(sigtype, sig_type_map);
+    const char *sig_name = id_str_pair::lookup(sig_type_map, sigtype, "Unknown");
     if (!name) {
         name = "signature type";
     }
@@ -531,7 +532,7 @@ static void         stream_dump_signature_pkt(rnp_dump_ctx_t * ctx,
 static void
 signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, const pgp_sig_subpkt_t &subpkt)
 {
-    const char *sname = pgp_str_from_map(subpkt.type, sig_subpkt_type_map);
+    const char *sname = id_str_pair::lookup(sig_subpkt_type_map, subpkt.type, "Unknown");
 
     switch (subpkt.type) {
     case PGP_SIG_SUBPKT_CREATION_TIME:
@@ -625,7 +626,7 @@ signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, const pgp_sig_sub
         break;
     case PGP_SIG_SUBPKT_REVOCATION_REASON: {
         int         code = subpkt.fields.revocation_reason.code;
-        const char *reason = pgp_str_from_map(code, revoc_reason_map);
+        const char *reason = id_str_pair::lookup(revoc_reason_map, code, "Unknown");
         dst_printf(dst, "%s: %d (%s)\n", sname, code, reason);
         dst_print_raw(dst,
                       "message",
@@ -798,7 +799,7 @@ stream_dump_key(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
         return ret;
     }
 
-    dst_printf(dst, "%s packet\n", pgp_str_from_map(key.tag, key_type_map));
+    dst_printf(dst, "%s packet\n", id_str_pair::lookup(key_type_map, key.tag, "Unknown"));
     indent_dest_increase(dst);
 
     dst_printf(dst, "version: %d\n", (int) key.version);
@@ -1424,7 +1425,7 @@ finish:
 }
 
 static bool
-obj_add_intstr_json(json_object *obj, const char *name, int val, pgp_map_t map[])
+obj_add_intstr_json(json_object *obj, const char *name, int val, const id_str_pair map[])
 {
     if (!obj_add_field_json(obj, name, json_object_new_int(val))) {
         return false;
@@ -1433,7 +1434,7 @@ obj_add_intstr_json(json_object *obj, const char *name, int val, pgp_map_t map[]
         return true;
     }
     char        namestr[64] = {0};
-    const char *str = pgp_str_from_map(val, map);
+    const char *str = id_str_pair::lookup(map, val, "Unknown");
     snprintf(namestr, sizeof(namestr), "%s.str", name);
     return obj_add_field_json(obj, namestr, json_object_new_string(str));
 }
@@ -1455,7 +1456,7 @@ obj_add_mpi_json(json_object *obj, const char *name, const pgp_mpi_t *mpi, bool 
 
 static bool
 subpacket_obj_add_algs(
-  json_object *obj, const char *name, uint8_t *algs, size_t len, pgp_map_t map[])
+  json_object *obj, const char *name, uint8_t *algs, size_t len, const id_str_pair map[])
 {
     json_object *jso_algs = json_object_new_array();
     if (!jso_algs || !obj_add_field_json(obj, name, jso_algs)) {
@@ -1478,8 +1479,9 @@ subpacket_obj_add_algs(
         return false;
     }
     for (size_t i = 0; i < len; i++) {
-        if (!array_add_element_json(jso_algs,
-                                    json_object_new_string(pgp_str_from_map(algs[i], map)))) {
+        if (!array_add_element_json(
+              jso_algs,
+              json_object_new_string(id_str_pair::lookup(map, algs[i], "Unknown")))) {
             return false;
         }
     }


### PR DESCRIPTION
This PR replaces old pgp_map_t type, used together with defines, with more C++-ish code to lookup ids/strings in the pair map.
Also it removes some unused code.

All suggestions on naming/improving the approach are welcome!