### PR TITLE
Upload only single report for all tests to the codecov to avoid mess.

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -71,18 +71,7 @@ jobs:
             CXX: clang++
             IMAGE: centos:7
 # Coverage can only been tested with the GNU compiler
-          - BUILD_MODE: coverage
-            GPG_VERSION: beta
-            RNP_TESTS: cli_tests
-            CC: gcc
-            CXX: g++
-            IMAGE: centos:7
-          - BUILD_MODE: coverage
-            GPG_VERSION: beta
-            RNP_TESTS: rnp_tests
-            CC: gcc
-            CXX: g++
-            IMAGE: centos:7
+# Upload only single report from centos8 to the codecov to avoid mess
     name: ${{ matrix.env.IMAGE }} Botan [mode ${{ matrix.env.BUILD_MODE }}; test type ${{ matrix.env.RNP_TESTS }}; CC ${{ matrix.env.CC }}; GnuPG ${{ matrix.env.GPG_VERSION }}]
     env: ${{ matrix.env }}
     steps:

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -68,15 +68,10 @@ jobs:
             CXX: clang++
             IMAGE: centos:8
 # Coverage can only been tested with the GNU compiler
+# Upload only single report to the codecov to avoid mess
           - BUILD_MODE: coverage
             GPG_VERSION: beta
-            RNP_TESTS: cli_tests
-            CC: gcc
-            CXX: g++
-            IMAGE: centos:8
-          - BUILD_MODE: coverage
-            GPG_VERSION: beta
-            RNP_TESTS: rnp_tests
+            RNP_TESTS: ".*"
             CC: gcc
             CXX: g++
             IMAGE: centos:8

--- a/ci/success.sh
+++ b/ci/success.sh
@@ -11,6 +11,6 @@ if [ "$BUILD_MODE" = "coverage" ]; then
     gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
     shasum -a 256 -c codecov.SHA256SUM
     chmod +x codecov
-    find "${LOCAL_BUILDS}/rnp-build/" -type f -name '*.gcno' -exec gcov {} +
+    find "${LOCAL_BUILDS}/rnp-build/" -type f -name '*.gcno' -exec gcov -p {} +
     ./codecov
 fi


### PR DESCRIPTION
As I understand now, codecov uses only latest uploaded report from the PR, i.e. it can go messy for multiple test runs (and different for cli_tests and rnp_tests runs). So this PR changes to run single pass on centos8. Let's see how it goes.

Feel free to correct me if this works in a different way.