### PR TITLE
Make pgp_signature_t::keyid() and pgp_signature_t::keyfp() noexcept.

### DIFF
--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -648,7 +648,7 @@ pgp_signature_t::has_keyid() const
 }
 
 pgp_key_id_t
-pgp_signature_t::keyid() const
+pgp_signature_t::keyid() const noexcept
 {
     /* version 3 uses signature field */
     if (version < PGP_V4) {
@@ -656,7 +656,7 @@ pgp_signature_t::keyid() const
     }
 
     /* version 4 and up use subpackets */
-    pgp_key_id_t res;
+    pgp_key_id_t res{};
     static_assert(std::tuple_size<decltype(res)>::value == PGP_KEY_ID_SIZE,
                   "pgp_key_id_t size mismatch");
 
@@ -671,7 +671,7 @@ pgp_signature_t::keyid() const
                PGP_KEY_ID_SIZE);
         return res;
     }
-    throw rnp::rnp_exception(RNP_ERROR_BAD_PARAMETERS);
+    return res;
 }
 
 void
@@ -703,15 +703,15 @@ pgp_signature_t::has_keyfp() const
 }
 
 pgp_fingerprint_t
-pgp_signature_t::keyfp() const
+pgp_signature_t::keyfp() const noexcept
 {
+    pgp_fingerprint_t res{};
     if (version < PGP_V4) {
-        throw rnp::rnp_exception(RNP_ERROR_BAD_STATE);
+        return res;
     }
     const pgp_sig_subpkt_t *subpkt = get_subpkt(PGP_SIG_SUBPKT_ISSUER_FPR);
-    pgp_fingerprint_t       res;
     if (!subpkt || (subpkt->fields.issuer_fp.len > sizeof(res.fingerprint))) {
-        throw rnp::rnp_exception(RNP_ERROR_BAD_STATE);
+        return res;
     }
     res.length = subpkt->fields.issuer_fp.len;
     memcpy(res.fingerprint, subpkt->fields.issuer_fp.fp, subpkt->fields.issuer_fp.len);

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -105,9 +105,9 @@ typedef struct pgp_signature_t {
     bool has_keyid() const;
     /**
      * @brief Get signer's key id if available. Availability may be checked via has_keyid().
-     * @return signer's key id if available, or throws an exception otherwise.
+     * @return signer's key id if available, or empty (zero-filled) keyid otherwise.
      */
-    pgp_key_id_t keyid() const;
+    pgp_key_id_t keyid() const noexcept;
     /** @brief Set the signer's key id for the signature being populated. Version should be set
      *         prior of setting key id. */
     void set_keyid(const pgp_key_id_t &id);
@@ -120,9 +120,9 @@ typedef struct pgp_signature_t {
     /**
      * @brief Get signing key's fingerprint if it is available. Availability may be checked via
      *        has_keyfp() method.
-     * @return fingerprint or throws an error if it is unavailable.
+     * @return fingerprint (or empty zero-size fp in case it is unavailable)
      */
-    pgp_fingerprint_t keyfp() const;
+    pgp_fingerprint_t keyfp() const noexcept;
 
     /** @brief Set signing key's fingerprint. Works only for signatures with version 4 and up,
      *         so version should be set prior to fingerprint. */


### PR DESCRIPTION
Fixes Coverity issues 1764240 and 1764241.