### PR TITLE
Fix broken OpenSSL CI runs and corresponding undetected errors.

### DIFF
--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -39,13 +39,14 @@ env:
   LC_LANG: C.UTF-8
   USE_STATIC_DEPENDENCIES: yes
   DOWNLOAD_RUBYRNP: Off
+  CRYPTO_BACKEND: openssl
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     container:
-      image: ${{ matrix.env.IMAGE }}
+      image: centos:8
     timeout-minutes: 70
     strategy:
       fail-fast: false
@@ -55,44 +56,36 @@ jobs:
             RNP_TESTS: rnp_tests
             CC: gcc
             CXX: g++
-            IMAGE: centos:8
           - BUILD_MODE: sanitize
             RNP_TESTS: rnp_tests
             CC: gcc
             CXX: g++
-            IMAGE: centos:8
           - BUILD_MODE: normal
             RNP_TESTS: cli_tests
             CC: gcc
             CXX: g++
-            IMAGE: centos:8
           - BUILD_MODE: sanitize
             RNP_TESTS: cli_tests
             CC: gcc
             CXX: g++
-            IMAGE: centos:8
           - BUILD_MODE: normal
             RNP_TESTS: rnp_tests
             CC: clang
             CXX: clang++
-            IMAGE: centos:8
           - BUILD_MODE: sanitize
             RNP_TESTS: rnp_tests
             CC: clang
             CXX: clang++
-            IMAGE: centos:8
           - BUILD_MODE: normal
             RNP_TESTS: cli_tests
             CC: clang
             CXX: clang++
-            IMAGE: centos:8
           - BUILD_MODE: sanitize
             RNP_TESTS: cli_tests
             CC: clang
             CXX: clang++
-            IMAGE: centos:8
     env: ${{ matrix.env }}
-    name: ${{ matrix.env.IMAGE }} OpenSSL [test type ${{ matrix.env.RNP_TESTS }}; mode ${{ matrix.env.BUILD_MODE }}; CC ${{ matrix.env.CC }}; GnuPG ${{ matrix.env.GPG_VERSION }}]
+    name: centos:8 OpenSSL [test type ${{ matrix.env.RNP_TESTS }}; mode ${{ matrix.env.BUILD_MODE }}; CC ${{ matrix.env.CC }}; GnuPG ${{ matrix.env.GPG_VERSION }}]
     steps:
       - run: |
           yum -y install git

--- a/src/lib/crypto/elgamal_ossl.cpp
+++ b/src/lib/crypto/elgamal_ossl.cpp
@@ -36,6 +36,7 @@
 #include <openssl/dh.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/rand.h>
 
 // Max supported key byte size
 #define ELGAMAL_MAX_P_BYTELEN BITS_TO_BYTES(PGP_MPINT_BITS)

--- a/src/lib/crypto/rng_ossl.cpp
+++ b/src/lib/crypto/rng_ossl.cpp
@@ -27,9 +27,10 @@
 #include <assert.h>
 #include <openssl/rand.h>
 #include "rng.h"
+#include "types.h"
 
 namespace rnp {
-RNG::RNG(Type type = Type::DRBG)
+RNG::RNG(Type type)
 {
 }
 

--- a/src/tests/data/test_cli_rnpkeys/test_stream_key_load_keys_no_bp
+++ b/src/tests/data/test_cli_rnpkeys/test_stream_key_load_keys_no_bp
@@ -28,10 +28,10 @@ uid           ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-pub   3072/RSA (Encrypt or Sign) 2fb9179118898e8b 2018-04-03 [SC]
+pub   3072/RSA (Encrypt or Sign) 2fb9179118898e8b 2018-04-03 [ESCA]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
 uid           rsa-rsa
-sub   3072/RSA (Encrypt or Sign) 6e2f73008f8b8d6e 2018-04-03 [E]
+sub   3072/RSA (Encrypt or Sign) 6e2f73008f8b8d6e 2018-04-03 [ESCA]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
 pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SCA]
@@ -69,3 +69,4 @@ pub   2048/RSA (Encrypt or Sign) bd860a52d1899c0f 2021-12-24 [SC]
 uid           rsa-rsa-2
 sub   2048/RSA (Encrypt or Sign) 8e08d46a37414996 2021-12-24 [E]
       ca3e4420cf3d3b62d9ee7c6e8e08d46a37414996
+

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1158,13 +1158,16 @@ TEST_F(rnp_tests, test_stream_key_signature_validate)
     assert_true(validate_key_sigs("data/test_stream_key_load/ecc-p521-sec.asc"));
     assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp256-pub.asc") ==
                 brainpool_enabled());
-    assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp256-sec.asc"));
+    assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp256-sec.asc") ==
+                brainpool_enabled());
     assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp384-pub.asc") ==
                 brainpool_enabled());
-    assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp384-sec.asc"));
+    assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp384-sec.asc") ==
+                brainpool_enabled());
     assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp512-pub.asc") ==
                 brainpool_enabled());
-    assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp512-sec.asc"));
+    assert_true(validate_key_sigs("data/test_stream_key_load/ecc-bp512-sec.asc") ==
+                brainpool_enabled());
     assert_true(validate_key_sigs("data/test_stream_key_load/ecc-p256k1-pub.asc"));
     assert_true(validate_key_sigs("data/test_stream_key_load/ecc-p256k1-sec.asc"));
 }


### PR DESCRIPTION
OpenSSL crypto backend was accidentally deleted from the workflow, so for a while we didn't actually run OpenSSL tests.
This PR should fix this and accummulated errors, and make workflow file a bit less redundant.