### PR TITLE
Added Clang builds to Ubuntu, CentOS7, CentOS8 (+ ossl), MacOS, Debian9 and Windows-msys2 workflows

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -114,8 +114,9 @@ jobs:
         run: |
           set -euxo pipefail
           nm --defined-only -g $RNP_INSTALL/lib64/librnp*.so > exports
-          grep -qv dst_close exports
-          grep -qw rnp_version_string exports
+          [ $(grep -c dst_close exports) == "0" ]
+          [ $(grep -c Botan exports) == "0" ]
+          [ $(grep -c rnp_version_string_full exports) == "1" ]
   pkgconfig-cmake-target:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -120,8 +120,9 @@ jobs:
         run: |
           set -euxo pipefail
           nm --defined-only -g $RNP_INSTALL/lib64/librnp*.so > exports
-          grep -qv dst_close exports
-          grep -qw rnp_version_string exports
+          [ $(grep -c dst_close exports) == "0" ]
+          [ $(grep -c Botan exports) == "0" ]
+          [ $(grep -c rnp_version_string_full exports) == "1" ]
   pkgconfig-cmake-target:
     runs-on: ubuntu-latest
     # TODO: re-enable when the following can pass

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,3 +61,10 @@ jobs:
       - name: tests
         run: |
           ci/run.sh
+      - name: symbol-visibility
+        run: |
+          set -euxo pipefail
+          nm --extern-only --defined-only --demangle $RNP_INSTALL/lib/librnp.dylib > exports
+          [ $(grep -c dst_close exports) == "0" ]
+          [ $(grep -c Botan exports) == "0" ]
+          [ $(grep -c _rnp_version_string_full exports) == "1" ]

--- a/ci/lib/cacheable_install_functions.inc.sh
+++ b/ci/lib/cacheable_install_functions.inc.sh
@@ -181,7 +181,7 @@ _install_gpg() {
   export CFLAGS="-D_XOPEN_SOURCE_EXTENDED"
   export CXXFLAGS="-D_XOPEN_SOURCE_EXTENDED"
 
-  # Always build gnugpg with gcc, even if we are testing clang
+  # Always build GnuPG with gcc, even if we are testing clang
   # ref https://github.com/rnpgp/rnp/issues/1669
   export CC="gcc"
   export CXX="g++"

--- a/src/common/str-utils.cpp
+++ b/src/common/str-utils.cpp
@@ -53,6 +53,20 @@ strip_eol(char *s)
 }
 
 bool
