### PR TITLE
Fix Cirrus CI run

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,8 +31,10 @@ task:
     su rnpuser -c 'bash ci/install_noncacheable_dependencies.sh'
   dependencies_cache:
     folder: $LOCAL_INSTALLS
-    fingerprint_script: sha256 ci/install.sh && git ls-remote https://github.com/rnpgp/ruby-rnp.git HEAD
+    fingerprint_script: sha256 ci/*.sh ci/lib/*.sh && date +"%U" && git ls-remote https://github.com/rnpgp/ruby-rnp.git HEAD
   install_script: |
+    # Currently GnuPG is forced to be built with gcc
+    pkg install -y gcc
     # cirrus cache doesn't seem to retain ownership
     mkdir -p "$LOCAL_INSTALLS"
     chown -R rnpuser:rnpuser "$LOCAL_INSTALLS"

--- a/ci/lib/cacheable_install_functions.inc.sh
+++ b/ci/lib/cacheable_install_functions.inc.sh
@@ -233,7 +233,7 @@ install_gpg() {
     case "${GPG_VERSION}" in
       stable)
         #                              npth libgpg-error libgcrypt libassuan libksba pinentry gnupg
-        _install_gpg component-version 1.6  1.39         1.8.7     2.5.4     1.5.0   1.1.0    2.2.24
+        _install_gpg component-version 1.6  1.43         1.8.8     2.5.5     1.6.0   1.1.0    2.2.33
         # _install_gpg component-version 1.6  1.42         1.9.2     2.5.5     1.5.0   1.1.1    2.2.27
         ;;
       beta)


### PR DESCRIPTION
This PR:
- fixes CI run which was failing due to forced GnuPG gcc requirement. However, since cache key was based only on install.sh and ruby-rnp repository this did not appear for 3 or 4 months.
- updates cache key calculation
- update stable GnuPG and it's component versions to the LTS ones.