### PR TITLE
Support parsing of 'None' algorithm in the compressed packet.

### DIFF
--- a/src/tests/data/test_messages/message.txt.signed-sym-none-z
+++ b/src/tests/data/test_messages/message.txt.signed-sym-none-z
@@ -1,0 +1,2 @@
+Ã	KÉ1F0gàúÒÀÖ|º×„òTãRB]ˆGÝzí ·ó(“ïhªÅ€¥³—û¼#UÕsÞŒg{°ÄÚŽÇ*Cîœˆnm_q‰^#k³t–ó9P2}‹¸Ùó`ùºXKRZZ+hD‰#æ^ *ÙmU‰´³%/ñ2yáyÖÈäÁªÉVÐë<¾>@YTÕi	¤S¥î4;Ä£¸Šà@«>ÒØšÌ4 <˜Qï¨AÊx~è´æ¦jæä‹þ&"‰¤ÅÜp-j‚AnùŽ_°¸hœwœ»%ÄÆº™[,úK_úŒÆ	^,%¼Üœ÷­{5ÜŸ×®
+¦K¤Þ?µþ”BÆÆMŒCn&Ì~À!x&ß•­~õ‘„÷,÷Ò"|×Ò¨™Oàg~•µu>?&k­ÖœÌõªy¢ã&>øÀl,.„`çäRü$=V$^†„Sí?\Q	$’p\†ÍYÞ÷Â˜øNŽà‹fñÿât;ËÇésóßsØT† «~6rè•6±ûÃ™ß|ö]ï);1*éÀÅp"þíZ—r!Ëarêô

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -7297,6 +7297,21 @@ TEST_F(rnp_tests, test_ffi_op_verify_sig_count)
     rnp_input_destroy(input);
     rnp_output_destroy(output);
 
+    /* signed and password-encrypted data with 0 compression algo */
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_messages/message.txt.signed-sym-none-z"));
+    assert_rnp_success(rnp_output_to_null(&output));
+    verify = NULL;
+    assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
+    assert_rnp_success(rnp_op_verify_execute(verify));
+    sigcount = 255;
+    assert_rnp_success(rnp_op_verify_get_signature_count(verify, &sigcount));
+    assert_int_equal(sigcount, 1);
+    assert_true(check_signature(verify, 0, RNP_SUCCESS));
+    rnp_op_verify_destroy(verify);
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+
     /* signed message with one-pass with wrong version */
     assert_rnp_success(
       rnp_input_from_path(&input, "data/test_messages/message.txt.signed-no-z-malf"));


### PR DESCRIPTION
While it's a bit awkward to have additional layer of uncompressed compressed stream, this configuration seems to be generated by other implementations.

I believe we had issue for this but cannot find it right now.
