### PR TITLE
nix: Add initial Nix support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
 task:
   name: build
   only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'release/.*' || $CIRRUS_PR != ''
-  skip: "changesIncludeOnly('docs/*', '.github/*') || $CIRRUS_CHANGE_MESSAGE =~ '.*skip ci.*'"
+  skip: "!changesInclude('.cirrus.yml') && changesIncludeOnly('/*.sh', '/.*', '/_*', '/vcpkg.txt', 'Brewfile', 'docs/**', '**.adoc', '**.md', '**.nix', 'flake.lock', '.github/**') || $CIRRUS_CHANGE_MESSAGE =~ '.*skip ci.*'"
   # increase timeout since we use a single task for building cache and testing
   timeout_in: 90m
   env:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -6,16 +6,30 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/centos7.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   CORES: 2

--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -6,16 +6,30 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/centos8-ossl.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   CORES: 2

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -6,16 +6,30 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/centos8.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   CORES: 2

--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -6,16 +6,30 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/debian9.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   CORES: 2

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -3,9 +3,16 @@ name: fuzzing
 on:
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 jobs:
   fuzzing:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,16 @@ name: lint
 on:
   pull_request:
     paths-ignore:
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - '!.clang-format'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 jobs:
   clang-format:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,16 +6,28 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/macos.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   CORES: 2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,47 @@
+name: nix
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - 'ci/**'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/nix.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - 'ci/**'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,16 +6,30 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   CORES: 2

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -5,16 +5,28 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/windows-msvc.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 jobs:
   build_and_test:

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -6,16 +6,28 @@ on:
       - master
       - 'release/**'
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
       - '.github/workflows/*.yml'
       - '!.github/workflows/windows-msys2.yml'
   pull_request:
     paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 env:
   BUILD_MODE: normal
@@ -57,7 +69,7 @@ jobs:
 #          . ci/gha/setup-env.inc.sh
         run: |
           bash ci/install_noncacheable_dependencies.sh
-# Since all dependencies are available as binary packages no extra steps or cache are required 
+# Since all dependencies are available as binary packages no extra steps or cache are required
 # The code below kept here for potential need to build some dependencies locally
 #      - name: Cache
 #        id: cache

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ CPackSourceConfig.cmake
 DartConfiguration.tcl
 _CPack_Packages/
 
+# Nix
+result
+
 # Created by https://www.toptal.com/developers/gitignore/api/c,vim,c++,macos,linux,patch,cmake,emacs,vscode,python,windows,textmate,sublimetext
 # Edit at https://www.toptal.com/developers/gitignore?templates=c,vim,c++,macos,linux,patch,cmake,emacs,vscode,python,windows,textmate,sublimetext
 

--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,7 @@ Currently supported platforms:
 * Fedora 25
 * RHEL/CentOS 7
 * Ubuntu 14.04 LTS, 16.04 LTS, 18.04
+* NixOS / Nix
 
 Upcoming supported platforms:
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,46 @@
+{ pkgs ? import <nixpkgs> { }
+, lib ? pkgs.lib
+, stdenv ? pkgs.stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rnp";
+  version = "unstable";
+
+  src = ./.;
+
+  buildInputs = with pkgs; [ zlib bzip2 json_c botan2 ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DBUILD_SHARED_LIBS=on"
+    "-DBUILD_TESTING=on"
+    "-DDOWNLOAD_GTEST=off"
+    "-DDOWNLOAD_RUBYRNP=off"
+  ];
+
+  nativeBuildInputs = with pkgs; [ asciidoctor cmake gnupg gtest pkg-config python3 ];
+
+  # NOTE: check-only inputs should ideally be moved to checkInputs, but it
+  # would fail during buildPhase.
+  # checkInputs = [ gtest python3 ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  preConfigure = ''
+    commitEpoch=$(date +%s)
+    baseVersion=$(cat version.txt)
+    echo "v$baseVersion-0-g0-dirty+$commitEpoch" > version.txt
+
+    # For generating the correct timestamp in cmake
+    export SOURCE_DATE_EPOCH=$commitEpoch
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/rnpgp/rnp";
+    description = "High performance C++ OpenPGP library, fully compliant to RFC 4880";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ribose-jeffreylau ];
+  };
+}

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -5,6 +5,26 @@ Binaries that will be installed:
 * `rnp`
 * `rnpkeys`
 
+
+== On NixOS or Nix package manager
+
+We provide a Nix package for easy installation on NixOS and any OS with Nix
+installed (including Linux and macOS, even NixOS on WSL).
+
+[source,console]
+----
+nix-env -iA nixpkgs.rnp
+----
+
+== With Nix Flakes
+
+We provide a Nix flake.
+
+[source,console]
+----
+nix profile install github:rnpgp/rnp
+----
+
 == On macOS using Homebrew
 
 We provide a Homebrew tap for easy installation of RNP on macOS.
@@ -211,4 +231,3 @@ executables):
 
 You may check dependencies and their paths via `ntldd.exe` in the MSYS command
 prompt.
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1640849002,
+        "narHash": "sha256-XrU11TR+Nz7bm8XLU07uQJAxeH5cKnZhXf0hfZftFqE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d50c9666ca2b96b4488551ec968babe4cc45c52b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "High performance C++ OpenPGP library, fully compliant to RFC 4880";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        thePackage = pkgs.callPackage ./default.nix { };
+      in
+      rec {
+        defaultApp = flake-utils.lib.mkApp {
+          drv = defaultPackage;
+        };
+        defaultPackage = thePackage;
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            thePackage
+          ];
+        };
+      });
+}


### PR DESCRIPTION
With Nix installed, the following are enabled:

- Build `rnp`:

  ```console
  > nix-build        # if in rnp source dir
  > ls result/bin
  rnp  rnpkeys
  ```

  You can then directly run the built binaries:

  ```console
  > result/bin/rnp --version
  ...
  > result/bin/rnpkeys --version
  ...
  ```

- Install `rnp` imperatively:

  ```console
  > nix-env -i -f .  # if in rnp source dir
  ```
    or
  ```console
  > nix-env -i rnp  # This is actually provided by the rnp Nix files in github:nixos/nixpkgs.
  ```

- Drop into `rnp` development shell (with all build dependencies installed for you):

  ```console
  > nix-shell       # if in rnp source dir
  ```
    or
  ```console
  > nix-shell '<nixpkgs>' -A rnp   # This is actually provided by the rnp Nix files in github:nixos/nixpkgs.
  ```

Assuming Nix Flake (https://nixos.wiki/wiki/Flakes) support is configured, the following are enabled:

- Build `rnp`:

  ```console
  > nix build    # if in rnp source dir
  ```
    or
  ```console
  > nix build github:rnpgp/rnp
  ```

- Run `rnp` without installing:

  ```console
  > nix run . [-- [RNP_OPTIONS_AND_PARAMS]]  # if in rnp source dir
  ```
    or
  ```console
  > nix run github:rnpgp/rnp [-- [RNP_OPTIONS_AND_PARAMS]]
  ```

- Install `rnp` imperatively:

  ```console
  > nix profile install    # if in rnp source dir
  ```
    or
  ```console
  > nix profile install github:rnpgp/rnp
  ```

- Drop into `rnp` development shell (with all build dependencies installed for you):

  ```console
  > nix develop    # if in rnp source dir
  ```
    or
  ```console
  > nix develop github:rnpgp/rnp
  ```
