### PR TITLE
Add simple repetition count test for RNG output.

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(rnp_tests
   partial-length.cpp
   pipe.cpp
   rnp_tests.cpp
+  rng-randomness.cpp
   s2k-iterations.cpp
   streams.cpp
   support.cpp

--- a/src/tests/rng-randomness.cpp
+++ b/src/tests/rng-randomness.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017-2022 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <rnp/rnp.h>
+#include "rnp_tests.h"
+#include <crypto/rng.h>
+#include <string.h>
+
+extern rnp::RNG global_rng;
+
+TEST_F(rnp_tests, test_rng_randomness)
+{
+    uint8_t samples[4096];
+
+    memset(samples, 0, sizeof(samples));
+
+    // Repetition Count Test, see NIST SP 800-90B
+    const int C = 6; // cutoff value
+    int       B = 1;
+    uint8_t   A;
+    global_rng.get(samples, sizeof(samples));
+    A = samples[0];
+    for (int i = 1; i < sizeof(samples); i++) {
+        if (samples[i] == A) {
+            B++;
+            assert_int_not_equal(B, C);
+        } else {
+            A = samples[i];
+            B = 1;
+        }
+    }
+}

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -457,6 +457,8 @@ void test_fuzz_dump(void **state);
 
 void test_fuzz_verify_detached(void **state);
 
+void test_rng_randomness(void **state);
+
 #define assert_true(a) EXPECT_TRUE((a))
 #define assert_false(a) EXPECT_FALSE((a))
 #define assert_string_equal(a, b) EXPECT_STREQ((a), (b))


### PR DESCRIPTION
This test recommended by NIST SP 800-90B is intended to detect catastrophic failures of RNG, possibly caused by misconfiguration. It can fail with some low probability on a good random data provided by RNG.