### PR TITLE
Added Clang builds to Ubuntu, CentOS7, CentOS8 (+ ossl), MacOS, Debian9 and Windows-msys2 workflows

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -74,7 +74,7 @@ jobs:
             RNP_TESTS: rnp_tests
             CC: gcc
             CXX: g++
-    name: centos7 ${{ matrix.env.BUILD_MODE }}, ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.RNP_TESTS }}, ${{ matrix.env.CC }}, ${{ matrix.env.CXX }}
+    name: centos7 tests ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.CC }}, ${{ matrix.env.BUILD_MODE }} ${{ matrix.env.RNP_TESTS }}
     env: ${{ matrix.env }}
     steps:
       - run: |

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/centos7.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -37,18 +39,42 @@ jobs:
         env:
           - BUILD_MODE: normal
             GPG_VERSION: stable
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: normal
             GPG_VERSION: beta
+            CC: gcc
+            CXX: g++
+          - BUILD_MODE: normal
+            GPG_VERSION: stable
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: normal
+            GPG_VERSION: beta
+            CC: clang
+            CXX: clang++
+# Sanitize is only been tested with the clang compiler
+# see env-common.inc.sh
           - BUILD_MODE: sanitize
             GPG_VERSION: stable
+            CC: clang
+            CXX: clang++
           - BUILD_MODE: sanitize
             GPG_VERSION: beta
+            CC: clang
+            CXX: clang++
+# Coverage can only been tested with the GNU compiler
           - BUILD_MODE: coverage
             GPG_VERSION: beta
             RNP_TESTS: cli_tests
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: coverage
             GPG_VERSION: beta
             RNP_TESTS: rnp_tests
+            CC: gcc
+            CXX: g++
+    name: centos7 ${{ matrix.env.BUILD_MODE }}, ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.RNP_TESTS }}, ${{ matrix.env.CC }}, ${{ matrix.env.CXX }}
     env: ${{ matrix.env }}
     steps:
       - run: |
@@ -72,7 +98,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
       - name: Build cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -1,12 +1,21 @@
 name: centos8-openssl
 
 on:
-  pull_request:
   push:
     branches:
       - master
       - 'release/**'
-
+    paths-ignore:
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/centos8-ossl.yml'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
 env:
   CORES: 2
   CODECOV_TOKEN: dbecf176-ea3f-4832-b743-295fd71d0fad
@@ -23,18 +32,42 @@ jobs:
       image: centos:8
     timeout-minutes: 70
     strategy:
-      fail-fast: false
       matrix:
         env:
           - BUILD_MODE: normal
             RNP_TESTS: rnp_tests
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: sanitize
             RNP_TESTS: rnp_tests
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: normal
             RNP_TESTS: cli_tests
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: sanitize
-            RNP_TESTS: cli_tests          
+            RNP_TESTS: cli_tests
+            CC: gcc
+            CXX: g++
+          - BUILD_MODE: normal
+            RNP_TESTS: rnp_tests
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: sanitize
+            RNP_TESTS: rnp_tests
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: normal
+            RNP_TESTS: cli_tests
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: sanitize
+            RNP_TESTS: cli_tests
+            CC: clang
+            CXX: clang++
     env: ${{ matrix.env }}
+    name: centos8 openssl tests ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.CC }}, ${{ matrix.env.BUILD_MODE }} ${{ matrix.env.RNP_TESTS }}
     steps:
       - run: |
           yum -y install git
@@ -56,7 +89,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
       - name: Build cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -67,7 +67,7 @@ jobs:
             CC: clang
             CXX: clang++
     env: ${{ matrix.env }}
-    name: centos8 openssl tests ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.CC }}, ${{ matrix.env.BUILD_MODE }} ${{ matrix.env.RNP_TESTS }}
+    name: centos8 openssl tests ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.CC }}, ${{ matrix.env.BUILD_MODE }}, ${{ matrix.env.RNP_TESTS }}
     steps:
       - run: |
           yum -y install git

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -36,8 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         env:
-      matrix:
-        env:
           - BUILD_MODE: normal
             GPG_VERSION: stable
             CC: gcc

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/centos8.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -34,30 +36,55 @@ jobs:
       fail-fast: false
       matrix:
         env:
