### PR TITLE
Fix OpenSSL version detection in rnp::backend_version()

### DIFF
--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -114,6 +114,5 @@ jobs:
       - name: tests
         run: |
           set -x
-          export CRYPTO_BACKEND=openssl
           chown -R rnpuser:rnpuser $PWD
           exec su rnpuser -c ci/run.sh


### PR DESCRIPTION
This PR fixes (and slightly refactors) OpenSSL version detection code, which didn't work with dev/beta versions.
Now it should handle all possible cases as from `opensslv.h`.
Also it adds automatic backend detection in `cli_tests.py`.
