### PR TITLE
Disable ruby-rnp download where applicable.

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -25,6 +25,7 @@ env:
   LC_LANG: en_US.UTF-8
   USE_STATIC_DEPENDENCIES: yes
   BOTAN_VERSION: 2.17.3 # NOTE: 2.18.x may need newer GCC versions to build
+  DOWNLOAD_RUBYRNP: Off
 
 jobs:
   tests:

--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -24,6 +24,7 @@ env:
   LC_ALL: C.UTF-8
   LC_LANG: C.UTF-8
   USE_STATIC_DEPENDENCIES: yes
+  DOWNLOAD_RUBYRNP: Off
 
 jobs:
   tests:

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -24,6 +24,7 @@ env:
   LC_ALL: C.UTF-8
   LC_LANG: C.UTF-8
   USE_STATIC_DEPENDENCIES: yes
+  DOWNLOAD_RUBYRNP: Off
 
 jobs:
   tests:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,6 +11,7 @@ env:
   GPG_VERSION: stable
   RNP_TESTS: ''
   USE_STATIC_DEPENDENCIES: yes
+  DOWNLOAD_RUBYRNP: Off
 
 jobs:
   scan:


### PR DESCRIPTION
We do not need to download it where we run only rnp_tests/cli_tests.