+      matrix:
+        env:
           - BUILD_MODE: normal
             GPG_VERSION: stable
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: normal
             GPG_VERSION: beta
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: normal
             GPG_VERSION: 2.3.1
-          - BUILD_MODE: sanitize
+            CC: gcc
+            CXX: g++
+          - BUILD_MODE: normal
             GPG_VERSION: stable
-
-          # TODO: fix build error:
-          # libcommon.a(libcommon_a-iobuf.o):(.bss+0x8): multiple definition of `iobuf_debug_mode'
-          # t-iobuf.o:(.bss+0x0): first defined here
-          # clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
-          #
-          # - BUILD_MODE: sanitize
-          #   GPG_VERSION: beta
-
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: normal
+            GPG_VERSION: beta
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: normal
+            GPG_VERSION: 2.3.1
+            CC: clang
+            CXX: clang++
+# Coverage can only been tested with the GNU compiler
           - BUILD_MODE: coverage
             GPG_VERSION: beta
             RNP_TESTS: cli_tests
+            CC: gcc
+            CXX: g++
           - BUILD_MODE: coverage
             GPG_VERSION: beta
             RNP_TESTS: rnp_tests
+            CC: gcc
+            CXX: g++
+# Sanitize is only tested with the clang compiler
+# see env-common.inc.sh
+          - BUILD_MODE: sanitize
+            GPG_VERSION: stable
+            CC: clang
+            CXX: clang++
+          - BUILD_MODE: sanitize
+            GPG_VERSION: beta
+            CC: clang
+            CXX: clang++
     env: ${{ matrix.env }}
+    name: centos8 tests ${{ matrix.env.GPG_VERSION }}, ${{ matrix.env.CC }}, ${{ matrix.env.BUILD_MODE }}, ${{ matrix.env.RNP_TESTS }}
     steps:
       - run: |
           yum -y install git
@@ -79,7 +106,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
       - name: Build cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 2
 
       - name: Setup noncacheable dependencies
         run: |

--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/debian9.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -37,19 +39,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-# I386: actions/checkout@V2,  actions/cache@V2 actions/cache@V2 
-#       give error about OCI container [https://github.com/actions/checkout/issues/334]
-#                                      [https://github.com/actions/runner/issues/1011]
         env:
-          - CPU: i386
+          - CC: gcc
+            CXX: g++
+            CPU: i386
+            IMAGE: "i386/debian:9"
+          - CC: clang
+            CXX: clang++
+            CPU: i386
             IMAGE: "i386/debian:9"
     env: ${{ matrix.env }}
+    name: ${{ matrix.env.IMAGE }} tests ${{ matrix.env.CC }}
     steps:
       - name: Install prerequisites
         run: |
           apt update
           apt -y install git sudo
       
+# I386: actions/checkout@V2,  actions/cache@V2 actions/cache@V2
+#       give error about OCI container [https://github.com/actions/checkout/issues/334]
+#                                      [https://github.com/actions/runner/issues/1011]
       - name: Check out repository
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 2
+          fetch-depth: 10
 
       - name: Setup noncacheable dependencies
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,6 @@ jobs:
             CXX: clang++
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: ${{ matrix.os }} tests ${{ matrix.env.CC }}
-    runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
     timeout-minutes: 250
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/macos.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -23,13 +25,20 @@ env:
 
 jobs:
   tests:
-    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-10.15, macos-11.0]
+        env:
+          - CC: gcc
+            CXX: g++
+          - CC: clang
+            CXX: clang++
     if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: ${{ matrix.os }} tests ${{ matrix.env.CC }}
