### PR TITLE
Use single RNG in library code and refactor RNG class.

### DIFF
--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -152,7 +152,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t &crypto,
     seckey.sec_protection.s2k.usage = PGP_S2KU_NONE;
     seckey.material.secret = true;
     /* fill the sec_data/sec_len */
-    if (encrypt_secret_key(&seckey, NULL, NULL)) {
+    if (encrypt_secret_key(&seckey, NULL, *crypto.rng)) {
         RNP_LOG("failed to fill sec_data");
         return false;
     }

--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -191,7 +191,7 @@ key_material_equal(const pgp_key_material_t *key1, const pgp_key_material_t *key
 }
 
 rnp_result_t
-validate_pgp_key_material(const pgp_key_material_t *material, rng_t *rng)
+validate_pgp_key_material(const pgp_key_material_t *material, rnp::RNG *rng)
 {
 #ifdef FUZZERS_ENABLED
     /* do not timeout on large keys during fuzzing */

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -116,7 +116,7 @@ bool pgp_generate_subkey(rnp_keygen_subkey_desc_t &     desc,
  *  @param subkey_pub pointer to store the generated public key, must not be NULL
  *  @return true if successful, false otherwise.
  **/
-bool pgp_generate_keypair(rng_t &                    rng,
+bool pgp_generate_keypair(rnp::RNG &                 rng,
                           rnp_keygen_primary_desc_t &primary_desc,
                           rnp_keygen_subkey_desc_t & subkey_desc,
                           bool                       merge_defaults,
@@ -136,6 +136,6 @@ bool pgp_generate_keypair(rng_t &                    rng,
  */
 bool key_material_equal(const pgp_key_material_t *key1, const pgp_key_material_t *key2);
 
-rnp_result_t validate_pgp_key_material(const pgp_key_material_t *material, rng_t *rng);
+rnp_result_t validate_pgp_key_material(const pgp_key_material_t *material, rnp::RNG *rng);
 
 #endif /* CRYPTO_H_ */

--- a/src/lib/crypto/dsa.cpp
+++ b/src/lib/crypto/dsa.cpp
@@ -87,7 +87,7 @@
 #define DSA_MAX_Q_BITLEN 256
 
 rnp_result_t
-dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret)
+dsa_validate_key(rnp::RNG *rng, const pgp_dsa_key_t *key, bool secret)
 {
     bignum_t *      p = NULL;
     bignum_t *      q = NULL;
@@ -115,7 +115,7 @@ dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret)
         goto done;
     }
 
-    if (botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+    if (botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
 
@@ -136,7 +136,7 @@ dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret)
         goto done;
     }
 
-    if (botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+    if (botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
 
@@ -153,7 +153,7 @@ done:
 }
 
 rnp_result_t
-dsa_sign(rng_t *              rng,
+dsa_sign(rnp::RNG *           rng,
          pgp_dsa_signature_t *sig,
          const uint8_t *      hash,
          size_t               hash_len,
@@ -204,7 +204,7 @@ dsa_sign(rng_t *              rng,
         goto end;
     }
 
-    if (botan_pk_op_sign_finish(sign_op, rng_handle(rng), sign_buf, &sigbuf_size)) {
+    if (botan_pk_op_sign_finish(sign_op, rng->handle(), sign_buf, &sigbuf_size)) {
         RNP_LOG("Signing has failed");
         goto end;
     }
@@ -299,7 +299,7 @@ end:
 }
 
 rnp_result_t
-dsa_generate(rng_t *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits)
+dsa_generate(rnp::RNG *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits)
 {
     if ((keylen < 1024) || (keylen > 3072) || (qbits < 160) || (qbits > 256)) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -319,8 +319,8 @@ dsa_generate(rng_t *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits)
         goto end;
     }
 
-    if (botan_privkey_create_dsa(&key_priv, rng_handle(rng), keylen, qbits) ||
-        botan_privkey_check_key(key_priv, rng_handle(rng), 1) ||
+    if (botan_privkey_create_dsa(&key_priv, rng->handle(), keylen, qbits) ||
+        botan_privkey_check_key(key_priv, rng->handle(), 1) ||
         botan_privkey_export_pubkey(&key_pub, key_priv)) {
         RNP_LOG("Wrong parameters");
         ret = RNP_ERROR_BAD_PARAMETERS;

--- a/src/lib/crypto/dsa.h
+++ b/src/lib/crypto/dsa.h
@@ -59,7 +59,7 @@ typedef struct pgp_dsa_signature_t {
  *
  * @return RNP_SUCCESS if key is valid or error code otherwise
  */
-rnp_result_t dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret);
+rnp_result_t dsa_validate_key(rnp::RNG *rng, const pgp_dsa_key_t *key, bool secret);
 
 /*
  * @brief   Performs DSA signing
@@ -74,7 +74,7 @@ rnp_result_t dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret)
  *          RNP_ERROR_BAD_PARAMETERS wrong input provided
  *          RNP_ERROR_SIGNING_FAILED internal error
  */
-rnp_result_t dsa_sign(rng_t *              rng,
+rnp_result_t dsa_sign(rnp::RNG *           rng,
                       pgp_dsa_signature_t *sig,
                       const uint8_t *      hash,
                       size_t               hash_len,
@@ -112,7 +112,7 @@ rnp_result_t dsa_verify(const pgp_dsa_signature_t *sig,
  *          RNP_ERROR_GENERIC internal error
  *          RNP_ERROR_SIGNATURE_INVALID signature is invalid
  */
-rnp_result_t dsa_generate(rng_t *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits);
+rnp_result_t dsa_generate(rnp::RNG *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits);
 
 /*
  * @brief   Returns minimally sized hash which will work

--- a/src/lib/crypto/dsa_ossl.cpp
+++ b/src/lib/crypto/dsa_ossl.cpp
@@ -140,7 +140,7 @@ done:
 }
 
 rnp_result_t
-dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret)
+dsa_validate_key(rnp::RNG *rng, const pgp_dsa_key_t *key, bool secret)
 {
     /* OpenSSL doesn't implement key checks for the DSA, however we may use DL via DH */
     EVP_PKEY *pkey = dl_load_key(key->p, &key->q, key->g, key->y, NULL);
@@ -154,7 +154,7 @@ dsa_validate_key(rng_t *rng, const pgp_dsa_key_t *key, bool secret)
 }
 
 rnp_result_t
-dsa_sign(rng_t *              rng,
+dsa_sign(rnp::RNG *           rng,
          pgp_dsa_signature_t *sig,
          const uint8_t *      hash,
          size_t               hash_len,
@@ -240,7 +240,7 @@ done:
 }
 
 rnp_result_t
-dsa_generate(rng_t *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits)
+dsa_generate(rnp::RNG *rng, pgp_dsa_key_t *key, size_t keylen, size_t qbits)
 {
     if ((keylen < 1024) || (keylen > 3072) || (qbits < 160) || (qbits > 256)) {
         return RNP_ERROR_BAD_PARAMETERS;

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -41,7 +41,7 @@ static id_str_pair ec_algo_to_botan[] = {
 };
 
 rnp_result_t
-x25519_generate(rng_t *rng, pgp_ec_key_t *key)
+x25519_generate(rnp::RNG *rng, pgp_ec_key_t *key)
 {
     botan_privkey_t pr_key = NULL;
     botan_pubkey_t  pu_key = NULL;
@@ -49,7 +49,7 @@ x25519_generate(rng_t *rng, pgp_ec_key_t *key)
 
     rnp::secure_array<uint8_t, 32> keyle;
 
-    if (botan_privkey_create(&pr_key, "Curve25519", "", rng_handle(rng))) {
+    if (botan_privkey_create(&pr_key, "Curve25519", "", rng->handle())) {
         goto end;
     }
 
@@ -84,7 +84,7 @@ end:
 }
 
 rnp_result_t
-ec_generate(rng_t *                rng,
+ec_generate(rnp::RNG *             rng,
             pgp_ec_key_t *         key,
             const pgp_pubkey_alg_t alg_id,
             const pgp_curve_t      curve)
@@ -117,7 +117,7 @@ ec_generate(rng_t *                rng,
     filed_byte_size = BITS_TO_BYTES(ec_desc->bitlen);
 
     // at this point it must succeed
-    if (botan_privkey_create(&pr_key, ec_algo, ec_desc->botan_name, rng_handle(rng))) {
+    if (botan_privkey_create(&pr_key, ec_algo, ec_desc->botan_name, rng->handle())) {
         goto end;
     }
 

--- a/src/lib/crypto/ec.h
+++ b/src/lib/crypto/ec.h
@@ -126,7 +126,7 @@ bool curve_supported(pgp_curve_t curve);
 /*
  * @brief   Generates EC key in uncompressed format
  *
- * @param   rng initialized rng_t context*
+ * @param   rng initialized rnp::RNG context*
  * @param   key key data to be generated
  * @param   alg_id ID of EC algorithm
  * @param   curve underlying ECC curve ID
@@ -137,7 +137,7 @@ bool curve_supported(pgp_curve_t curve);
  * @returns RNP_ERROR_OUT_OF_MEMORY memory allocation failed
  * @returns RNP_ERROR_KEY_GENERATION implementation error
  */
-rnp_result_t ec_generate(rng_t *                rng,
+rnp_result_t ec_generate(rnp::RNG *             rng,
                          pgp_ec_key_t *         key,
                          const pgp_pubkey_alg_t alg_id,
                          const pgp_curve_t      curve);
@@ -145,12 +145,12 @@ rnp_result_t ec_generate(rng_t *                rng,
 /*
  * @brief   Generates x25519 ECDH key in x25519-specific format
  *
- * @param   rng initialized rng_t context*
+ * @param   rng initialized rnp::RNG context*
  * @param   key key data to be generated
  *
  * @returns RNP_ERROR_KEY_GENERATION implementation error
  */
-rnp_result_t x25519_generate(rng_t *rng, pgp_ec_key_t *key);
+rnp_result_t x25519_generate(rnp::RNG *rng, pgp_ec_key_t *key);
 
 /**
  * @brief Set least significant/most significant bits of the 25519 secret key as per

--- a/src/lib/crypto/ec_ossl.cpp
+++ b/src/lib/crypto/ec_ossl.cpp
@@ -44,7 +44,7 @@ ec_is_raw_key(const pgp_curve_t curve)
 }
 
 rnp_result_t
-x25519_generate(rng_t *rng, pgp_ec_key_t *key)
+x25519_generate(rnp::RNG *rng, pgp_ec_key_t *key)
 {
     return ec_generate(rng, key, PGP_PKA_ECDH, PGP_CURVE_25519);
 }
@@ -108,7 +108,7 @@ ec_write_raw_seckey(EVP_PKEY *pkey, pgp_ec_key_t *key)
 }
 
 rnp_result_t
-ec_generate(rng_t *                rng,
+ec_generate(rnp::RNG *             rng,
             pgp_ec_key_t *         key,
             const pgp_pubkey_alg_t alg_id,
             const pgp_curve_t      curve)

--- a/src/lib/crypto/ecdh.cpp
+++ b/src/lib/crypto/ecdh.cpp
@@ -152,7 +152,7 @@ ecdh_load_secret_key(botan_privkey_t *seckey, const pgp_ec_key_t *key)
 }
 
 rnp_result_t
-ecdh_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+ecdh_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     botan_pubkey_t  bpkey = NULL;
     botan_privkey_t bskey = NULL;
@@ -164,7 +164,7 @@ ecdh_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!ecdh_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+        botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
     if (!secret) {
@@ -173,7 +173,7 @@ ecdh_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!ecdh_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+        botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;
@@ -184,7 +184,7 @@ done:
 }
 
 rnp_result_t
-ecdh_encrypt_pkcs5(rng_t *                  rng,
+ecdh_encrypt_pkcs5(rnp::RNG *               rng,
                    pgp_ecdh_encrypted_t *   out,
                    const uint8_t *const     in,
                    size_t                   in_len,
@@ -231,12 +231,12 @@ ecdh_encrypt_pkcs5(rng_t *                  rng,
     }
 
     if (!strcmp(curve_desc->botan_name, "curve25519")) {
-        if (botan_privkey_create(&eph_prv_key, "Curve25519", "", rng_handle(rng))) {
+        if (botan_privkey_create(&eph_prv_key, "Curve25519", "", rng->handle())) {
             goto end;
         }
     } else {
         if (botan_privkey_create(
-              &eph_prv_key, "ECDH", curve_desc->botan_name, rng_handle(rng))) {
+              &eph_prv_key, "ECDH", curve_desc->botan_name, rng->handle())) {
             goto end;
         }
     }

--- a/src/lib/crypto/ecdh.h
+++ b/src/lib/crypto/ecdh.h
@@ -45,7 +45,7 @@ typedef struct pgp_ecdh_encrypted_t {
     size_t    mlen;
 } pgp_ecdh_encrypted_t;
 
-rnp_result_t ecdh_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret);
+rnp_result_t ecdh_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret);
 
 /*
  * @brief   Sets hash algorithm and key wrapping algo
@@ -62,7 +62,7 @@ bool ecdh_set_params(pgp_ec_key_t *key, pgp_curve_t curve_id);
  * Encrypts session key with a KEK agreed during ECDH as specified in
  * RFC 4880 bis 01, 13.5
  *
- * @param rng initialized rng_t object
+ * @param rng initialized rnp::RNG object
  * @param session_key key to be encrypted
  * @param session_key_len length of the key buffer
  * @param wrapped_key [out] resulting key wrapped in by some AES
@@ -81,7 +81,7 @@ bool ecdh_set_params(pgp_ec_key_t *key, pgp_curve_t curve_id);
  * @return RNP_ERROR_SHORT_BUFFER `wrapped_key_len' to small to store result
  * @return RNP_ERROR_GENERIC implementation error
  */
-rnp_result_t ecdh_encrypt_pkcs5(rng_t *                  rng,
+rnp_result_t ecdh_encrypt_pkcs5(rnp::RNG *               rng,
                                 pgp_ecdh_encrypted_t *   out,
                                 const uint8_t *const     in,
                                 size_t                   in_len,

--- a/src/lib/crypto/ecdh_ossl.cpp
+++ b/src/lib/crypto/ecdh_ossl.cpp
@@ -46,7 +46,7 @@ static const struct ecdh_wrap_alg_map_t {
                          {PGP_SA_AES_256, "aes256-wrap"}};
 
 rnp_result_t
-ecdh_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+ecdh_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     return ec_validate_key(*key, secret);
 }
@@ -237,7 +237,7 @@ ecdh_kek_len(pgp_symm_alg_t wrap_alg)
 }
 
 rnp_result_t
-ecdh_encrypt_pkcs5(rng_t *                  rng,
+ecdh_encrypt_pkcs5(rnp::RNG *               rng,
                    pgp_ecdh_encrypted_t *   out,
                    const uint8_t *const     in,
                    size_t                   in_len,

--- a/src/lib/crypto/ecdsa.cpp
+++ b/src/lib/crypto/ecdsa.cpp
@@ -85,14 +85,14 @@ ecdsa_load_secret_key(botan_privkey_t *seckey, const pgp_ec_key_t *keydata)
 }
 
 rnp_result_t
-ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+ecdsa_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     botan_pubkey_t  bpkey = NULL;
     botan_privkey_t bskey = NULL;
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
 
     if (!ecdsa_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+        botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
     if (!secret) {
@@ -101,7 +101,7 @@ ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!ecdsa_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+        botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;
@@ -143,7 +143,7 @@ ecdsa_padding_str_for(pgp_hash_alg_t hash_alg)
 }
 
 rnp_result_t
-ecdsa_sign(rng_t *             rng,
+ecdsa_sign(rnp::RNG *          rng,
            pgp_ec_signature_t *sig,
            pgp_hash_alg_t      hash_alg,
            const uint8_t *     hash,
@@ -176,7 +176,7 @@ ecdsa_sign(rng_t *             rng,
         goto end;
     }
 
-    if (botan_pk_op_sign_finish(signer, rng_handle(rng), out_buf, &sig_len)) {
+    if (botan_pk_op_sign_finish(signer, rng->handle(), out_buf, &sig_len)) {
         RNP_LOG("Signing failed");
         goto end;
     }

--- a/src/lib/crypto/ecdsa.h
+++ b/src/lib/crypto/ecdsa.h
@@ -29,9 +29,9 @@
 
 #include "crypto/ec.h"
 
-rnp_result_t ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret);
+rnp_result_t ecdsa_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret);
 
-rnp_result_t ecdsa_sign(rng_t *             rng,
+rnp_result_t ecdsa_sign(rnp::RNG *          rng,
                         pgp_ec_signature_t *sig,
                         pgp_hash_alg_t      hash_alg,
                         const uint8_t *     hash,

--- a/src/lib/crypto/ecdsa_ossl.cpp
+++ b/src/lib/crypto/ecdsa_ossl.cpp
@@ -79,13 +79,13 @@ done:
 }
 
 rnp_result_t
-ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+ecdsa_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     return ec_validate_key(*key, secret);
 }
 
 rnp_result_t
-ecdsa_sign(rng_t *             rng,
+ecdsa_sign(rnp::RNG *          rng,
            pgp_ec_signature_t *sig,
            pgp_hash_alg_t      hash_alg,
            const uint8_t *     hash,

--- a/src/lib/crypto/eddsa.cpp
+++ b/src/lib/crypto/eddsa.cpp
@@ -70,14 +70,14 @@ eddsa_load_secret_key(botan_privkey_t *seckey, const pgp_ec_key_t *keydata)
 }
 
 rnp_result_t
-eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+eddsa_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     botan_pubkey_t  bpkey = NULL;
     botan_privkey_t bskey = NULL;
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
 
     if (!eddsa_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+        botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
 
@@ -87,7 +87,7 @@ eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!eddsa_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+        botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;
@@ -98,13 +98,13 @@ done:
 }
 
 rnp_result_t
-eddsa_generate(rng_t *rng, pgp_ec_key_t *key)
+eddsa_generate(rnp::RNG *rng, pgp_ec_key_t *key)
 {
     botan_privkey_t eddsa = NULL;
     rnp_result_t    ret = RNP_ERROR_GENERIC;
     uint8_t         key_bits[64];
 
-    if (botan_privkey_create(&eddsa, "Ed25519", NULL, rng_handle(rng)) != 0) {
+    if (botan_privkey_create(&eddsa, "Ed25519", NULL, rng->handle()) != 0) {
         goto end;
     }
 
@@ -168,7 +168,7 @@ done:
 }
 
 rnp_result_t
-eddsa_sign(rng_t *             rng,
+eddsa_sign(rnp::RNG *          rng,
            pgp_ec_signature_t *sig,
            const uint8_t *     hash,
            size_t              hash_len,
@@ -193,7 +193,7 @@ eddsa_sign(rng_t *             rng,
         goto done;
     }
 
-    if (botan_pk_op_sign_finish(sign_op, rng_handle(rng), bn_buf, &sig_size) != 0) {
+    if (botan_pk_op_sign_finish(sign_op, rng->handle(), bn_buf, &sig_size) != 0) {
         goto done;
     }
 

--- a/src/lib/crypto/eddsa.h
+++ b/src/lib/crypto/eddsa.h
@@ -33,19 +33,19 @@
 
 #include "ec.h"
 
-rnp_result_t eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret);
+rnp_result_t eddsa_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret);
 /*
  * curve_len must be 255 currently (for Ed25519)
  * If Ed448 was supported in the future curve_len=448 would also be allowed.
  */
-rnp_result_t eddsa_generate(rng_t *rng, pgp_ec_key_t *key);
+rnp_result_t eddsa_generate(rnp::RNG *rng, pgp_ec_key_t *key);
 
 rnp_result_t eddsa_verify(const pgp_ec_signature_t *sig,
                           const uint8_t *           hash,
                           size_t                    hash_len,
                           const pgp_ec_key_t *      key);
 
-rnp_result_t eddsa_sign(rng_t *             rng,
+rnp_result_t eddsa_sign(rnp::RNG *          rng,
                         pgp_ec_signature_t *sig,
                         const uint8_t *     hash,
                         size_t              hash_len,

--- a/src/lib/crypto/eddsa_ossl.cpp
+++ b/src/lib/crypto/eddsa_ossl.cpp
@@ -37,7 +37,7 @@
 #include <openssl/ec.h>
 
 rnp_result_t
-eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+eddsa_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     /* Not implemented in the OpenSSL, so just do basic size checks. */
     if ((mpi_bytes(&key->p) != 33) || (key->p.mpi[0] != 0x40)) {
@@ -50,7 +50,7 @@ eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
 }
 
 rnp_result_t
-eddsa_generate(rng_t *rng, pgp_ec_key_t *key)
+eddsa_generate(rnp::RNG *rng, pgp_ec_key_t *key)
 {
     rnp_result_t ret = ec_generate(rng, key, PGP_PKA_EDDSA, PGP_CURVE_ED25519);
     if (!ret) {
@@ -107,7 +107,7 @@ done:
 }
 
 rnp_result_t
-eddsa_sign(rng_t *             rng,
+eddsa_sign(rnp::RNG *          rng,
            pgp_ec_signature_t *sig,
            const uint8_t *     hash,
            size_t              hash_len,

--- a/src/lib/crypto/elgamal.cpp
+++ b/src/lib/crypto/elgamal.cpp
@@ -142,7 +142,7 @@ done:
 }
 
 rnp_result_t
-elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secret)
+elgamal_validate_key(rnp::RNG *rng, const pgp_eg_key_t *key, bool secret)
 {
     botan_pubkey_t  bpkey = NULL;
     botan_privkey_t bskey = NULL;
@@ -150,7 +150,7 @@ elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secret)
 
     // Check if provided public key byte size is not greater than ELGAMAL_MAX_P_BYTELEN.
     if (!elgamal_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+        botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
 
@@ -160,7 +160,7 @@ elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secret)
     }
 
     if (!elgamal_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+        botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;
@@ -171,7 +171,7 @@ done:
 }
 
 rnp_result_t
-elgamal_encrypt_pkcs1(rng_t *             rng,
+elgamal_encrypt_pkcs1(rnp::RNG *          rng,
                       pgp_eg_encrypted_t *out,
                       const uint8_t *     in,
                       size_t              in_len,
@@ -198,7 +198,7 @@ elgamal_encrypt_pkcs1(rng_t *             rng,
     p_len = mpi_bytes(&key->p) * 2;
 
     if (botan_pk_op_encrypt_create(&op_ctx, b_key, "PKCS1v15", 0) ||
-        botan_pk_op_encrypt(op_ctx, rng_handle(rng), enc_buf, &p_len, in, in_len)) {
+        botan_pk_op_encrypt(op_ctx, rng->handle(), enc_buf, &p_len, in, in_len)) {
         RNP_LOG("Failed to create operation context");
         goto end;
     }
@@ -225,7 +225,7 @@ end:
 }
 
 rnp_result_t
-elgamal_decrypt_pkcs1(rng_t *                   rng,
+elgamal_decrypt_pkcs1(rnp::RNG *                rng,
                       uint8_t *                 out,
                       size_t *                  out_len,
                       const pgp_eg_encrypted_t *in,
@@ -279,7 +279,7 @@ end:
 }
 
 rnp_result_t
-elgamal_generate(rng_t *rng, pgp_eg_key_t *key, size_t keybits)
+elgamal_generate(rnp::RNG *rng, pgp_eg_key_t *key, size_t keybits)
 {
     if ((keybits < 1024) || (keybits > PGP_MPINT_BITS)) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -298,7 +298,7 @@ elgamal_generate(rng_t *rng, pgp_eg_key_t *key, size_t keybits)
     }
 
 start:
-    if (botan_privkey_create_elgamal(&key_priv, rng_handle(rng), keybits, keybits - 1)) {
+    if (botan_privkey_create_elgamal(&key_priv, rng->handle(), keybits, keybits - 1)) {
         RNP_LOG("Wrong parameters");
         ret = RNP_ERROR_BAD_PARAMETERS;
         goto end;

--- a/src/lib/crypto/elgamal.h
+++ b/src/lib/crypto/elgamal.h
@@ -55,13 +55,13 @@ typedef struct pgp_eg_encrypted_t {
     pgp_mpi_t m;
 } pgp_eg_encrypted_t;
 
-rnp_result_t elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secret);
+rnp_result_t elgamal_validate_key(rnp::RNG *rng, const pgp_eg_key_t *key, bool secret);
 
 /*
  * Performs ElGamal encryption
  * Result of an encryption is composed of two parts - g2k and encm
  *
- * @param rng initialized rng_t
+ * @param rng initialized rnp::RNG
  * @param out encryption result
  * @param in plaintext to be encrypted
  * @param in_len length of the plaintext
@@ -74,7 +74,7 @@ rnp_result_t elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secr
  *         RNP_ERROR_OUT_OF_MEMORY  allocation failure
  *         RNP_ERROR_BAD_PARAMETERS wrong input provided
  */
-rnp_result_t elgamal_encrypt_pkcs1(rng_t *             rng,
+rnp_result_t elgamal_encrypt_pkcs1(rnp::RNG *          rng,
                                    pgp_eg_encrypted_t *out,
                                    const uint8_t *     in,
                                    size_t              in_len,
@@ -83,7 +83,7 @@ rnp_result_t elgamal_encrypt_pkcs1(rng_t *             rng,
 /*
  * Performs ElGamal decryption
  *
- * @param rng initialized rng_t
+ * @param rng initialized rnp::RNG
  * @param out decrypted plaintext. Must be capable of storing at least as much bytes as p size
  * @param out_len number of plaintext bytes written will be put here
  * @param in encrypted data
@@ -97,7 +97,7 @@ rnp_result_t elgamal_encrypt_pkcs1(rng_t *             rng,
  *         RNP_ERROR_OUT_OF_MEMORY  allocation failure
  *         RNP_ERROR_BAD_PARAMETERS wrong input provided
  */
-rnp_result_t elgamal_decrypt_pkcs1(rng_t *                   rng,
+rnp_result_t elgamal_decrypt_pkcs1(rnp::RNG *                rng,
                                    uint8_t *                 out,
                                    size_t *                  out_len,
                                    const pgp_eg_encrypted_t *in,
@@ -116,5 +116,5 @@ rnp_result_t elgamal_decrypt_pkcs1(rng_t *                   rng,
  *          RNP_ERROR_GENERIC internal error
  *          RNP_SUCCESS key generated and copied to `seckey'
  */
-rnp_result_t elgamal_generate(rng_t *rng, pgp_eg_key_t *key, size_t keybits);
+rnp_result_t elgamal_generate(rnp::RNG *rng, pgp_eg_key_t *key, size_t keybits);
 #endif

--- a/src/lib/crypto/elgamal_ossl.cpp
+++ b/src/lib/crypto/elgamal_ossl.cpp
@@ -41,7 +41,7 @@
 #define ELGAMAL_MAX_P_BYTELEN BITS_TO_BYTES(PGP_MPINT_BITS)
 
 rnp_result_t
-elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secret)
+elgamal_validate_key(rnp::RNG *rng, const pgp_eg_key_t *key, bool secret)
 {
     /* OpenSSL doesn't implement ElGamal, however we may use DL via DH */
     EVP_PKEY *pkey = dl_load_key(key->p, NULL, key->g, key->y, NULL);
@@ -106,7 +106,7 @@ pkcs1v15_unpad(size_t *padlen, const uint8_t *in, size_t in_len, bool skip0)
 }
 
 rnp_result_t
-elgamal_encrypt_pkcs1(rng_t *             rng,
+elgamal_encrypt_pkcs1(rnp::RNG *          rng,
                       pgp_eg_encrypted_t *out,
                       const uint8_t *     in,
                       size_t              in_len,
@@ -185,7 +185,7 @@ done:
 }
 
 rnp_result_t
-elgamal_decrypt_pkcs1(rng_t *                   rng,
+elgamal_decrypt_pkcs1(rnp::RNG *                rng,
                       uint8_t *                 out,
                       size_t *                  out_len,
                       const pgp_eg_encrypted_t *in,
@@ -267,7 +267,7 @@ done:
 }
 
 rnp_result_t
-elgamal_generate(rng_t *rng, pgp_eg_key_t *key, size_t keybits)
+elgamal_generate(rnp::RNG *rng, pgp_eg_key_t *key, size_t keybits)
 {
     if ((keybits < 1024) || (keybits > PGP_MPINT_BITS)) {
         return RNP_ERROR_BAD_PARAMETERS;

--- a/src/lib/crypto/elgamal_ossl.cpp
+++ b/src/lib/crypto/elgamal_ossl.cpp
@@ -65,14 +65,13 @@ pkcs1v15_pad(uint8_t *out, size_t out_len, const uint8_t *in, size_t in_len)
     out[1] = 0x02;
     size_t rnd = out_len - in_len - 3;
     out[2 + rnd] = 0x00;
-    if (!rng_generate(&out[2], rnd)) {
+    if (RAND_bytes(&out[2], rnd) != 1) {
         return false;
     }
     for (size_t i = 2; i < 2 + rnd; i++) {
         /* we need non-zero bytes */
         size_t cntr = 16;
-        while (!out[i] && cntr) {
-            rng_generate(&out[i], 1);
+        while (!out[i] && (cntr--) && (RAND_bytes(&out[i], 1) == 1)) {
         }
         if (!out[i]) {
             RNP_LOG("Something is wrong with RNG.");

--- a/src/lib/crypto/rng.cpp
+++ b/src/lib/crypto/rng.cpp
@@ -1,101 +1,59 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
- * Copyright (c) 2009 The NetBSD Foundation, Inc.
+ * Copyright (c) 2017-2021, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
- * This code is originally derived from software contributed to
- * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
- * carried further by Ribose Inc (https://www.ribose.com).
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>
 #include <botan/ffi.h>
 #include "rng.h"
+#include "types.h"
 
-static inline bool
-rng_ensure_initialized(rng_t *ctx)
+namespace rnp {
+RNG::RNG(Type type)
 {
-    assert(ctx);
-    if (ctx->initialized) {
-        return true;
+    if (botan_rng_init(&botan_rng, type == Type::DRBG ? "user" : NULL)) {
+        throw rnp::rnp_exception(RNP_ERROR_RNG);
     }
-
-    ctx->initialized =
-      !botan_rng_init(&ctx->botan_rng, ctx->rng_type == RNG_DRBG ? "user" : NULL);
-    return ctx->initialized;
 }
 
-bool
-rng_init(rng_t *ctx, rng_type_t rng_type)
+RNG::~RNG()
 {
-    if (!ctx) {
-        return false;
-    }
-
-    if ((rng_type != RNG_DRBG) && (rng_type != RNG_SYSTEM)) {
-        return false;
-    }
-
-    ctx->initialized = false;
-    ctx->rng_type = rng_type;
-    return (rng_type == RNG_SYSTEM) ? rng_ensure_initialized(ctx) : true;
+    (void) botan_rng_destroy(botan_rng);
 }
 
 void
-rng_destroy(rng_t *ctx)
+RNG::get(uint8_t *data, size_t len)
 {
-    if (!ctx || !ctx->initialized) {
-        return;
-    }
-
-    (void) botan_rng_destroy(ctx->botan_rng);
-    ctx->botan_rng = NULL;
-    ctx->initialized = false;
-}
-
-bool
-rng_get_data(rng_t *ctx, uint8_t *data, size_t len)
-{
-    if (!ctx) {
-        return false;
-    }
-
-    if (!rng_ensure_initialized(ctx)) {
-        return false;
-    }
-
-    if (botan_rng_get(ctx->botan_rng, data, len)) {
+    if (botan_rng_get(botan_rng, data, len)) {
         // This should never happen
-        return false;
+        throw rnp::rnp_exception(RNP_ERROR_RNG);
     }
-
-    return true;
 }
 
 struct botan_rng_struct *
-rng_handle(rng_t *ctx)
+RNG::handle()
 {
-    (void) rng_ensure_initialized(ctx);
-    return ctx->initialized ? ctx->botan_rng : NULL;
+    return botan_rng;
 }
+} // namespace rnp

--- a/src/lib/crypto/rng.cpp
+++ b/src/lib/crypto/rng.cpp
@@ -99,15 +99,3 @@ rng_handle(rng_t *ctx)
     (void) rng_ensure_initialized(ctx);
     return ctx->initialized ? ctx->botan_rng : NULL;
 }
-
-bool
-rng_generate(uint8_t *data, size_t data_len)
-{
-    botan_rng_t rng;
-    if (botan_rng_init(&rng, NULL)) {
-        return false;
-    }
-    const bool rc = botan_rng_get(rng, data, data_len) == 0;
-    (void) botan_rng_destroy(rng);
-    return rc;
-}

--- a/src/lib/crypto/rng.h
+++ b/src/lib/crypto/rng.h
@@ -1,100 +1,78 @@
 /*
- * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
- * Copyright (c) 2009 The NetBSD Foundation, Inc.
+ * Copyright (c) 2017-2021, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
- * This code is originally derived from software contributed to
- * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
- * carried further by Ribose Inc (https://www.ribose.com).
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef RNP_RANDOM_H_
-#define RNP_RANDOM_H_
+#ifndef RNP_RNG_H_
+#define RNP_RNG_H_
 
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "config.h"
 
-enum { RNG_DRBG, RNG_SYSTEM };
-typedef uint8_t rng_type_t;
 #ifdef CRYPTO_BACKEND_BOTAN
 typedef struct botan_rng_struct *botan_rng_t;
 #endif
 
-typedef struct rng_st_t {
-    rng_type_t rng_type;
+namespace rnp {
+class RNG {
+  private:
 #ifdef CRYPTO_BACKEND_BOTAN
-    bool        initialized;
-    botan_rng_t botan_rng;
+    struct botan_rng_struct *botan_rng;
 #endif
-} rng_t;
-
-/*
- * @brief Initializes rng structure
- *
- * @param rng_type indicates which random generator to initialize.
- *        Two values possible
- *          RNG_DRBG - will initialize HMAC_DRBG, this generator
- *                     is initialized on-demand (when used for the
- *                     first time)
- *          RNG_SYSTEM will initialize /dev/(u)random
- * @returns false if lazy initialization wasn't requested
- *          and initialization failed, otherwise true
- */
-bool rng_init(rng_t *ctx, rng_type_t rng_type);
-
-/*
- * Frees memory allocated by `rng_get_data'
- */
-void rng_destroy(rng_t *ctx);
-
-/*
- *  @brief  Used to retrieve random data. First successful completion
- *          of this function initializes memory in `ctx' which
- *          needs to be released with `rng_destroy'.
- *
- *          Function initializes HMAC_DRBG with automatic reseeding
- *          after each 1024'th call.
- *
- *  @param ctx pointer to rng_t
- *  @param data [out] output buffer of size at least `len`
- *  @param len number of bytes to get
- *
- *  @return true on success, false indicates implementation error.
- **/
-bool rng_get_data(rng_t *ctx, uint8_t *data, size_t len);
-
+  public:
+    enum Type { DRBG, System };
+    /**
+     * @brief Construct a new RNG object.
+     *        Note: OpenSSL uses own global RNG, so this class is not needed there and left
+     *        only for code-level compatibility.
+     *
+     * @param type indicates which random generator to initialize.
+     *             Possible values for Botan backend:
+     *             - DRBG will initialize HMAC_DRBG, this generator is initialized on-demand
+     *               (when used for the first time)
+     *             - SYSTEM will initialize /dev/(u)random
+     */
+    RNG(Type type = Type::DRBG);
+    ~RNG();
+    /**
+     * @brief Get randoom bytes.
+     *
+     * @param data buffer where data should be stored. Cannot be NULL.
+     * @param len number of bytes required.
+     */
+    void get(uint8_t *data, size_t len);
 #ifdef CRYPTO_BACKEND_BOTAN
-/*
- * @brief   Returns internal handle to botan rng. Returned
- *          handle is always initialized. In case of
- *          internal error NULL is returned
- *
- * @param   valid pointer to rng_t object
- */
-struct botan_rng_struct *rng_handle(rng_t *);
+    /**
+     * @brief   Returns internal handle to botan rng. Returned
+     *          handle is always initialized. In case of
+     *          internal error NULL is returned
+     */
+    struct botan_rng_struct *handle();
 #endif
+};
+} // namespace rnp
 
-#endif // RNP_RANDOM_H_
+#endif // RNP_RNG_H_

--- a/src/lib/crypto/rng.h
+++ b/src/lib/crypto/rng.h
@@ -97,17 +97,4 @@ bool rng_get_data(rng_t *ctx, uint8_t *data, size_t len);
 struct botan_rng_struct *rng_handle(rng_t *);
 #endif
 
-/*
- * @brief   Initializes RNG_SYSTEM and generates random data.
- *          This function should be used only in places where
- *          rng_t is not available. Using this function may
- *          impact performance
- *
- * @param   data[out] Output buffer storing random data
- * @param   data_len length of data to be generated
- *
- * @return  true one success, otherwise false
- */
-bool rng_generate(uint8_t *data, size_t data_len);
-
 #endif // RNP_RANDOM_H_

--- a/src/lib/crypto/rng_ossl.cpp
+++ b/src/lib/crypto/rng_ossl.cpp
@@ -55,9 +55,3 @@ rng_get_data(rng_t *ctx, uint8_t *data, size_t len)
     }
     return RAND_bytes(data, len) == 1;
 }
-
-bool
-rng_generate(uint8_t *data, size_t data_len)
-{
-    return RAND_bytes(data, data_len) == 1;
-}

--- a/src/lib/crypto/rng_ossl.cpp
+++ b/src/lib/crypto/rng_ossl.cpp
@@ -28,30 +28,20 @@
 #include <openssl/rand.h>
 #include "rng.h"
 
-bool
-rng_init(rng_t *ctx, rng_type_t rng_type)
+namespace rnp {
+RNG::RNG(Type type = Type::DRBG)
 {
-    if (!ctx) {
-        return false;
-    }
-    if ((rng_type != RNG_DRBG) && (rng_type != RNG_SYSTEM)) {
-        return false;
-    }
-    ctx->rng_type = rng_type;
-    return true;
+}
+
+RNG::~RNG()
+{
 }
 
 void
-rng_destroy(rng_t *ctx)
+RNG::get(uint8_t *data, size_t len)
 {
-    ;
-}
-
-bool
-rng_get_data(rng_t *ctx, uint8_t *data, size_t len)
-{
-    if (!ctx) {
-        return false;
+    if (RAND_bytes(data, len) != 1) {
+        throw rnp::rnp_exception(RNP_ERROR_RNG);
     }
-    return RAND_bytes(data, len) == 1;
 }
+} // namespace rnp

--- a/src/lib/crypto/rsa.cpp
+++ b/src/lib/crypto/rsa.cpp
@@ -85,7 +85,7 @@
 #include "bn.h"
 
 rnp_result_t
-rsa_validate_key(rng_t *rng, const pgp_rsa_key_t *key, bool secret)
+rsa_validate_key(rnp::RNG *rng, const pgp_rsa_key_t *key, bool secret)
 {
     bignum_t *      n = NULL;
     bignum_t *      e = NULL;
@@ -106,7 +106,7 @@ rsa_validate_key(rng_t *rng, const pgp_rsa_key_t *key, bool secret)
         goto done;
     }
 
-    if (botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+    if (botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
 
@@ -127,7 +127,7 @@ rsa_validate_key(rng_t *rng, const pgp_rsa_key_t *key, bool secret)
         goto done;
     }
 
-    if (botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+    if (botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;
@@ -192,7 +192,7 @@ done:
 }
 
 rnp_result_t
-rsa_encrypt_pkcs1(rng_t *              rng,
+rsa_encrypt_pkcs1(rnp::RNG *           rng,
                   pgp_rsa_encrypted_t *out,
                   const uint8_t *      in,
                   size_t               in_len,
@@ -212,7 +212,7 @@ rsa_encrypt_pkcs1(rng_t *              rng,
     }
 
     out->m.len = sizeof(out->m.mpi);
-    if (botan_pk_op_encrypt(enc_op, rng_handle(rng), out->m.mpi, &out->m.len, in, in_len)) {
+    if (botan_pk_op_encrypt(enc_op, rng->handle(), out->m.mpi, &out->m.len, in, in_len)) {
         out->m.len = 0;
         goto done;
     }
@@ -265,7 +265,7 @@ done:
 }
 
 rnp_result_t
-rsa_sign_pkcs1(rng_t *              rng,
+rsa_sign_pkcs1(rnp::RNG *           rng,
                pgp_rsa_signature_t *sig,
                pgp_hash_alg_t       hash_alg,
                const uint8_t *      hash,
@@ -301,7 +301,7 @@ rsa_sign_pkcs1(rng_t *              rng,
     }
 
     sig->s.len = sizeof(sig->s.mpi);
-    if (botan_pk_op_sign_finish(sign_op, rng_handle(rng), sig->s.mpi, &sig->s.len)) {
+    if (botan_pk_op_sign_finish(sign_op, rng->handle(), sig->s.mpi, &sig->s.len)) {
         goto done;
     }
 
@@ -313,7 +313,7 @@ done:
 }
 
 rnp_result_t
-rsa_decrypt_pkcs1(rng_t *                    rng,
+rsa_decrypt_pkcs1(rnp::RNG *                 rng,
                   uint8_t *                  out,
                   size_t *                   out_len,
                   const pgp_rsa_encrypted_t *in,
@@ -349,7 +349,7 @@ done:
 }
 
 rnp_result_t
-rsa_generate(rng_t *rng, pgp_rsa_key_t *key, size_t numbits)
+rsa_generate(rnp::RNG *rng, pgp_rsa_key_t *key, size_t numbits)
 {
     if ((numbits < 1024) || (numbits > PGP_MPINT_BITS)) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -371,11 +371,11 @@ rsa_generate(rng_t *rng, pgp_rsa_key_t *key, size_t numbits)
     }
 
     if (botan_privkey_create(
-          &rsa_key, "RSA", std::to_string(numbits).c_str(), rng_handle(rng))) {
+          &rsa_key, "RSA", std::to_string(numbits).c_str(), rng->handle())) {
         goto end;
     }
 
-    if (botan_privkey_check_key(rsa_key, rng_handle(rng), 1) != 0) {
+    if (botan_privkey_check_key(rsa_key, rng->handle(), 1) != 0) {
         goto end;
     }
 

--- a/src/lib/crypto/rsa.h
+++ b/src/lib/crypto/rsa.h
@@ -58,17 +58,17 @@ typedef struct pgp_rsa_encrypted_t {
  * RSA encrypt/decrypt
  */
 
-rnp_result_t rsa_validate_key(rng_t *rng, const pgp_rsa_key_t *key, bool secret);
+rnp_result_t rsa_validate_key(rnp::RNG *rng, const pgp_rsa_key_t *key, bool secret);
 
-rnp_result_t rsa_generate(rng_t *rng, pgp_rsa_key_t *key, size_t numbits);
+rnp_result_t rsa_generate(rnp::RNG *rng, pgp_rsa_key_t *key, size_t numbits);
 
-rnp_result_t rsa_encrypt_pkcs1(rng_t *              rng,
+rnp_result_t rsa_encrypt_pkcs1(rnp::RNG *           rng,
                                pgp_rsa_encrypted_t *out,
                                const uint8_t *      in,
                                size_t               in_len,
                                const pgp_rsa_key_t *key);
 
-rnp_result_t rsa_decrypt_pkcs1(rng_t *                    rng,
+rnp_result_t rsa_decrypt_pkcs1(rnp::RNG *                 rng,
                                uint8_t *                  out,
                                size_t *                   out_len,
                                const pgp_rsa_encrypted_t *in,
@@ -80,7 +80,7 @@ rnp_result_t rsa_verify_pkcs1(const pgp_rsa_signature_t *sig,
                               size_t                     hash_len,
                               const pgp_rsa_key_t *      key);
 
-rnp_result_t rsa_sign_pkcs1(rng_t *              rng,
+rnp_result_t rsa_sign_pkcs1(rnp::RNG *           rng,
                             pgp_rsa_signature_t *sig,
                             pgp_hash_alg_t       hash_alg,
                             const uint8_t *      hash,

--- a/src/lib/crypto/rsa_ossl.cpp
+++ b/src/lib/crypto/rsa_ossl.cpp
@@ -139,7 +139,7 @@ done:
 }
 
 rnp_result_t
-rsa_validate_key(rng_t *rng, const pgp_rsa_key_t *key, bool secret)
+rsa_validate_key(rnp::RNG *rng, const pgp_rsa_key_t *key, bool secret)
 {
     if (secret) {
         EVP_PKEY_CTX *ctx = rsa_init_context(key, secret);
@@ -201,7 +201,7 @@ rsa_setup_context(EVP_PKEY_CTX *ctx, pgp_hash_alg_t hash_alg = PGP_HASH_UNKNOWN)
 }
 
 rnp_result_t
-rsa_encrypt_pkcs1(rng_t *              rng,
+rsa_encrypt_pkcs1(rnp::RNG *           rng,
                   pgp_rsa_encrypted_t *out,
                   const uint8_t *      in,
                   size_t               in_len,
@@ -274,7 +274,7 @@ done:
 }
 
 rnp_result_t
-rsa_sign_pkcs1(rng_t *              rng,
+rsa_sign_pkcs1(rnp::RNG *           rng,
                pgp_rsa_signature_t *sig,
                pgp_hash_alg_t       hash_alg,
                const uint8_t *      hash,
@@ -310,7 +310,7 @@ done:
 }
 
 rnp_result_t
-rsa_decrypt_pkcs1(rng_t *                    rng,
+rsa_decrypt_pkcs1(rnp::RNG *                 rng,
                   uint8_t *                  out,
                   size_t *                   out_len,
                   const pgp_rsa_encrypted_t *in,
@@ -345,7 +345,7 @@ done:
 }
 
 rnp_result_t
-rsa_generate(rng_t *rng, pgp_rsa_key_t *key, size_t numbits)
+rsa_generate(rnp::RNG *rng, pgp_rsa_key_t *key, size_t numbits)
 {
     if ((numbits < 1024) || (numbits > PGP_MPINT_BITS)) {
         return RNP_ERROR_BAD_PARAMETERS;

--- a/src/lib/crypto/signatures.cpp
+++ b/src/lib/crypto/signatures.cpp
@@ -73,7 +73,7 @@ void
 signature_calculate(pgp_signature_t &         sig,
                     const pgp_key_material_t &seckey,
                     rnp::Hash &               hash,
-                    rng_t &                   rng)
+                    rnp::RNG &                rng)
 {
     uint8_t              hval[PGP_MAX_HASH_SIZE];
     size_t               hlen = 0;

--- a/src/lib/crypto/signatures.h
+++ b/src/lib/crypto/signatures.h
@@ -49,7 +49,7 @@ void signature_init(const pgp_key_material_t &key, pgp_hash_alg_t hash_alg, rnp:
 void signature_calculate(pgp_signature_t &         sig,
                          const pgp_key_material_t &seckey,
                          rnp::Hash &               hash,
-                         rng_t &                   rng);
+                         rnp::RNG &                rng);
 
 /**
  * @brief Validate a signature with pre-populated hash. This method just checks correspondence

--- a/src/lib/crypto/sm2.cpp
+++ b/src/lib/crypto/sm2.cpp
@@ -125,14 +125,13 @@ done:
 }
 
 rnp_result_t
-sm2_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+sm2_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     botan_pubkey_t  bpkey = NULL;
     botan_privkey_t bskey = NULL;
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
 
-    if (!sm2_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
+    if (!sm2_load_public_key(&bpkey, key) || botan_pubkey_check_key(bpkey, rng->handle(), 0)) {
         goto done;
     }
 
@@ -142,7 +141,7 @@ sm2_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!sm2_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
+        botan_privkey_check_key(bskey, rng->handle(), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;
@@ -153,7 +152,7 @@ done:
 }
 
 rnp_result_t
-sm2_sign(rng_t *             rng,
+sm2_sign(rnp::RNG *          rng,
          pgp_ec_signature_t *sig,
          pgp_hash_alg_t      hash_alg,
          const uint8_t *     hash,
@@ -197,7 +196,7 @@ sm2_sign(rng_t *             rng,
         goto end;
     }
 
-    if (botan_pk_op_sign_finish(signer, rng_handle(rng), out_buf, &sig_len)) {
+    if (botan_pk_op_sign_finish(signer, rng->handle(), out_buf, &sig_len)) {
         RNP_LOG("Signing failed");
         goto end;
     }
@@ -276,7 +275,7 @@ end:
 }
 
 rnp_result_t
-sm2_encrypt(rng_t *              rng,
+sm2_encrypt(rnp::RNG *           rng,
             pgp_sm2_encrypted_t *out,
             const uint8_t *      in,
             size_t               in_len,
@@ -327,8 +326,7 @@ sm2_encrypt(rng_t *              rng,
     }
 
     out->m.len = sizeof(out->m.mpi);
-    if (botan_pk_op_encrypt(enc_op, rng_handle(rng), out->m.mpi, &out->m.len, in, in_len) ==
-        0) {
+    if (botan_pk_op_encrypt(enc_op, rng->handle(), out->m.mpi, &out->m.len, in, in_len) == 0) {
         out->m.mpi[out->m.len++] = hash_algo;
         ret = RNP_SUCCESS;
     }

--- a/src/lib/crypto/sm2.h
+++ b/src/lib/crypto/sm2.h
@@ -39,7 +39,7 @@ class Hash;
 }
 
 #if defined(ENABLE_SM2)
-rnp_result_t sm2_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret);
+rnp_result_t sm2_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret);
 
 /**
  * Compute the SM2 "ZA" field, and add it to the hash object
@@ -50,7 +50,7 @@ rnp_result_t sm2_compute_za(const pgp_ec_key_t &key,
                             rnp::Hash &         hash,
                             const char *        ident_field = NULL);
 
-rnp_result_t sm2_sign(rng_t *             rng,
+rnp_result_t sm2_sign(rnp::RNG *          rng,
                       pgp_ec_signature_t *sig,
                       pgp_hash_alg_t      hash_alg,
                       const uint8_t *     hash,
@@ -63,7 +63,7 @@ rnp_result_t sm2_verify(const pgp_ec_signature_t *sig,
                         size_t                    hash_len,
                         const pgp_ec_key_t *      key);
 
-rnp_result_t sm2_encrypt(rng_t *              rng,
+rnp_result_t sm2_encrypt(rnp::RNG *           rng,
                          pgp_sm2_encrypted_t *out,
                          const uint8_t *      in,
                          size_t               in_len,

--- a/src/lib/crypto/sm2_ossl.cpp
+++ b/src/lib/crypto/sm2_ossl.cpp
@@ -30,13 +30,13 @@
 #include "utils.h"
 
 rnp_result_t
-sm2_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
+sm2_validate_key(rnp::RNG *rng, const pgp_ec_key_t *key, bool secret)
 {
     return RNP_ERROR_NOT_IMPLEMENTED;
 }
 
 rnp_result_t
-sm2_sign(rng_t *             rng,
+sm2_sign(rnp::RNG *          rng,
          pgp_ec_signature_t *sig,
          pgp_hash_alg_t      hash_alg,
          const uint8_t *     hash,
@@ -57,7 +57,7 @@ sm2_verify(const pgp_ec_signature_t *sig,
 }
 
 rnp_result_t
-sm2_encrypt(rng_t *              rng,
+sm2_encrypt(rnp::RNG *           rng,
             pgp_sm2_encrypted_t *out,
             const uint8_t *      in,
             size_t               in_len,

--- a/src/lib/crypto/symmetric.h
+++ b/src/lib/crypto/symmetric.h
@@ -112,7 +112,7 @@ typedef struct pgp_crypt_t {
 
     pgp_symm_alg_t alg;
     size_t         blocksize;
-    rng_t *        rng;
+    rnp::RNG *     rng;
 } pgp_crypt_t;
 
 unsigned pgp_block_size(pgp_symm_alg_t);

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -74,9 +74,12 @@ struct rnp_ffi_st {
     void *                  getkeycb_ctx;
     rnp_password_cb         getpasscb;
     void *                  getpasscb_ctx;
-    rng_t                   rng;
+    rnp::RNG                rng;
     pgp_key_provider_t      key_provider;
     pgp_password_provider_t pass_provider;
+
+    rnp_ffi_st(pgp_key_store_format_t pub_fmt, pgp_key_store_format_t sec_fmt);
+    ~rnp_ffi_st();
 };
 
 struct rnp_input_st {

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -69,10 +69,8 @@ static const id_str_pair pubkey_alg_map[] = {
   {0, NULL}};
 
 static bool
-load_generated_g10_key(pgp_key_t *    dst,
-                       pgp_key_pkt_t *newkey,
-                       pgp_key_t *    primary_key,
-                       pgp_key_t *    pubkey)
+load_generated_g10_key(
+  pgp_key_t *dst, pgp_key_pkt_t *newkey, pgp_key_t *primary_key, pgp_key_t *pubkey, rng_t &rng)
 {
     bool                     ok = false;
     pgp_dest_t               memdst = {};
@@ -94,7 +92,7 @@ load_generated_g10_key(pgp_key_t *    dst,
         goto end;
     }
 
-    if (!g10_write_seckey(&memdst, newkey, NULL)) {
+    if (!g10_write_seckey(&memdst, newkey, NULL, rng)) {
         RNP_LOG("failed to write generated seckey");
         goto end;
     }
@@ -368,7 +366,8 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t &desc,
             break;
         case PGP_KEY_STORE_G10:
             primary_pub = std::move(pub);
-            if (!load_generated_g10_key(&primary_sec, &secpkt, NULL, &primary_pub)) {
+            if (!load_generated_g10_key(
+                  &primary_sec, &secpkt, NULL, &primary_pub, *desc.crypto.rng)) {
                 RNP_LOG("failed to load generated key");
                 return false;
             }
@@ -471,7 +470,8 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t &     desc,
             subkey_sec = std::move(sec);
             break;
         case PGP_KEY_STORE_G10:
-            if (!load_generated_g10_key(&subkey_sec, &secpkt, &primary_sec, &subkey_pub)) {
+            if (!load_generated_g10_key(
+                  &subkey_sec, &secpkt, &primary_sec, &subkey_pub, *desc.crypto.rng)) {
                 RNP_LOG("failed to load generated key");
                 return false;
             }

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -69,8 +69,11 @@ static const id_str_pair pubkey_alg_map[] = {
   {0, NULL}};
 
 static bool
-load_generated_g10_key(
-  pgp_key_t *dst, pgp_key_pkt_t *newkey, pgp_key_t *primary_key, pgp_key_t *pubkey, rng_t &rng)
+load_generated_g10_key(pgp_key_t *    dst,
+                       pgp_key_pkt_t *newkey,
+                       pgp_key_t *    primary_key,
+                       pgp_key_t *    pubkey,
+                       rnp::RNG &     rng)
 {
     bool                     ok = false;
     pgp_dest_t               memdst = {};
@@ -504,7 +507,7 @@ keygen_merge_defaults(rnp_keygen_primary_desc_t &primary_desc,
 }
 
 bool
-pgp_generate_keypair(rng_t &                    rng,
+pgp_generate_keypair(rnp::RNG &                 rng,
                      rnp_keygen_primary_desc_t &primary_desc,
                      rnp_keygen_subkey_desc_t & subkey_desc,
                      bool                       merge_defaults,

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -239,7 +239,7 @@ bool
 pgp_key_t::write_sec_pgp(pgp_dest_t &       dst,
                          pgp_key_pkt_t &    seckey,
                          const std::string &password,
-                         rng_t &            rng)
+                         rnp::RNG &         rng)
 {
     bool           res = false;
     pgp_pkt_type_t oldtag = seckey.tag;
@@ -260,7 +260,7 @@ done:
 }
 
 bool
-pgp_key_t::write_sec_rawpkt(pgp_key_pkt_t &seckey, const std::string &password, rng_t &rng)
+pgp_key_t::write_sec_rawpkt(pgp_key_pkt_t &seckey, const std::string &password, rnp::RNG &rng)
 {
     pgp_dest_t memdst = {};
     if (init_mem_dest(&memdst, NULL, 0)) {
@@ -324,7 +324,7 @@ pgp_key_set_expiration(pgp_key_t *                    key,
                        pgp_key_t *                    seckey,
                        uint32_t                       expiry,
                        const pgp_password_provider_t &prov,
-                       rng_t &                        rng)
+                       rnp::RNG &                     rng)
 {
     if (!key->is_primary()) {
         RNP_LOG("Not a primary key");
@@ -409,7 +409,7 @@ pgp_subkey_set_expiration(pgp_key_t *                    sub,
                           pgp_key_t *                    secsub,
                           uint32_t                       expiry,
                           const pgp_password_provider_t &prov,
-                          rng_t &                        rng)
+                          rnp::RNG &                     rng)
 {
     if (!sub->is_subkey()) {
         RNP_LOG("Not a subkey");
@@ -1545,7 +1545,7 @@ pgp_key_t::lock()
 bool
 pgp_key_t::protect(const rnp_key_protection_params_t &protection,
                    const pgp_password_provider_t &    password_provider,
-                   rng_t &                            rng)
+                   rnp::RNG &                         rng)
 {
     pgp_password_ctx_t ctx;
     memset(&ctx, 0, sizeof(ctx));
@@ -1564,7 +1564,7 @@ bool
 pgp_key_t::protect(pgp_key_pkt_t &                    decrypted,
                    const rnp_key_protection_params_t &protection,
                    const std::string &                new_password,
-                   rng_t &                            rng)
+                   rnp::RNG &                         rng)
 {
     if (!is_secret()) {
         RNP_LOG("Warning: this is not a secret key");
@@ -1602,7 +1602,7 @@ pgp_key_t::protect(pgp_key_pkt_t &                    decrypted,
 }
 
 bool
-pgp_key_t::unprotect(const pgp_password_provider_t &password_provider, rng_t &rng)
+pgp_key_t::unprotect(const pgp_password_provider_t &password_provider, rnp::RNG &rng)
 {
     /* sanity check */
     if (!is_secret()) {
@@ -2308,7 +2308,7 @@ void
 pgp_key_t::sign_cert(const pgp_key_pkt_t &   key,
                      const pgp_userid_pkt_t &uid,
                      pgp_signature_t &       sig,
-                     rng_t &                 rng) const
+                     rnp::RNG &              rng) const
 {
     rnp::Hash hash;
     sig.fill_hashed_data();
@@ -2317,7 +2317,7 @@ pgp_key_t::sign_cert(const pgp_key_pkt_t &   key,
 }
 
 void
-pgp_key_t::sign_direct(const pgp_key_pkt_t &key, pgp_signature_t &sig, rng_t &rng) const
+pgp_key_t::sign_direct(const pgp_key_pkt_t &key, pgp_signature_t &sig, rnp::RNG &rng) const
 {
     rnp::Hash hash;
     sig.fill_hashed_data();
@@ -2326,7 +2326,7 @@ pgp_key_t::sign_direct(const pgp_key_pkt_t &key, pgp_signature_t &sig, rng_t &rn
 }
 
 void
-pgp_key_t::sign_binding(const pgp_key_pkt_t &key, pgp_signature_t &sig, rng_t &rng) const
+pgp_key_t::sign_binding(const pgp_key_pkt_t &key, pgp_signature_t &sig, rnp::RNG &rng) const
 {
     rnp::Hash hash;
     sig.fill_hashed_data();
@@ -2343,7 +2343,7 @@ pgp_key_t::gen_revocation(const pgp_revoke_t & revoke,
                           pgp_hash_alg_t       hash,
                           const pgp_key_pkt_t &key,
                           pgp_signature_t &    sig,
-                          rng_t &              rng) const
+                          rnp::RNG &           rng) const
 {
     sign_init(sig, hash);
     sig.set_type(is_primary_key_pkt(key.tag) ? PGP_SIG_REV_KEY : PGP_SIG_REV_SUBKEY);
@@ -2359,7 +2359,7 @@ pgp_key_t::gen_revocation(const pgp_revoke_t & revoke,
 void
 pgp_key_t::sign_subkey_binding(const pgp_key_t &sub,
                                pgp_signature_t &sig,
-                               rng_t &          rng,
+                               rnp::RNG &       rng,
                                bool             subsign) const
 {
     if (!is_primary()) {
@@ -2379,7 +2379,7 @@ pgp_key_t::sign_subkey_binding(const pgp_key_t &sub,
 void
 pgp_key_t::add_uid_cert(rnp_selfsig_cert_info_t &cert,
                         pgp_hash_alg_t           hash,
-                        rng_t &                  rng,
+                        rnp::RNG &               rng,
                         pgp_key_t *              pubkey)
 {
     if (!cert.userid[0]) {
@@ -2441,7 +2441,7 @@ pgp_key_t::add_sub_binding(pgp_key_t &                       subsec,
                            pgp_key_t &                       subpub,
                            const rnp_selfsig_binding_info_t &binding,
                            pgp_hash_alg_t                    hash,
-                           rng_t &                           rng)
+                           rnp::RNG &                        rng)
 {
     if (!is_primary()) {
         RNP_LOG("must be called on primary key");

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -171,7 +171,10 @@ struct pgp_key_t {
     void          validate_primary(rnp_key_store_t &keyring);
     void          merge_validity(const pgp_validity_t &src);
     uint64_t      valid_till_common(bool expiry) const;
-    bool write_sec_pgp(pgp_dest_t &dst, pgp_key_pkt_t &seckey, const std::string &password);
+    bool          write_sec_pgp(pgp_dest_t &       dst,
+                                pgp_key_pkt_t &    seckey,
+                                const std::string &password,
+                                rng_t &            rng);
 
   public:
     pgp_key_store_format_t format{}; /* the format of the key in packets[0] */
@@ -285,7 +288,7 @@ struct pgp_key_t {
     const pgp_rawpacket_t &rawpkt() const;
     void                   set_rawpkt(const pgp_rawpacket_t &src);
     /** @brief write secret key data to the rawpkt, optionally encrypting with password */
-    bool write_sec_rawpkt(pgp_key_pkt_t &seckey, const std::string &password);
+    bool write_sec_rawpkt(pgp_key_pkt_t &seckey, const std::string &password, rng_t &rng);
 
     /** @brief Unlock a key, i.e. decrypt its secret data so it can be used for
      *         signing/decryption.
@@ -306,13 +309,15 @@ struct pgp_key_t {
     /** @brief Add protection to an unlocked key, i.e. encrypt its secret data with specified
      *         parameters. */
     bool protect(const rnp_key_protection_params_t &protection,
-                 const pgp_password_provider_t &    password_provider);
+                 const pgp_password_provider_t &    password_provider,
+                 rng_t &                            rng);
     /** @brief Add/change protection of a key */
     bool protect(pgp_key_pkt_t &                    decrypted,
                  const rnp_key_protection_params_t &protection,
-                 const std::string &                new_password);
+                 const std::string &                new_password,
+                 rng_t &                            rng);
     /** @brief Remove protection from a key, i.e. leave secret fields unencrypted */
-    bool unprotect(const pgp_password_provider_t &password_provider);
+    bool unprotect(const pgp_password_provider_t &password_provider, rng_t &rng);
 
     /** @brief Write key's packets to the output. */
     void write(pgp_dest_t &dst) const;

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -174,7 +174,7 @@ struct pgp_key_t {
     bool          write_sec_pgp(pgp_dest_t &       dst,
                                 pgp_key_pkt_t &    seckey,
                                 const std::string &password,
-                                rng_t &            rng);
+                                rnp::RNG &         rng);
 
   public:
     pgp_key_store_format_t format{}; /* the format of the key in packets[0] */
@@ -288,7 +288,7 @@ struct pgp_key_t {
     const pgp_rawpacket_t &rawpkt() const;
     void                   set_rawpkt(const pgp_rawpacket_t &src);
     /** @brief write secret key data to the rawpkt, optionally encrypting with password */
-    bool write_sec_rawpkt(pgp_key_pkt_t &seckey, const std::string &password, rng_t &rng);
+    bool write_sec_rawpkt(pgp_key_pkt_t &seckey, const std::string &password, rnp::RNG &rng);
 
     /** @brief Unlock a key, i.e. decrypt its secret data so it can be used for
      *         signing/decryption.
@@ -310,14 +310,14 @@ struct pgp_key_t {
      *         parameters. */
     bool protect(const rnp_key_protection_params_t &protection,
                  const pgp_password_provider_t &    password_provider,
-                 rng_t &                            rng);
+                 rnp::RNG &                         rng);
     /** @brief Add/change protection of a key */
     bool protect(pgp_key_pkt_t &                    decrypted,
                  const rnp_key_protection_params_t &protection,
                  const std::string &                new_password,
-                 rng_t &                            rng);
+                 rnp::RNG &                         rng);
     /** @brief Remove protection from a key, i.e. leave secret fields unencrypted */
-    bool unprotect(const pgp_password_provider_t &password_provider, rng_t &rng);
+    bool unprotect(const pgp_password_provider_t &password_provider, rnp::RNG &rng);
 
     /** @brief Write key's packets to the output. */
     void write(pgp_dest_t &dst) const;
@@ -458,7 +458,7 @@ struct pgp_key_t {
     void sign_cert(const pgp_key_pkt_t &   key,
                    const pgp_userid_pkt_t &uid,
                    pgp_signature_t &       sig,
-                   rng_t &                 rng) const;
+                   rnp::RNG &              rng) const;
 
     /**
      * @brief Calculate direct-key signature.
@@ -468,7 +468,7 @@ struct pgp_key_t {
      * @param sig signature, pre-populated with all of the required data, except the
      *            signature material.
      */
-    void sign_direct(const pgp_key_pkt_t &key, pgp_signature_t &sig, rng_t &rng) const;
+    void sign_direct(const pgp_key_pkt_t &key, pgp_signature_t &sig, rnp::RNG &rng) const;
 
     /**
      * @brief Calculate subkey or primary key binding.
@@ -479,7 +479,7 @@ struct pgp_key_t {
      * @param sig signature, pre-populated with all of the required data, except the
      *            signature material.
      */
-    void sign_binding(const pgp_key_pkt_t &key, pgp_signature_t &sig, rng_t &rng) const;
+    void sign_binding(const pgp_key_pkt_t &key, pgp_signature_t &sig, rnp::RNG &rng) const;
 
     /**
      * @brief Calculate subkey binding.
@@ -494,7 +494,7 @@ struct pgp_key_t {
      */
     void sign_subkey_binding(const pgp_key_t &sub,
                              pgp_signature_t &sig,
-                             rng_t &          rng,
+                             rnp::RNG &       rng,
                              bool             subsign = false) const;
 
     /**
@@ -508,7 +508,7 @@ struct pgp_key_t {
                         pgp_hash_alg_t       hash,
                         const pgp_key_pkt_t &key,
                         pgp_signature_t &    sig,
-                        rng_t &              rng) const;
+                        rnp::RNG &           rng) const;
 
     /**
      * @brief Add and certify userid.
@@ -522,7 +522,7 @@ struct pgp_key_t {
      */
     void add_uid_cert(rnp_selfsig_cert_info_t &cert,
                       pgp_hash_alg_t           hash,
-                      rng_t &                  rng,
+                      rnp::RNG &               rng,
                       pgp_key_t *              pubkey = nullptr);
 
     /**
@@ -540,7 +540,7 @@ struct pgp_key_t {
                          pgp_key_t &                       subpub,
                          const rnp_selfsig_binding_info_t &binding,
                          pgp_hash_alg_t                    hash,
-                         rng_t &                           rng);
+                         rnp::RNG &                        rng);
 
     /** @brief Refresh internal fields after primary key is updated */
     bool refresh_data();
@@ -608,14 +608,14 @@ bool pgp_key_set_expiration(pgp_key_t *                    key,
                             pgp_key_t *                    signer,
                             uint32_t                       expiry,
                             const pgp_password_provider_t &prov,
-                            rng_t &                        rng);
+                            rnp::RNG &                     rng);
 
 bool pgp_subkey_set_expiration(pgp_key_t *                    sub,
                                pgp_key_t *                    primsec,
                                pgp_key_t *                    secsub,
                                uint32_t                       expiry,
                                const pgp_password_provider_t &prov,
-                               rng_t &                        rng);
+                               rnp::RNG &                     rng);
 
 /** find a key suitable for a particular operation
  *

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -408,7 +408,7 @@ typedef struct rnp_keygen_crypto_params_t {
     // Hash to be used for key signature
     pgp_hash_alg_t hash_alg;
     // Pointer to initialized RNG engine
-    rng_t *rng;
+    rnp::RNG *rng;
     union {
         struct rnp_keygen_ecc_params_t     ecc;
         struct rnp_keygen_rsa_params_t     rsa;

--- a/src/librekey/g10_sexp.hpp
+++ b/src/librekey/g10_sexp.hpp
@@ -108,7 +108,7 @@ class s_exp_t : public s_exp_element_t {
     void add_curve(const std::string &name, const pgp_ec_key_t &key);
     void add_pubkey(const pgp_key_pkt_t &key);
     void add_seckey(const pgp_key_pkt_t &key);
-    void add_protected_seckey(pgp_key_pkt_t &seckey, const std::string &password);
+    void add_protected_seckey(pgp_key_pkt_t &seckey, const std::string &password, rng_t &rng);
 
     void clear();
 };

--- a/src/librekey/g10_sexp.hpp
+++ b/src/librekey/g10_sexp.hpp
@@ -108,7 +108,9 @@ class s_exp_t : public s_exp_element_t {
     void add_curve(const std::string &name, const pgp_ec_key_t &key);
     void add_pubkey(const pgp_key_pkt_t &key);
     void add_seckey(const pgp_key_pkt_t &key);
-    void add_protected_seckey(pgp_key_pkt_t &seckey, const std::string &password, rng_t &rng);
+    void add_protected_seckey(pgp_key_pkt_t &    seckey,
+                              const std::string &password,
+                              rnp::RNG &         rng);
 
     void clear();
 };

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1135,7 +1135,9 @@ s_exp_t::write_padded(size_t padblock) const
 }
 
 void
-s_exp_t::add_protected_seckey(pgp_key_pkt_t &seckey, const std::string &password, rng_t &rng)
+s_exp_t::add_protected_seckey(pgp_key_pkt_t &    seckey,
+                              const std::string &password,
+                              rnp::RNG &         rng)
 {
     pgp_key_protection_t &prot = seckey.sec_protection;
     if (prot.s2k.specifier != PGP_S2KS_ITERATED_AND_SALTED) {
@@ -1150,11 +1152,8 @@ s_exp_t::add_protected_seckey(pgp_key_pkt_t &seckey, const std::string &password
     }
 
     // randomize IV and salt
-    if (!rng_get_data(&rng, prot.iv, sizeof(prot.iv)) ||
-        !rng_get_data(&rng, prot.s2k.salt, sizeof(prot.s2k.salt))) {
-        RNP_LOG("iv generation failed");
-        throw rnp::rnp_exception(RNP_ERROR_RNG);
-    }
+    rng.get(prot.iv, sizeof(prot.iv));
+    rng.get(prot.s2k.salt, sizeof(prot.s2k.salt));
 
     // write seckey
     s_exp_t  raw_s_exp;
@@ -1239,7 +1238,7 @@ s_exp_t::add_protected_seckey(pgp_key_pkt_t &seckey, const std::string &password
 }
 
 bool
-g10_write_seckey(pgp_dest_t *dst, pgp_key_pkt_t *seckey, const char *password, rng_t &rng)
+g10_write_seckey(pgp_dest_t *dst, pgp_key_pkt_t *seckey, const char *password, rnp::RNG &rng)
 {
     bool is_protected = true;
 

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -31,7 +31,10 @@
 
 bool rnp_key_store_g10_from_src(rnp_key_store_t *, pgp_source_t *, const pgp_key_provider_t *);
 bool rnp_key_store_g10_key_to_dst(pgp_key_t *, pgp_dest_t *);
-bool g10_write_seckey(pgp_dest_t *dst, pgp_key_pkt_t *seckey, const char *password);
+bool g10_write_seckey(pgp_dest_t *   dst,
+                      pgp_key_pkt_t *seckey,
+                      const char *   password,
+                      rng_t &        rng);
 pgp_key_pkt_t *g10_decrypt_seckey(const uint8_t *      data,
                                   size_t               data_len,
                                   const pgp_key_pkt_t *pubkey,

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -34,7 +34,7 @@ bool rnp_key_store_g10_key_to_dst(pgp_key_t *, pgp_dest_t *);
 bool g10_write_seckey(pgp_dest_t *   dst,
                       pgp_key_pkt_t *seckey,
                       const char *   password,
-                      rng_t &        rng);
+                      rnp::RNG &     rng);
 pgp_key_pkt_t *g10_decrypt_seckey(const uint8_t *      data,
                                   size_t               data_len,
                                   const pgp_key_pkt_t *pubkey,

--- a/src/librepgp/stream-ctx.h
+++ b/src/librepgp/stream-ctx.h
@@ -111,7 +111,7 @@ typedef struct rnp_ctx_t {
     std::list<rnp_symmetric_pass_info_t> passwords{}; /* passwords to encrypt message */
     std::list<rnp_signer_info_t>         signers{};   /* keys to which sign message */
     bool                                 discard{};   /* discard the output */
-    rng_t *                              rng{};       /* pointer to rng_t */
+    rnp::RNG *                           rng{};       /* pointer to rnp::RNG */
     rnp_operation_t                      operation{}; /* current operation type */
 
     rnp_ctx_t() = default;
@@ -121,8 +121,6 @@ typedef struct rnp_ctx_t {
     rnp_ctx_t &operator=(const rnp_ctx_t &) = delete;
     rnp_ctx_t &operator=(rnp_ctx_t &&) = delete;
 } rnp_ctx_t;
-
-struct rng_st_t *rnp_ctx_rng_handle(const rnp_ctx_t *ctx);
 
 rnp_result_t rnp_ctx_add_encryption_password(rnp_ctx_t &    ctx,
                                              const char *   password,

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -888,7 +888,7 @@ write_secret_key_mpis(pgp_packet_body_t &body, pgp_key_pkt_t &key)
 }
 
 rnp_result_t
-encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t *rng)
+encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t &rng)
 {
     if (!is_secret_key_pkt(key->tag) || !key->material.secret) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -931,23 +931,12 @@ encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t *rng)
             return RNP_ERROR_BAD_PARAMETERS;
         }
         /* generate iv and s2k salt */
-        if (rng) {
-            if (!rng_get_data(rng, key->sec_protection.iv, blsize)) {
-                return RNP_ERROR_RNG;
-            }
-            if ((key->sec_protection.s2k.specifier != PGP_S2KS_SIMPLE) &&
-                !rng_get_data(rng, key->sec_protection.s2k.salt, PGP_SALT_SIZE)) {
-                return RNP_ERROR_RNG;
-            }
-        } else {
-            /* temporary solution! */
-            if (!rng_generate(key->sec_protection.iv, blsize)) {
-                return RNP_ERROR_RNG;
-            }
-            if ((key->sec_protection.s2k.specifier != PGP_S2KS_SIMPLE) &&
-                !rng_generate(key->sec_protection.s2k.salt, PGP_SALT_SIZE)) {
-                return RNP_ERROR_RNG;
-            }
+        if (!rng_get_data(&rng, key->sec_protection.iv, blsize)) {
+            return RNP_ERROR_RNG;
+        }
+        if ((key->sec_protection.s2k.specifier != PGP_S2KS_SIMPLE) &&
+            !rng_get_data(&rng, key->sec_protection.s2k.salt, PGP_SALT_SIZE)) {
+            return RNP_ERROR_RNG;
         }
         /* derive key */
         rnp::secure_array<uint8_t, PGP_MAX_KEY_SIZE> keybuf;

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -888,7 +888,7 @@ write_secret_key_mpis(pgp_packet_body_t &body, pgp_key_pkt_t &key)
 }
 
 rnp_result_t
-encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t &rng)
+encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rnp::RNG &rng)
 {
     if (!is_secret_key_pkt(key->tag) || !key->material.secret) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -931,12 +931,9 @@ encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t &rng)
             return RNP_ERROR_BAD_PARAMETERS;
         }
         /* generate iv and s2k salt */
-        if (!rng_get_data(&rng, key->sec_protection.iv, blsize)) {
-            return RNP_ERROR_RNG;
-        }
-        if ((key->sec_protection.s2k.specifier != PGP_S2KS_SIMPLE) &&
-            !rng_get_data(&rng, key->sec_protection.s2k.salt, PGP_SALT_SIZE)) {
-            return RNP_ERROR_RNG;
+        rng.get(key->sec_protection.iv, blsize);
+        if ((key->sec_protection.s2k.specifier != PGP_S2KS_SIMPLE)) {
+            rng.get(key->sec_protection.s2k.salt, PGP_SALT_SIZE);
         }
         /* derive key */
         rnp::secure_array<uint8_t, PGP_MAX_KEY_SIZE> keybuf;

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -140,7 +140,7 @@ rnp_result_t write_pgp_keys(pgp_key_sequence_t &keys, pgp_dest_t *dst, bool armo
 
 rnp_result_t decrypt_secret_key(pgp_key_pkt_t *key, const char *password);
 
-rnp_result_t encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t &rng);
+rnp_result_t encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rnp::RNG &rng);
 
 void forget_secret_key_fields(pgp_key_material_t *key);
 

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -140,7 +140,7 @@ rnp_result_t write_pgp_keys(pgp_key_sequence_t &keys, pgp_dest_t *dst, bool armo
 
 rnp_result_t decrypt_secret_key(pgp_key_pkt_t *key, const char *password);
 
-rnp_result_t encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t *rng);
+rnp_result_t encrypt_secret_key(pgp_key_pkt_t *key, const char *password, rng_t &rng);
 
 void forget_secret_key_fields(pgp_key_material_t *key);
 

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1411,7 +1411,7 @@ static bool
 encrypted_try_key(pgp_source_encrypted_param_t *param,
                   pgp_pk_sesskey_t *            sesskey,
                   pgp_key_pkt_t *               seckey,
-                  rng_t *                       rng)
+                  rnp::RNG *                    rng)
 {
     pgp_encrypted_material_t encmaterial;
     try {
@@ -2102,8 +2102,7 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
             }
 
             /* Try to initialize the decryption */
-            if (encrypted_try_key(
-                  param, &pubenc, decrypted_seckey, rnp_ctx_rng_handle(handler->ctx))) {
+            if (encrypted_try_key(param, &pubenc, decrypted_seckey, handler->ctx->rng)) {
                 have_key = true;
                 /* inform handler that we used this pubenc */
                 if (handler->on_decryption_start) {

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1994,15 +1994,14 @@ done:
 }
 
 rnp_result_t
-rnp_raw_encrypt_src(pgp_source_t &src, pgp_dest_t &dst, const std::string &password)
+rnp_raw_encrypt_src(pgp_source_t &     src,
+                    pgp_dest_t &       dst,
+                    const std::string &password,
+                    rng_t &            rng)
 {
     pgp_write_handler_t handler = {};
     rnp_ctx_t           ctx;
-    rng_t               rng = {};
 
-    if (!rng_init(&rng, RNG_SYSTEM)) {
-        return RNP_ERROR_BAD_STATE;
-    }
     ctx.rng = &rng;
     ctx.ealg = DEFAULT_PGP_SYMM_ALG;
     handler.ctx = &ctx;
@@ -2022,6 +2021,5 @@ rnp_raw_encrypt_src(pgp_source_t &src, pgp_dest_t &dst, const std::string &passw
     ret = dst_write_src(&src, &encrypted);
 done:
     dst_close(&encrypted, ret);
-    rng_destroy(&rng);
     return ret;
 }

--- a/src/librepgp/stream-write.h
+++ b/src/librepgp/stream-write.h
@@ -84,6 +84,7 @@ rnp_result_t rnp_wrap_src(pgp_source_t &     src,
 
 rnp_result_t rnp_raw_encrypt_src(pgp_source_t &     src,
                                  pgp_dest_t &       dst,
-                                 const std::string &password);
+                                 const std::string &password,
+                                 rng_t &            rng);
 
 #endif

--- a/src/librepgp/stream-write.h
+++ b/src/librepgp/stream-write.h
@@ -85,6 +85,6 @@ rnp_result_t rnp_wrap_src(pgp_source_t &     src,
 rnp_result_t rnp_raw_encrypt_src(pgp_source_t &     src,
                                  pgp_dest_t &       dst,
                                  const std::string &password,
-                                 rng_t &            rng);
+                                 rnp::RNG &         rng);
 
 #endif

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -35,7 +35,7 @@
 #include "support.h"
 #include "fingerprint.h"
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 TEST_F(rnp_tests, hash_test_success)
 {
@@ -264,7 +264,7 @@ TEST_F(rnp_tests, ecdsa_signverify_success)
 
     for (size_t i = 0; i < ARRAY_SIZE(curves); i++) {
         // Generate test data. Mainly to make valgrind not to complain about uninitialized data
-        assert_true(rng_get_data(&global_rng, message, sizeof(message)));
+        global_rng.get(message, sizeof(message));
 
         pgp_ec_signature_t         sig = {{{0}}};
         rnp_keygen_crypto_params_t key_desc;
@@ -399,7 +399,7 @@ TEST_F(rnp_tests, sm2_roundtrip)
     key_desc.ecc = {.curve = PGP_CURVE_SM2_P_256};
     key_desc.rng = &global_rng;
 
-    assert_true(rng_get_data(&global_rng, key, sizeof(key)));
+    global_rng.get(key, sizeof(key));
 
     pgp_key_pkt_t seckey;
     assert_true(pgp_generate_seckey(key_desc, seckey, true));
@@ -541,7 +541,7 @@ TEST_F(rnp_tests, test_dsa_roundtrip)
       {1024, 256, PGP_HASH_SHA256},
     };
 
-    assert_true(rng_get_data(&global_rng, message, sizeof(message)));
+    global_rng.get(message, sizeof(message));
 
     for (size_t i = 0; i < ARRAY_SIZE(keys); i++) {
         sig = {};
@@ -581,7 +581,7 @@ TEST_F(rnp_tests, test_dsa_verify_negative)
         pgp_hash_alg_t h;
     } key = {1024, 160, PGP_HASH_SHA1};
 
-    assert_true(rng_get_data(&global_rng, message, sizeof(message)));
+    global_rng.get(message, sizeof(message));
 
     rnp_keygen_crypto_params_t key_desc;
     key_desc.key_alg = PGP_PKA_DSA;
@@ -679,7 +679,7 @@ read_key_pkt(pgp_key_pkt_t *key, const char *path)
 TEST_F(rnp_tests, test_validate_key_material)
 {
     pgp_key_pkt_t key;
-    rng_t &       rng = global_rng;
+    rnp::RNG &    rng = global_rng;
 
     /* RSA key and subkey */
     assert_true(read_key_pkt(&key, KEYS "rsa-pub.pgp"));

--- a/src/tests/data/test_key_validity/case5/generate.cpp
+++ b/src/tests/data/test_key_validity/case5/generate.cpp
@@ -46,7 +46,7 @@ bool calculate_primary_binding(const pgp_key_pkt_t &key,
                                pgp_hash_alg_t       halg,
                                pgp_signature_t &    sig,
                                rnp::Hash &          hash,
-                               rng_t &              rng);
+                               rnp::RNG &           rng);
 
 int
 main(int argc, char **argv)
@@ -109,12 +109,7 @@ main(int argc, char **argv)
         return 1;
     }
 
-    rng_t rng = {};
-    if (!rng_init(&rng, RNG_SYSTEM)) {
-        RNP_LOG("RNG init failed");
-        return 1;
-    }
-
+    rnp::RNG rng(rnp::RNG::Type::System);
     if (signature_calculate(binding, &tskey.key.material, &hash, &rng)) {
         RNP_LOG("failed to calculate signature");
         return 1;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -40,7 +40,7 @@
 #include "defaults.h"
 #include <fstream>
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 static bool
 generate_test_key(const char *keystore, const char *userid, const char *hash, const char *home)

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -26,10 +26,11 @@
 
 #include "../librekey/key_store_pgp.h"
 #include "pgp-key.h"
-
 #include "rnp_tests.h"
 #include "support.h"
 #include "crypto/hash.h"
+
+extern rng_t global_rng;
 
 /* This test loads a pgp keyring and adds a few userids to the key.
  */
@@ -67,8 +68,7 @@ TEST_F(rnp_tests, test_key_add_userid)
     unsigned subsigc = key->sig_count();
 
     // init rng
-    rng_t rng;
-    assert_true(rng_init(&rng, RNG_DRBG));
+    rng_t &rng = global_rng;
     // add first, non-primary userid
     rnp_selfsig_cert_info_t selfsig0 = {};
     memcpy(selfsig0.userid, "added0", 7);
@@ -115,7 +115,6 @@ TEST_F(rnp_tests, test_key_add_userid)
 
     // actually add another userid
     key->add_uid_cert(selfsig2, PGP_HASH_SHA1, rng);
-    rng_destroy(&rng);
 
     // confirm that the counts have increased as expected
     assert_int_equal(key->uid_count(), uidc + 3);

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -30,7 +30,7 @@
 #include "support.h"
 #include "crypto/hash.h"
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 /* This test loads a pgp keyring and adds a few userids to the key.
  */
@@ -68,7 +68,7 @@ TEST_F(rnp_tests, test_key_add_userid)
     unsigned subsigc = key->sig_count();
 
     // init rng
-    rng_t &rng = global_rng;
+    rnp::RNG &rng = global_rng;
     // add first, non-primary userid
     rnp_selfsig_cert_info_t selfsig0 = {};
     memcpy(selfsig0.userid, "added0", 7);

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -32,7 +32,7 @@
 #include "crypto/hash.h"
 #include "crypto.h"
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 /* This test loads a .gpg keyring and tests protect/unprotect functionality.
  * There is also some lock/unlock testing in here, since the two are

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -32,6 +32,8 @@
 #include "crypto/hash.h"
 #include "crypto.h"
 
+extern rng_t global_rng;
+
 /* This test loads a .gpg keyring and tests protect/unprotect functionality.
  * There is also some lock/unlock testing in here, since the two are
  * somewhat related.
@@ -87,15 +89,15 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
     // try to unprotect with a failing password provider
     pgp_password_provider_t pprov = {.callback = failing_password_callback, .userdata = NULL};
-    assert_false(key->unprotect(pprov));
+    assert_false(key->unprotect(pprov, global_rng));
 
     // try to unprotect with an incorrect password
     pprov = {.callback = string_copy_password_callback, .userdata = (void *) "badpass"};
-    assert_false(key->unprotect(pprov));
+    assert_false(key->unprotect(pprov, global_rng));
 
     // unprotect with the correct password
     pprov = {.callback = string_copy_password_callback, .userdata = (void *) "password"};
-    assert_true(key->unprotect(pprov));
+    assert_true(key->unprotect(pprov, global_rng));
     assert_false(key->is_protected());
 
     // should still be locked
@@ -183,7 +185,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
     // try to protect (will fail when key is locked)
     pprov = {.callback = string_copy_password_callback, .userdata = (void *) "newpass"};
-    assert_false(key->protect({}, pprov));
+    assert_false(key->protect({}, pprov, global_rng));
     assert_false(key->is_protected());
 
     // unlock
@@ -193,12 +195,12 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
     // try to protect with a failing password provider
     pprov = {.callback = failing_password_callback, .userdata = NULL};
-    assert_false(key->protect({}, pprov));
+    assert_false(key->protect({}, pprov, global_rng));
     assert_false(key->is_protected());
 
     // (re)protect with a new password
     pprov = {.callback = string_copy_password_callback, .userdata = (void *) "newpass"};
-    assert_true(key->protect({}, pprov));
+    assert_true(key->protect({}, pprov, global_rng));
     assert_true(key->is_protected());
 
     // lock
@@ -227,24 +229,21 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
 TEST_F(rnp_tests, test_key_protect_sec_data)
 {
-    rng_t rng;
-    assert_true(rng_init(&rng, RNG_DRBG));
-
     rnp_keygen_primary_desc_t pri_desc = {};
     pri_desc.crypto.key_alg = PGP_PKA_RSA;
     pri_desc.crypto.rsa.modulus_bit_len = 1024;
-    pri_desc.crypto.rng = &rng;
+    pri_desc.crypto.rng = &global_rng;
     memcpy(pri_desc.cert.userid, "test", 5);
 
     rnp_keygen_subkey_desc_t sub_desc = {};
     sub_desc.crypto.key_alg = PGP_PKA_RSA;
     sub_desc.crypto.rsa.modulus_bit_len = 1024;
-    sub_desc.crypto.rng = &rng;
+    sub_desc.crypto.rng = &global_rng;
 
     /* generate raw unprotected keypair */
     pgp_key_t skey, pkey, ssub, psub;
     assert_true(pgp_generate_keypair(
-      rng, pri_desc, sub_desc, true, skey, pkey, ssub, psub, PGP_KEY_STORE_GPG));
+      global_rng, pri_desc, sub_desc, true, skey, pkey, ssub, psub, PGP_KEY_STORE_GPG));
     assert_non_null(skey.pkt().sec_data);
     assert_non_null(ssub.pkt().sec_data);
     assert_null(pkey.pkt().sec_data);
@@ -292,8 +291,8 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     pgp_password_provider_t     pprov = {.callback = string_copy_password_callback,
                                      .userdata = (void *) "password"};
     rnp_key_protection_params_t prot = {};
-    assert_true(skey.protect(prot, pprov));
-    assert_true(ssub.protect(prot, pprov));
+    assert_true(skey.protect(prot, pprov, global_rng));
+    assert_true(ssub.protect(prot, pprov, global_rng));
     assert_int_not_equal(memcmp(raw_skey, skey.pkt().sec_data, 32), 0);
     assert_int_not_equal(memcmp(raw_ssub, ssub.pkt().sec_data, 32), 0);
 #if defined(__has_feature)
@@ -327,15 +326,15 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_int_not_equal(memcmp(raw_skey, skey.pkt().sec_data, 32), 0);
     assert_int_not_equal(memcmp(raw_ssub, ssub.pkt().sec_data, 32), 0);
     /* unprotect key */
-    assert_true(skey.unprotect(pprov));
-    assert_true(ssub.unprotect(pprov));
+    assert_true(skey.unprotect(pprov, global_rng));
+    assert_true(ssub.unprotect(pprov, global_rng));
     assert_int_equal(memcmp(raw_skey, skey.pkt().sec_data, 32), 0);
     assert_int_equal(memcmp(raw_ssub, ssub.pkt().sec_data, 32), 0);
     /* protect it back  with another password */
     pgp_password_provider_t pprov2 = {.callback = string_copy_password_callback,
                                       .userdata = (void *) "password2"};
-    assert_true(skey.protect(prot, pprov2));
-    assert_true(ssub.protect(prot, pprov2));
+    assert_true(skey.protect(prot, pprov2, global_rng));
+    assert_true(ssub.protect(prot, pprov2, global_rng));
     assert_int_not_equal(memcmp(raw_skey, skey.pkt().sec_data, 32), 0);
     assert_int_not_equal(memcmp(raw_ssub, ssub.pkt().sec_data, 32), 0);
     assert_false(skey.unlock(pprov));
@@ -361,6 +360,4 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_int_not_equal(memcmp(raw_ssub, ssubpkt->sec_data, 32), 0);
     assert_int_equal(ssubpkt->sec_protection.s2k.specifier, PGP_S2KS_ITERATED_AND_SALTED);
     delete ssubpkt;
-
-    rng_destroy(&rng);
 }

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -32,7 +32,7 @@
 #include "../librepgp/stream-packet.h"
 #include "../librepgp/stream-armor.h"
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 static bool
 all_keys_valid(const rnp_key_store_t *keyring, pgp_key_t *except = NULL)

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -34,7 +34,7 @@ static char original_dir[PATH_MAX];
 /*
  * Handler used to access DRBG.
  */
-rng_t global_rng;
+rnp::RNG global_rng;
 
 rnp_tests::rnp_tests() : m_dir(make_temp_dir())
 {

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -42,7 +42,7 @@
 #include <algorithm>
 #include "time-utils.h"
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 static bool
 stream_hash_file(rnp::Hash &hash, const char *path)

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -50,7 +50,7 @@
 #include <ftw.h>
 #endif
 
-extern rng_t global_rng;
+extern rnp::RNG global_rng;
 
 #ifdef _WIN32
 int


### PR DESCRIPTION
Within this PR:
- only single top-level RNG is used in underlying code, which fixes #1106 
- refactors POD rng_t to C++ class
- makes rnp_ffi_st C++ object instead POD, which will be usefull later