+strip_eol(std::string &s)
+{
+    size_t len = s.size();
+    while (len && ((s[len - 1] == '\n') || (s[len - 1] == '\r'))) {
+        len--;
+    }
+    if (len == s.size()) {
+        return false;
+    }
+    s.resize(len);
+    return true;
+}
+
+bool
 is_blank_line(const char *line, size_t len)
 {
     for (size_t i = 0; i < len && line[i]; i++) {

--- a/src/common/str-utils.h
+++ b/src/common/str-utils.h
@@ -27,10 +27,19 @@
 #ifndef RNP_STR_UTILS_H_
 #define RNP_STR_UTILS_H_
 
+#include <string>
+
 namespace rnp {
 char *strip_eol(char *s);
-bool  is_blank_line(const char *line, size_t len);
-bool  str_case_eq(const char *s1, const char *s2);
+/**
+ * @brief Strip EOL characters from the string's end.
+ *
+ * @param s string to check
+ * @return true if EOL was found and stripped, or false otherwise.
+ */
+bool strip_eol(std::string &s);
+bool is_blank_line(const char *line, size_t len);
+bool str_case_eq(const char *s1, const char *s2);
 } // namespace rnp
 #ifdef _WIN32
 #include <string>

--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -132,6 +132,13 @@ Hash::clone(Hash &dst) const
     dst.handle_ = copy.release();
 }
 
+Hash::~Hash()
+{
+    if (handle_) {
+        delete static_cast<Botan::HashFunction *>(handle_);
+    }
+}
+
 CRC24::CRC24()
 {
     auto hash_fn = Botan::HashFunction::create("CRC24");

--- a/src/lib/crypto/hash_common.cpp
+++ b/src/lib/crypto/hash_common.cpp
@@ -150,11 +150,6 @@ Hash::operator=(Hash &&src)
     return *this;
 }
 
-Hash::~Hash()
-{
-    finish();
-}
-
 void
 HashList::add_alg(pgp_hash_alg_t alg)
 {

--- a/src/lib/crypto/hash_ossl.cpp
+++ b/src/lib/crypto/hash_ossl.cpp
@@ -155,6 +155,13 @@ Hash::clone(Hash &dst) const
     dst.handle_ = hash_fn;
 }
 
+Hash::~Hash()
+{
+    if (handle_) {
+        EVP_MD_CTX_free(static_cast<EVP_MD_CTX *>(handle_));
+    }
+}
+
 const char *
 Hash::name_backend(pgp_hash_alg_t alg)
 {

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -177,6 +177,12 @@ struct rnp_op_encrypt_st {
     rnp_op_sign_signatures_t signatures{};
 };
 
+#define RNP_LOCATOR_MAX_SIZE (MAX_ID_LENGTH + 1)
+static_assert(RNP_LOCATOR_MAX_SIZE > PGP_FINGERPRINT_SIZE * 2, "Locator size mismatch.");
+static_assert(RNP_LOCATOR_MAX_SIZE > PGP_KEY_ID_SIZE * 2, "Locator size mismatch.");
+static_assert(RNP_LOCATOR_MAX_SIZE > PGP_KEY_GRIP_SIZE * 2, "Locator size mismatch.");
+static_assert(RNP_LOCATOR_MAX_SIZE > MAX_ID_LENGTH, "Locator size mismatch.");
+
 struct rnp_identifier_iterator_st {
     rnp_ffi_t                       ffi;
     pgp_key_search_type_t           type;
@@ -184,9 +190,7 @@ struct rnp_identifier_iterator_st {
     std::list<pgp_key_t>::iterator *keyp;
     unsigned                        uididx;
     json_object *                   tbl;
-    char
-      buf[1 + MAX(MAX(MAX(PGP_KEY_ID_SIZE * 2, PGP_KEY_GRIP_SIZE), PGP_FINGERPRINT_SIZE * 2),
-                  MAX_ID_LENGTH)];
+    char                            buf[RNP_LOCATOR_MAX_SIZE];
 };
 
 /* This is just for readability at the call site and will hopefully reduce mistakes.

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -106,9 +106,7 @@ find_key(rnp_ffi_t               ffi,
         break;
     }
     if (!key && ffi->getkeycb && try_key_provider) {
-        char        identifier[1 + MAX(MAX(MAX(PGP_KEY_ID_SIZE * 2, PGP_KEY_GRIP_SIZE),
-                                    PGP_FINGERPRINT_SIZE * 2),
-                                MAX_ID_LENGTH)];
+        char        identifier[RNP_LOCATOR_MAX_SIZE];
         const char *identifier_type = NULL;
 
         if (locator_to_str(search, &identifier_type, identifier, sizeof(identifier))) {

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -88,10 +88,6 @@ STORE64BE(uint8_t x[8], uint64_t y)
     x[7] = (uint8_t)(y >> 0) & 0xff;
 }
 
-#ifndef MAX
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-
 inline char *
 getenv_logname(void)
 {

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -164,14 +164,14 @@ static void
 copy_tmp_path(char *buf, size_t buflen, pgp_dest_t *dst)
 {
     typedef struct pgp_dest_file_param_t {
-        int  fd;
-        int  errcode;
-        bool overwrite;
-        char path[PATH_MAX];
+        int         fd;
+        int         errcode;
+        bool        overwrite;
+        std::string path;
     } pgp_dest_file_param_t;
 
     pgp_dest_file_param_t *param = (pgp_dest_file_param_t *) dst->param;
-    strncpy(buf, param->path, buflen);
+    strncpy(buf, param->path.c_str(), buflen);
 }
 
 TEST_F(rnp_tests, test_stream_file)
@@ -182,7 +182,7 @@ TEST_F(rnp_tests, test_stream_file)
     const char * filedata = "dummy message to be stored in the file";
     const int    iterations = 10000;
     const int    filedatalen = strlen(filedata);
-    char         tmpname[PATH_MAX] = {0};
+    char         tmpname[128] = {0};
     uint8_t      tmpbuf[1024] = {0};
     pgp_dest_t   dst = {};
     pgp_source_t src = {};

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -206,17 +206,19 @@ get_tmp()
 static bool
 is_tmp_path(const char *path)
 {
-    char rlpath[PATH_MAX] = {0};
-    char rltmp[PATH_MAX] = {0};
-    if (!realpath(path, rlpath)) {
-        strncpy(rlpath, path, sizeof(rlpath));
-        rlpath[sizeof(rlpath) - 1] = '\0';
+    char *rlpath = realpath(path, NULL);
+    if (!rlpath) {
+        rlpath = strdup(path);
     }
     const char *tmp = get_tmp();
-    if (!realpath(tmp, rltmp)) {
-        strncpy(rltmp, tmp, sizeof(rltmp));
+    char *      rltmp = realpath(tmp, NULL);
+    if (!rltmp) {
+        rltmp = strdup(tmp);
     }
-    return strncmp(rlpath, rltmp, strlen(rltmp)) == 0;
+    bool res = rlpath && rltmp && !strncmp(rlpath, rltmp, strlen(rltmp));
+    free(rlpath);
+    free(rltmp);
+    return res;
 }
 
 /* Recursively remove a directory.


### PR DESCRIPTION
Clang build and test for the following workflows:

- centos7
- centos8-ossl
- centos8
- debian9
- macos
- ubuntu
- windows (msys) 

Fixed:

- Build with clang-cl #1129
- clang/rnp build issue (CentOS 7 workflow) clang/rnp build issue (CentOS 7 workflow) #1670
- clang/GnuPG v2.3.0-beta983 issue (CentOS 8 workflow) clang/GnuPG v2.3.0-beta983 issue (CentOS 8 workflow) #1669
- clang/libgcrypt v1.9.3 issue (CentOS 8 workflow) clang/libgcrypt v1.9.3 issue (CentOS 8 workflow) #1668

Changes previously reviewd but not included in this PR:

- Fix to 'centos8 / pkgconfig-cmake-target' job which was disabled in the upstream version. I have a fix for it, if you need it pls. create separate issue. It may go to another PR if so.
- All convinience changes that helped to run/debug CI scripts outside GHA environment