+    runs-on: ${{ matrix.os }}
+    env: ${{ matrix.env }}
     timeout-minutes: 250
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +53,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ github.workflow }}-${{ matrix.os }}-${{ env.BUILD_MODE }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
+          key: ${{ github.workflow }}-${{ matrix.os }}-${{ env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
       - name: Build cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -161,7 +161,7 @@ jobs:
           ci/run.sh
           [ -d "${LOCAL_BUILDS}/rnp-build/src/tests" ]
           [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-build" ]
-          [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-src" ]          
+          [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-src" ]
   cmake-disable-rubyrnp:
     strategy:
       matrix:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/ubuntu.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -23,8 +25,17 @@ env:
 
 jobs:
   tests:
+    strategy:
+      matrix:
+        env:
+          - CC: gcc
+            CXX: g++
+          - CC: clang
+            CXX: clang++
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: ubuntu ${{ matrix.env.CC }}, ${{ matrix.env.CXX }}
+    env: ${{ matrix.env }}    
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +50,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.BUILD_MODE }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
       - name: Build cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -34,7 +34,7 @@ jobs:
             CXX: clang++
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: ubuntu ${{ matrix.env.CC }}, ${{ matrix.env.CXX }}
+    name: ubuntu ${{ matrix.env.CC }} tests
     env: ${{ matrix.env }}    
     timeout-minutes: 50
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -108,7 +108,7 @@ jobs:
           ci/run.sh
           [ -d "${LOCAL_BUILDS}/rnp-build/src/tests" ]
           [ -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-build" ]
-          [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-src" ]          
+          [ ! -d "${LOCAL_BUILDS}/rnp-build/src/tests/googletest-src" ]
   cmake-offline-googletest:
     strategy:
       matrix:

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -9,7 +9,7 @@ on:
       - '**.adoc'
       - '**.md'
       - '.github/workflows/*.yml'
-      - '!.github/workflows/windows.yml'
+      - '!.github/workflows/windows-msvc.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -8,6 +8,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/windows.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/windows.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -25,9 +27,20 @@ jobs:
     runs-on: windows-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 70
-    env:
-      GTEST_SOURCES: /home/runneradmin/googletest-download/googletest-src
-    steps:
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - CC: gcc
+            CXX: g++
+            GTEST_SOURCES: /home/runneradmin/googletest-download/googletest-src
+          - CC: clang
+            CXX: clang++
+            GTEST_SOURCES: /home/runneradmin/googletest-download/googletest-src
+    runs-on: windows-latest
+    name: msys2 tests ${{ matrix.env.CC }}
+    env:  ${{ matrix.env }}    
+steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-latest
     name: msys2 tests ${{ matrix.env.CC }}
     env:  ${{ matrix.env }}    
-steps:
+  steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'release/**'
-      - maxirmx-clang
     paths-ignore:
       - 'docs/**'
       - '**.adoc'
@@ -25,7 +24,6 @@ env:
 
 jobs:
   tests:
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +36,7 @@ jobs:
             GTEST_SOURCES: /home/runneradmin/googletest-download/googletest-src
  # Note re clang setup 
  # https://github.com/randombit/botan/issues/1191:  "botan-2 is c++11 till the end of the times" 
- # It may cause ABI problems with clang (but not with gcc) if extra library is required and it is not loaded from clang 64 repo,  
+ # It may cause ABI problems with clang (but not with gcc) if extra library is required and it is not loaded from clang64 repo,  
  # but comes from mingw64. If so try '-std=c++11'
     runs-on: windows-latest
     name: msys2 ${{ matrix.env.CC }}, ${{ matrix.env.CXX }}
@@ -73,7 +71,7 @@ jobs:
       - name: tests
         shell: msys2 {0}
         run: bash ci/main.sh
-      - name: test with dependencies
+      - name: dependencies
         shell: msys2 {0}
         run: |
           set -euxo pipefail

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-latest
     name: msys2 tests ${{ matrix.env.CC }}
     env:  ${{ matrix.env }}    
-  steps:
+    steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,6 @@ jobs:
           - CC: clang
             CXX: clang++
             GTEST_SOURCES: /home/runneradmin/googletest-download/googletest-src
-    runs-on: windows-latest
     name: msys2 tests ${{ matrix.env.CC }}
     env:  ${{ matrix.env }}    
     steps:

--- a/ci/env-freebsd.inc.sh
+++ b/ci/env-freebsd.inc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 export MAKE=gmake
 export SUDO=sudo
 

--- a/ci/env-freebsd.inc.sh
+++ b/ci/env-freebsd.inc.sh
@@ -6,4 +6,3 @@ export SUDO=sudo
 
 : "${CORES:=$(sysctl -n hw.ncpu)}"
 export CORES
-

--- a/ci/env-msys.inc.sh
+++ b/ci/env-msys.inc.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
+# We rely on CC and CXX set either to gcc/g++ or to clang/clang++ 
+# by calling GHA workflow
+
 : "${CFLAGS:=}"
 : "${CXXFLAGS:=}"
 : "${LDFLAGS:=}"
 export CFLAGS="${CFLAGS}"
 export CXXFLAGS="${CXXFLAGS}"
 export LDFLAGS="${LDFLAGS}"
-export CC=gcc
-export CXX=g++
 : "${CORES:=$(nproc --all)}"
 export CORES
 export MAKE=make

--- a/ci/lib/cacheable_install_functions.inc.sh
+++ b/ci/lib/cacheable_install_functions.inc.sh
@@ -158,7 +158,7 @@ _install_gpg() {
 
   local common_args=(
       --force-autogen
-#      --verbose		commnted out to speed up recurring CI builds
+#      --verbose		commented out to speed up recurring CI builds
 #      --trace                  uncomment if you are debugging CI
       --build-dir "${gpg_build}"
       --configure-opts "${configure_opts[*]}"
@@ -180,6 +180,11 @@ _install_gpg() {
   # Workaround to correctly build pinentry on the latest GHA on macOS. Most likely there is a better solution.
   export CFLAGS="-D_XOPEN_SOURCE_EXTENDED"
   export CXXFLAGS="-D_XOPEN_SOURCE_EXTENDED"
+
+  # Always build gnugpg with gcc, even if we are testing clang
+  # ref https://github.com/rnpgp/rnp/issues/1669
+  export CC="gcc"
+  export CXX="g++"
 
   for component in libgpg-error:$LIBGPG_ERROR_VERSION \
                    libgcrypt:$LIBGCRYPT_VERSION \

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -479,6 +479,7 @@ declare util_dependencies_deb=(
   sudo
   wget
   git
+  software-properties-common
 )
 
 declare basic_build_dependencies_deb=(

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -727,7 +727,9 @@ is_version_at_least() {
   local installed_version installed_version_major installed_version_minor #version_patch
   installed_version="$("$@")"
 
-  # shellcheck disable=SC2181 
+
+  # shellcheck disable=SC2181
+  # shellcheck disable=SC2295
   if [[ $? -ne 0 ]]; then
     need_to_build=1
   else
@@ -735,9 +737,7 @@ is_version_at_least() {
     installed_version_minor="${installed_version#*.}"
     installed_version_minor="${installed_version_minor%%.*}"
     installed_version_minor="${installed_version_minor:-0}"
-  # shellcheck disable=SC2295  
     installed_version_patch="${installed_version#${installed_version_major}.}"
-  # shellcheck disable=SC2295  
     installed_version_patch="${installed_version_patch#${installed_version_minor}}"
     installed_version_patch="${installed_version_patch#.}"
     installed_version_patch="${installed_version_patch%%.*}"
@@ -749,9 +749,7 @@ is_version_at_least() {
     need_version_minor="${need_version_minor%%.*}"
     need_version_minor="${need_version_minor:-0}"
     need_version_patch="${version_constraint##*.}"
-  # shellcheck disable=SC2295  
     need_version_patch="${version_constraint#${need_version_major}.}"
-  # shellcheck disable=SC2295  
     need_version_patch="${need_version_patch#${need_version_minor}}"
     need_version_patch="${need_version_patch#.}"
     need_version_patch="${need_version_patch%%.*}"

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -557,16 +557,14 @@ msys_install() {
     automake-wrapper
     gnupg2
     make
-    pkg-config
+    pkg-config 
     mingw64/mingw-w64-x86_64-cmake
     mingw64/mingw-w64-x86_64-python3
   )
 
   if [ "${CC-gcc}" = "gcc" ]; then
-    packages+=(mingw64/mingw-w64-x86_64-gcc
+    packages+=(mingw64/mingw-w64-x86_64-gcc 
                mingw64/mingw-w64-x86_64-json-c
-               zlib-devel
-               libbz2-devel
     )
   else
    packages+=(clang64/mingw-w64-clang-x86_64-clang 
@@ -575,6 +573,7 @@ msys_install() {
               clang64/mingw-w64-clang-x86_64-libbotan
               clang64/mingw-w64-clang-x86_64-libssp
               clang64/mingw-w64-clang-x86_64-json-c
+              clang64/mingw-w64-clang-x86_64-libsystre
    ) 
   fi
 
@@ -728,7 +727,7 @@ is_version_at_least() {
   local installed_version installed_version_major installed_version_minor #version_patch
   installed_version="$("$@")"
 
-  # shellcheck disable=SC2181
+  # shellcheck disable=SC2181 
   if [[ $? -ne 0 ]]; then
     need_to_build=1
   else
@@ -736,7 +735,9 @@ is_version_at_least() {
     installed_version_minor="${installed_version#*.}"
     installed_version_minor="${installed_version_minor%%.*}"
     installed_version_minor="${installed_version_minor:-0}"
+  # shellcheck disable=SC2295  
     installed_version_patch="${installed_version#${installed_version_major}.}"
+  # shellcheck disable=SC2295  
     installed_version_patch="${installed_version_patch#${installed_version_minor}}"
     installed_version_patch="${installed_version_patch#.}"
     installed_version_patch="${installed_version_patch%%.*}"
@@ -748,7 +749,9 @@ is_version_at_least() {
     need_version_minor="${need_version_minor%%.*}"
     need_version_minor="${need_version_minor:-0}"
     need_version_patch="${version_constraint##*.}"
+  # shellcheck disable=SC2295  
     need_version_patch="${version_constraint#${need_version_major}.}"
+  # shellcheck disable=SC2295  
     need_version_patch="${need_version_patch#${need_version_minor}}"
     need_version_patch="${need_version_patch#.}"
     need_version_patch="${need_version_patch%%.*}"

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -546,8 +546,6 @@ linux_install() {
 msys_install() {
   local packages=(
     tar
-    zlib-devel
-    libbz2-devel
     git
     automake
     autoconf
@@ -557,19 +555,34 @@ msys_install() {
     make
     pkg-config
     mingw64/mingw-w64-x86_64-cmake
-    mingw64/mingw-w64-x86_64-gcc
-    mingw64/mingw-w64-x86_64-json-c
     mingw64/mingw-w64-x86_64-python3
   )
 
+  if [ "${CC}" = "gcc" ]; then
+    packages+=(mingw64/mingw-w64-x86_64-gcc 
+               mingw64/mingw-w64-x86_64-json-c
+    )
+  else
+   packages+=(clang64/mingw-w64-clang-x86_64-clang 
+              clang64/mingw-w64-clang-x86_64-openmp
+              clang64/mingw-w64-clang-x86_64-libc++
+              clang64/mingw-w64-clang-x86_64-libbotan
+              clang64/mingw-w64-clang-x86_64-libssp
+              clang64/mingw-w64-clang-x86_64-json-c
+              clang64/mingw-w64-clang-x86_64-libsystre
+   ) 
+  fi
+
   pacman --noconfirm -S --needed "${packages[@]}"
 
+  if [ "${CC-gcc}" = "gcc" ]; then
   # any version starting with 2.14 up to 2.17.3 caused the application to hang
   # as described in https://github.com/randombit/botan/issues/2582
   # fixed with https://github.com/msys2/MINGW-packages/pull/7640/files
-  botan_pkg="mingw-w64-x86_64-libbotan-2.17.3-2-any.pkg.tar.zst"
-  pacman --noconfirm -U https://repo.msys2.org/mingw/x86_64/${botan_pkg} || \
-  pacman --noconfirm -U https://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/${botan_pkg}
+    botan_pkg="mingw-w64-x86_64-libbotan-2.17.3-2-any.pkg.tar.zst"
+    pacman --noconfirm -U https://repo.msys2.org/mingw/x86_64/${botan_pkg} || \
+    pacman --noconfirm -U https://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/${botan_pkg}
+  fi
 
   # msys includes ruby 2.6.1 while we need lower version
   #wget http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-ruby-2.5.3-1-any.pkg.tar.xz -O /tmp/ruby-2.5.3.pkg.tar.xz

--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -522,6 +522,16 @@ linux_install_debian() {
     "${build_dependencies_deb[@]}" \
     "$@"
 
+  if [ "${CC-gcc}" = "clang" ]; then
+# Add apt.llvm.org repository and install clang
+# We may use https://packages.debian.org/stretch/clang-3.8 as well but this package gets installed to
+# /usr/lib/clang... and requires update-alternatives which would be very ugly considering CC/CXX environment
+# settings coming from yaml already   
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+    ${SUDO} apt-add-repository "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main"
+    ${SUDO} apt-get install -y clang 
+  fi
+
   ensure_automake
   build_and_install_cmake
 }

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -44,6 +44,9 @@ prepare_test_env() {
       export LIBRARY_PATH="/clang64/lib:${LIBRARY_PATH-}"
       export C_INCLUDE_PATH="/clang64/include:${C_INCLUDE_PATH-}"
       export CPP_INCLUDE_PATH="/clang64/include:${CPP_INCLUDE_PATH-}"
+
+  # clang 'wants' it explicit as opposed to gcc that links to glibc by default
+      export LDFLAGS="${LDFLAGS-} -lregex"
     fi
   fi
 }

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -37,6 +37,18 @@ prepare_test_env() {
   # update dll search path for windows
   if [[ "${OS}" = "msys" ]]; then
     export PATH="${LOCAL_BUILDS}/rnp-build/lib:${LOCAL_BUILDS}/rnp-build/bin:${LOCAL_BUILDS}/rnp-build/src/lib:$PATH"
+
+    if [[ "${CC}" = "clang" ]]; then
+  # clang paths shall have higher priority
+  # we rely on GHA workflow and env-msys.inc.sh that set LDFLAGS, CFLAGS, CXXFLAGS at least to null strings 
+      export PATH="/clang64/bin:$PATH"
+      export LD_LIBRARY_PATH="/clang64/lib:$LD_LIBRARY_PATH"
+  # clang 'wants' regex explicit as opposed to gcc that links to glibc by default
+      export LDFLAGS="-L/clang64/lib ${LDFLAGS} -lregex"
+      export CFLAGS="-I/clang64/include ${CFLAGS}"
+      export CXXFlAGS="-I/clang64/include ${CXXFLAGS}"
+    fi
+
   fi
 }
 


### PR DESCRIPTION
Clang build and test for the following workflows:

- centos7
- centos8-ossl
- centos8
- debian9
- macos
- ubuntu
- windows (msys)

Fixed:

- #1129 
- clang/rnp build issue (CentOS 7 workflow) #1670
- clang/GnuPG v2.3.0-beta983 issue (CentOS 8 workflow) #1669
- clang/libgcrypt v1.9.3 issue (CentOS 8 workflow) #1668

Not included in this PR comparing to the first attempt.
- Fix to 'centos8 / pkgconfig-cmake-target' job which was disabled in the upstream version. I have a fix for it, if you need it pls. create separate issue. It may go to another PR if so.
- All convinience changes that helped to run/debug CI scripts outside GHA environment