### PR TITLE
Check required OpenSSL features via CMake

### DIFF
--- a/cmake/Modules/FindOpenSSLFeatures.cmake
+++ b/cmake/Modules/FindOpenSSLFeatures.cmake
@@ -1,0 +1,125 @@
+# Copyright (c) 2021 Ribose Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+#.rst:
+# FindOpenSSLFeatures
+# -----------
+#
+# Find OpenSSL features: supported hashes, ciphers, curves and public-key algorithms.
+# Requires FindOpenSSL to be included first, and C compiler to be set as module 
+# compiles and executes program which do checks against installed OpenSSL library.
+#
+# Result variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ::
+#
+#   OPENSSL_SUPPORTED_HASHES    - list of the supported hash algorithms
+#   OPENSSL_SUPPORTED_CIPHERS   - list of the supported ciphers
+#   OPENSSL_SUPPORTED_CURVES    - list of the supported elliptic curves
+#   OPENSSL_SUPPORTED_PUBLICKEY - list of the supported public-key algorithms
+#   OPENSSL_SUPPORTED_FEATURES  - all previous lists, glued together
+#
+# Functions
+# ^^^^^^^^^
+# OpenSSLHasFeature(FEATURE <VARIABLE>)
+# Check whether OpenSSL has corresponding feature (hash/curve/public-key algorithm name, elliptic curve).
+# Result is stored in VARIABLE as boolean value, i.e. TRUE or FALSE
+#
+if (NOT OPENSSL_FOUND)
+  message(FATAL_ERROR "OpenSSL is not found. Please make sure that you call find_package(OpenSSL) first.")
+endif()
+
+# Copy and build findopensslfeatures.c in fossl-build subfolder.
+set(_fossl_work_dir "${CMAKE_BINARY_DIR}/fossl-build")
+file(MAKE_DIRECTORY "${_fossl_work_dir}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/findopensslfeatures.c"
+  DESTINATION "${_fossl_work_dir}"
+)
+# As it's short enough let's keep it here.
+file(WRITE "${_fossl_work_dir}/CMakeLists.txt"
+"cmake_minimum_required(VERSION 3.14)\n\
+project(findopensslfeatures LANGUAGES C)\n\
+set(CMAKE_C_STANDARD 99)\n\
+include(FindOpenSSL)\n\
+find_package(OpenSSL REQUIRED)\n\
+add_executable(findopensslfeatures findopensslfeatures.c)\n\
+target_link_libraries(findopensslfeatures PRIVATE OpenSSL::Crypto)\n"
+)
+
+execute_process(
+  COMMAND "cmake" "." "-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}"
+  WORKING_DIRECTORY "${_fossl_work_dir}"
+  OUTPUT_VARIABLE output
+  ERROR_VARIABLE error
+  RESULT_VARIABLE result
+)
+if (NOT ${result} EQUAL 0)
+  message(FATAL_ERROR "Error configuring findopensslfeatures: ${result}\n${error}")
+endif()
+
+execute_process(
+  COMMAND "cmake" "--build" "."
+  WORKING_DIRECTORY "${_fossl_work_dir}"
+  OUTPUT_VARIABLE output
+  ERROR_VARIABLE error
+  RESULT_VARIABLE result
+)
+if (NOT ${result} EQUAL 0)
+  message(FATAL_ERROR "Error building findopensslfeatures: ${result}\n${error}")
+endif()
+
+set(OPENSSL_SUPPORTED_FEATURES "")
+foreach(feature "hashes" "ciphers" "curves" "publickey")
+  execute_process(
+    COMMAND "./findopensslfeatures" "${feature}"
+    WORKING_DIRECTORY "${_fossl_work_dir}"
+    OUTPUT_VARIABLE feature_val
+    ERROR_VARIABLE error
+    RESULT_VARIABLE result
+  )
+
+  if(NOT ${result} EQUAL 0)
+    message(FATAL_ERROR "Error getting supported OpenSSL ${feature}: \n${error}")
+  endif()
+
+  string(TOUPPER ${feature} feature_up)
+  string(TOUPPER ${feature_val} feature_val)
+  string(REPLACE "\n" ";" feature_val ${feature_val})
+  set(OPENSSL_SUPPORTED_${feature_up} ${feature_val})
+  list(LENGTH OPENSSL_SUPPORTED_${feature_up} ${feature}_len)
+  list(APPEND OPENSSL_SUPPORTED_FEATURES ${OPENSSL_SUPPORTED_${feature_up}})
+endforeach()
+
+message(STATUS "Fetched OpenSSL features: ${hashes_len} hashes, ${ciphers_len} ciphers, ${curves_len} curves, ${publickey_len} publickey.")
+
+function(OpenSSLHasFeature FEATURE VARIABLE)
+  string(TOUPPER ${FEATURE} _feature_up)
+  set(${VARIABLE} FALSE PARENT_SCOPE)
+  if (${_feature_up} IN_LIST OPENSSL_SUPPORTED_FEATURES)
+      set(${VARIABLE} TRUE PARENT_SCOPE)
+  endif()
+endfunction(OpenSSLHasFeature)

