### PR TITLE
Deallocate handle instead of calling Hash::finish() in the destructor.

### DIFF
--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -132,6 +132,13 @@ Hash::clone(Hash &dst) const
     dst.handle_ = copy.release();
 }
 
+Hash::~Hash()
+{
+    if (handle_) {
+        delete static_cast<Botan::HashFunction *>(handle_);
+    }
+}
+
 CRC24::CRC24()
 {
     auto hash_fn = Botan::HashFunction::create("CRC24");

--- a/src/lib/crypto/hash_common.cpp
+++ b/src/lib/crypto/hash_common.cpp
@@ -150,11 +150,6 @@ Hash::operator=(Hash &&src)
     return *this;
 }
 
-Hash::~Hash()
-{
-    finish();
-}
-
 void
 HashList::add_alg(pgp_hash_alg_t alg)
 {

--- a/src/lib/crypto/hash_ossl.cpp
+++ b/src/lib/crypto/hash_ossl.cpp
@@ -155,6 +155,13 @@ Hash::clone(Hash &dst) const
     dst.handle_ = hash_fn;
 }
 
+Hash::~Hash()
+{
+    if (handle_) {
+        EVP_MD_CTX_free(static_cast<EVP_MD_CTX *>(handle_));
+    }
+}
+
 const char *
 Hash::name_backend(pgp_hash_alg_t alg)
 {


### PR DESCRIPTION
Reported by Coverity via CID 1465736.