### PR TITLE
Do not prematurely mark secret keys as valid.

### DIFF
--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -2083,7 +2083,7 @@ pgp_key_t::validate_primary(rnp_key_store_t &keyring)
     validate_self_signatures();
 
     /* consider public key as valid on this level if it is not expired and has at least one
-     * valid self-signature (or it is secret), and is not revoked */
+     * valid self-signature, and is not revoked */
     validity_.reset();
     validity_.validated = true;
     bool has_cert = false;
@@ -2117,8 +2117,8 @@ pgp_key_t::validate_primary(rnp_key_store_t &keyring)
         has_cert = !has_expired;
     }
 
-    /* we have at least one non-expiring key self-signature or secret key */
-    if (has_cert || is_secret()) {
+    /* we have at least one non-expiring key self-signature */
+    if (has_cert) {
         validity_.valid = true;
         return;
     }
@@ -2152,7 +2152,7 @@ void
 pgp_key_t::validate_subkey(pgp_key_t *primary)
 {
     /* consider subkey as valid on this level if it has valid primary key, has at least one
-     * non-expired binding signature (or is secret), and is not revoked. */
+     * non-expired binding signature, and is not revoked. */
     validity_.reset();
     validity_.validated = true;
     if (!primary || !primary->valid()) {
@@ -2180,7 +2180,7 @@ pgp_key_t::validate_subkey(pgp_key_t *primary)
             return;
         }
     }
-    validity_.valid = has_binding || (is_secret() && primary->is_secret());
+    validity_.valid = has_binding;
     if (!validity_.valid) {
         validity_.expired = has_expired;
     }

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -8459,14 +8459,15 @@ TEST_F(rnp_tests, test_ffi_key_set_expiry)
     assert_non_null(key);
     assert_rnp_success(rnp_locate_key(ffi, "keyid", "22F3A217C0E439CB", &sub));
     assert_rnp_success(rnp_key_is_valid(key, &valid));
-    /* key is not valid since function checks public key */
+    /* key is not valid since expired */
     assert_false(valid);
     assert_rnp_success(rnp_key_valid_till(key, &till));
     assert_int_equal(till, 1577369391 + 16324055);
     assert_rnp_success(rnp_key_valid_till64(key, &till64));
     assert_int_equal(till64, 1577369391 + 16324055);
     assert_false(key->pub->valid());
-    assert_true(key->sec->valid());
+    /* secret key part is also not valid till new sig is added */
+    assert_false(key->sec->valid());
     assert_rnp_success(rnp_key_is_valid(sub, &valid));
     assert_false(valid);
     assert_rnp_success(rnp_key_valid_till(sub, &till));
@@ -8475,7 +8476,7 @@ TEST_F(rnp_tests, test_ffi_key_set_expiry)
     assert_rnp_success(rnp_key_valid_till64(sub, &till64));
     assert_int_equal(till64, 1577369391 + 16324055);
     assert_false(sub->pub->valid());
-    assert_true(sub->sec->valid());
+    assert_false(sub->sec->valid());
     creation = 0;
     uint32_t validity = 2 * 30 * 24 * 60 * 60; // 2 monthes
     assert_rnp_success(rnp_key_get_creation(key, &creation));


### PR DESCRIPTION
As it can go wrong in cases of dummy secret keys and so on.
This changes behaviour in tests.
Tests cover the case when new certification is generated by secret key which is not marked as valid.