--- a/cmake/Modules/findopensslfeatures.c
+++ b/cmake/Modules/findopensslfeatures.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <openssl/ec.h>
+#include <openssl/objects.h>
+#include <openssl/evp.h>
+
+int
+list_curves()
+{
+    size_t            len = EC_get_builtin_curves(NULL, 0);
+    EC_builtin_curve *curves = OPENSSL_malloc(sizeof(EC_builtin_curve) * len);
+    if (!curves) {
+        fprintf(stderr, "Allocation failed.\n");
+        return 1;
+    }
+    if (!EC_get_builtin_curves(curves, len)) {
+        OPENSSL_free(curves);
+        fprintf(stderr, "Failed to get curves.\n");
+        return 1;
+    }
+    for (size_t i = 0; i < len; i++) {
+        const char *sname = OBJ_nid2sn(curves[i].nid);
+        if (!sname) {
+            continue;
+        }
+        printf("%s\n", sname);
+    }
+    OPENSSL_free(curves);
+    return 0;
+}
+
+static void
+print_hash(const EVP_MD *md, const char *from, const char *to, void *arg)
+{
+    if (!md) {
+        return;
+    }
+    if (strstr(from, "rsa") || strstr(from, "RSA")) {
+        return;
+    }
+    printf("%s\n", from);
+}
+
+int
+list_hashes()
+{
+    EVP_MD_do_all_sorted(print_hash, NULL);
+    return 0;
+}
+
+static void
+print_cipher(const EVP_CIPHER *ciph, const char *from, const char *to, void *x)
+{
+    if (!ciph) {
+        return;
+    }
+    printf("%s\n", from);
+}
+
+int
+list_ciphers()
+{
+    EVP_CIPHER_do_all_sorted(print_cipher, NULL);
+    return 0;
+}
+
+int
+list_publickey()
+{
+    for (size_t i = 0; i < EVP_PKEY_meth_get_count(); i++) {
+        const EVP_PKEY_METHOD *pmeth = EVP_PKEY_meth_get0(i);
+        int                    id = 0;
+        EVP_PKEY_meth_get0_info(&id, NULL, pmeth);
+        printf("%s\n", OBJ_nid2ln(id));
+    }
+    return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: opensslfeatures [curves|hashes|ciphers|publickey]\n");
+        return 1;
+    }
+    if (!strcmp(argv[1], "hashes")) {
+        return list_hashes();
+    }
+    if (!strcmp(argv[1], "ciphers")) {
+        return list_ciphers();
+    }
+    if (!strcmp(argv[1], "curves")) {
+        return list_curves();
+    }
+    if (!strcmp(argv[1], "publickey")) {
+        return list_publickey();
+    }
+    fprintf(stderr, "Unknown command: %s\n", argv[1]);
+    return 1;
+}

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 if (CRYPTO_BACKEND_OPENSSL)
   include(FindOpenSSL)
   find_package(OpenSSL 1.1.1 REQUIRED)
+  include(FindOpenSSLFeatures)
 endif()
 
 # generate a config.h
@@ -74,13 +75,13 @@ if(CRYPTO_BACKEND_BOTAN)
       # base
       BIGINT FFI HEX_CODEC PGP_S2K
       # symmetric ciphers
-      BLOCK_CIPHER AES BLOWFISH CAMELLIA CAST_128 DES IDEA RIPEMD_160
+      BLOCK_CIPHER AES BLOWFISH CAMELLIA CAST_128 DES IDEA
       # cipher modes
       MODE_CBC MODE_CFB
       # RNG
       AUTO_RNG AUTO_SEEDING_RNG HMAC HMAC_DRBG
       # hash
-      CRC24 HASH MD5 SHA1 SHA2_32 SHA2_64 SHA3
+      CRC24 HASH MD5 SHA1 SHA2_32 SHA2_64 SHA3 RIPEMD_160
       # public-key core
       DL_GROUP DL_PUBLIC_KEY_FAMILY ECC_GROUP ECC_PUBLIC_KEY_CRYPTO PUBLIC_KEY_CRYPTO
       # public-key algs
@@ -107,6 +108,37 @@ if(CRYPTO_BACKEND_BOTAN)
     endif()
   endforeach()
   set(CMAKE_REQUIRED_INCLUDES)
+endif()
+if(CRYPTO_BACKEND_OPENSSL)
+  # check OpenSSL features
+  set(_openssl_required_features
+    # symmetric ciphers
+    AES-128-ECB AES-192-ECB AES-256-ECB AES-128-CBC AES-192-CBC AES-256-CBC
+    BF-ECB CAMELLIA-128-ECB CAMELLIA-192-ECB CAMELLIA-256-ECB CAST5-ECB
+    DES-EDE3 IDEA-ECB IDEA-CBC
+    # hashes
+    MD5 SHA1 SHA224 SHA256 SHA384 SHA512 SHA3-256 SHA3-512 RIPEMD160
+    # curves
+    PRIME256V1 SECP384R1 SECP521R1 SECP256K1
+    # public key
+    RSAENCRYPTION DSAENCRYPTION DHKEYAGREEMENT ID-ECPUBLICKEY X25519 ED25519
+  )
+  # SM2 algorithms suite
+  if (ENABLE_SM2)
+    list(APPEND _openssl_required_features SM2 SM3 SM4-ECB)
+  endif()
+  # Brainpool curves
+  if (ENABLE_BRAINPOOL)
+    list(APPEND _openssl_required_features BRAINPOOLP256R1 BRAINPOOLP384R1 BRAINPOOLP512R1)
+  endif()
+  foreach(feature ${_openssl_required_features})
+    message(STATUS "Looking for OpenSSL feature ${feature}")
+    OpenSSLHasFeature("${feature}" _openssl_has_${feature})
+    if (NOT _openssl_has_${feature})
+      message(FATAL_ERROR "A required OpenSSL feature is missing: ${feature}")
+    endif()
+    message(STATUS "Looking for OpenSSL feature ${feature} - found")
+  endforeach()
 endif()
 
 if(CRYPTO_BACKEND_OPENSSL)

--- a/src/lib/crypto/symmetric_ossl.cpp
+++ b/src/lib/crypto/symmetric_ossl.cpp
@@ -42,7 +42,7 @@ pgp_sa_to_openssl_string(pgp_symm_alg_t alg)
     case PGP_SA_IDEA:
         return "idea-ecb";
     case PGP_SA_TRIPLEDES:
-        return "des-ede3-ecb";
+        return "des-ede3";
     case PGP_SA_CAST5:
         return "cast5-ecb";
     case PGP_SA_BLOWFISH:


### PR DESCRIPTION
This PR adds CMake module which is aimed to check for required OpenSSL features availability.
Currently it doesn't change much, but could be updated later on to be able to enable/disable certain features depending on OpenSSL compile switches.

Fixes #1692 