### PR TITLE
Display key/sig validity status in key listing.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1387,6 +1387,16 @@ RNP_API rnp_result_t rnp_signature_get_expiration(rnp_signature_handle_t sig,
  */
 RNP_API rnp_result_t rnp_signature_get_keyid(rnp_signature_handle_t sig, char **result);
 
+/** Get signer's key fingerprint from the signature.
+ *  Note: if key fingerprint is not available from the signature then NULL value will
+ *        be stored to result.
+ * @param sig signature handle
+ * @param result hex-encoded key fp will be stored here. Cannot be NULL. You must free it
+ *               later on using the rnp_buffer_destroy() function.
+ * @return RNP_SUCCESS or error code if failed.
+ */
+RNP_API rnp_result_t rnp_signature_get_key_fprint(rnp_signature_handle_t sig, char **result);
+
 /** Get signing key handle, if available.
  *  Note: if signing key is not available then NULL will be stored in key.
  * @param sig signature handle

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -6205,6 +6205,24 @@ try {
 FFI_GUARD
 
 rnp_result_t
+rnp_signature_get_key_fprint(rnp_signature_handle_t handle, char **result)
+try {
+    if (!handle || !result) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    if (!handle->sig) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    if (!handle->sig->sig.has_keyfp()) {
+        *result = NULL;
+        return RNP_SUCCESS;
+    }
+    pgp_fingerprint_t keyfp = handle->sig->sig.keyfp();
+    return hex_encode_value(keyfp.fingerprint, keyfp.length, result);
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_signature_get_signer(rnp_signature_handle_t sig, rnp_key_handle_t *key)
 try {
     if (!sig || !sig->sig) {

--- a/src/tests/data/test_cli_rnpkeys/g10_list_keys
+++ b/src/tests/data/test_cli_rnpkeys/g10_list_keys
@@ -28,10 +28,10 @@ uid           ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-pub   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+pub   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
 pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SC]

--- a/src/tests/data/test_cli_rnpkeys/g10_list_keys_no_bp
+++ b/src/tests/data/test_cli_rnpkeys/g10_list_keys_no_bp
@@ -28,28 +28,28 @@ uid           ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-pub   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+pub   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
-pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SCA]
+pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [INVALID]
       0633c5f72a198f51e650e4abd0c8a3daf9e0634a
-uid           ecc-bp256
-sub   256/ECDH 2edabb94d3055f76 2018-04-03 [E]
+uid           ecc-bp256 [INVALID]
+sub   256/ECDH 2edabb94d3055f76 2018-04-03 [INVALID]
       08192b478f740360b74c82cc2edabb94d3055f76
 
-pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [SCA]
+pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [INVALID]
       5b8a254c823ced98decd10ed6cf2dce85599ada2
-uid           ecc-bp384
-sub   384/ECDH cff1bb6f16d28191 2018-04-03 [E]
+uid           ecc-bp384 [INVALID]
+sub   384/ECDH cff1bb6f16d28191 2018-04-03 [INVALID]
       76969ce7033d990931df92b2cff1bb6f16d28191
 
-pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [SCA]
+pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [INVALID]
       4c59ab9272aa6a1f60b85bd0aa5c58d14f7b8f48
-uid           ecc-bp512
-sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [E]
+uid           ecc-bp512 [INVALID]
+sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [INVALID]
       270a7cd0dc6c2e01dce8603620cdaa1482ba79ce
 
 pub   255/EdDSA 941822a0fc1b30a5 2018-10-15 [SC]

--- a/src/tests/data/test_cli_rnpkeys/g10_list_keys_sec
+++ b/src/tests/data/test_cli_rnpkeys/g10_list_keys_sec
@@ -28,10 +28,10 @@ uid           ecc-p521
 ssb   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-sec   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+sec   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-ssb   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+ssb   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
 sec   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SC]

--- a/src/tests/data/test_cli_rnpkeys/g10_list_keys_sec_no_bp
+++ b/src/tests/data/test_cli_rnpkeys/g10_list_keys_sec_no_bp
@@ -28,28 +28,28 @@ uid           ecc-p521
 ssb   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-sec   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+sec   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-ssb   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+ssb   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
-sec   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SCA]
+sec   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [INVALID]
       0633c5f72a198f51e650e4abd0c8a3daf9e0634a
-uid           ecc-bp256
-ssb   256/ECDH 2edabb94d3055f76 2018-04-03 [E]
+uid           ecc-bp256 [INVALID]
+ssb   256/ECDH 2edabb94d3055f76 2018-04-03 [INVALID]
       08192b478f740360b74c82cc2edabb94d3055f76
 
-sec   384/ECDSA 6cf2dce85599ada2 2018-04-03 [SCA]
+sec   384/ECDSA 6cf2dce85599ada2 2018-04-03 [INVALID]
       5b8a254c823ced98decd10ed6cf2dce85599ada2
-uid           ecc-bp384
-ssb   384/ECDH cff1bb6f16d28191 2018-04-03 [E]
+uid           ecc-bp384 [INVALID]
+ssb   384/ECDH cff1bb6f16d28191 2018-04-03 [INVALID]
       76969ce7033d990931df92b2cff1bb6f16d28191
 
-sec   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [SCA]
+sec   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [INVALID]
       4c59ab9272aa6a1f60b85bd0aa5c58d14f7b8f48
-uid           ecc-bp512
-ssb   512/ECDH 20cdaa1482ba79ce 2018-04-03 [E]
+uid           ecc-bp512 [INVALID]
+ssb   512/ECDH 20cdaa1482ba79ce 2018-04-03 [INVALID]
       270a7cd0dc6c2e01dce8603620cdaa1482ba79ce
 
 sec   255/EdDSA 941822a0fc1b30a5 2018-10-15 [SC]

--- a/src/tests/data/test_cli_rnpkeys/getkey_2fcadf05ffa501bb_sig
+++ b/src/tests/data/test_cli_rnpkeys/getkey_2fcadf05ffa501bb_sig
@@ -10,6 +10,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/getkey_2fcadf05ffa501bb_sig_y2k38
+++ b/src/tests/data/test_cli_rnpkeys/getkey_2fcadf05ffa501bb_sig_y2k38
@@ -10,6 +10,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES >=2038-01-19]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs
+++ b/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs
@@ -10,10 +10,13 @@ uid           key0-uid2
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 sub   1024/RSA 1ed63ee56fadc34d 2017-07-20 [E]
       e332b27caf4742a11baa677f1ed63ee56fadc34d
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 sub   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
       c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 sub   1024/RSA 8a05b89fad5aded1 2017-07-20 [E]
       5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 
 pub   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
@@ -25,6 +28,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_sec
+++ b/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_sec
@@ -10,10 +10,13 @@ uid           key0-uid2
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 ssb   1024/RSA 1ed63ee56fadc34d 2017-07-20 [E]
       e332b27caf4742a11baa677f1ed63ee56fadc34d
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 ssb   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
       c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 ssb   1024/RSA 8a05b89fad5aded1 2017-07-20 [E]
       5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 
 sec   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
@@ -25,6 +28,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 ssb   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 ssb   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_sec_y2k38
+++ b/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_sec_y2k38
@@ -10,10 +10,13 @@ uid           key0-uid2
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 ssb   1024/RSA 1ed63ee56fadc34d 2017-07-20 [E]
       e332b27caf4742a11baa677f1ed63ee56fadc34d
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 ssb   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
       c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 ssb   1024/RSA 8a05b89fad5aded1 2017-07-20 [E]
       5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 
 sec   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES >=2038-01-19]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
@@ -25,6 +28,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 ssb   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES >=2038-01-19]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 ssb   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_y2k38
+++ b/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_y2k38
@@ -10,10 +10,13 @@ uid           key0-uid2
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 sub   1024/RSA 1ed63ee56fadc34d 2017-07-20 [E]
       e332b27caf4742a11baa677f1ed63ee56fadc34d
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 sub   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
       c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 sub   1024/RSA 8a05b89fad5aded1 2017-07-20 [E]
       5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid0
 
 pub   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES >=2038-01-19]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
@@ -25,6 +28,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES >=2038-01-19]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_3_list_sigs
+++ b/src/tests/data/test_cli_rnpkeys/keyring_3_list_sigs
@@ -6,4 +6,5 @@ uid           test1
 sig           4be147bb22df1e60 2019-10-11 test1
 sub   2048/RSA a49bae05c16e8bc8 2017-09-30 [E] [EXPIRES 2069-09-28]
       10793e367ee867c32e358f2aa49bae05c16e8bc8
+sig           4be147bb22df1e60 2019-10-11 test1
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_3_list_sigs_y2k38
+++ b/src/tests/data/test_cli_rnpkeys/keyring_3_list_sigs_y2k38
@@ -6,4 +6,5 @@ uid           test1
 sig           4be147bb22df1e60 2019-10-11 test1
 sub   2048/RSA a49bae05c16e8bc8 2017-09-30 [E] [EXPIRES >=2038-01-19]
       10793e367ee867c32e358f2aa49bae05c16e8bc8
+sig           4be147bb22df1e60 2019-10-11 test1
 

--- a/src/tests/data/test_cli_rnpkeys/keyring_5_list_sigs
+++ b/src/tests/data/test_cli_rnpkeys/keyring_5_list_sigs
@@ -6,4 +6,5 @@ uid           test0
 sig           0e33fd46ff10f19c 2017-11-22 test0
 sub   256/ECDH 074131bc8d16c5c9 2017-11-22 [E]
       481e6a41b10ecd71a477db02074131bc8d16c5c9
+sig           0e33fd46ff10f19c 2017-11-22 test0
 

--- a/src/tests/data/test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt
+++ b/src/tests/data/test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt
@@ -2,17 +2,20 @@
 
 pub   1024/RSA 7bc6709b15c23a4a 2017-07-20 [SC]
       e95a3cbf583aa80a2ccc53aa7bc6709b15c23a4a
-uid           key0-uid0
+uid           key0-uid0 [INVALID]
 uid           key0-uid1
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 uid           key0-uid2
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 sub   1024/RSA 1ed63ee56fadc34d 2017-07-20 [E]
       e332b27caf4742a11baa677f1ed63ee56fadc34d
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 sub   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
       c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 sub   1024/RSA 8a05b89fad5aded1 2017-07-20 [E]
       5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 
 pub   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
@@ -24,6 +27,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt_y2k38
+++ b/src/tests/data/test_cli_rnpkeys/pubring-malf-cert-permissive-import.txt_y2k38
@@ -2,17 +2,20 @@
 
 pub   1024/RSA 7bc6709b15c23a4a 2017-07-20 [SC]
       e95a3cbf583aa80a2ccc53aa7bc6709b15c23a4a
-uid           key0-uid0
+uid           key0-uid0 [INVALID]
 uid           key0-uid1
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 uid           key0-uid2
 sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 sub   1024/RSA 1ed63ee56fadc34d 2017-07-20 [E]
       e332b27caf4742a11baa677f1ed63ee56fadc34d
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 sub   1024/DSA 1d7e8a5393c997a8 2017-07-20 [S] [EXPIRED 2017-11-20]
       c5b15209940a7816a7af3fb51d7e8a5393c997a8
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 sub   1024/RSA 8a05b89fad5aded1 2017-07-20 [E]
       5cd46d2a0bd0b8cfe0b130ae8a05b89fad5aded1
+sig           7bc6709b15c23a4a 2017-07-20 key0-uid1
 
 pub   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES >=2038-01-19]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
@@ -24,6 +27,8 @@ uid           key1-uid1
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 54505a936a4a970e 2017-07-20 [E] [EXPIRES >=2038-01-19]
       a3e94de61a8cb229413d348e54505a936a4a970e
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 sub   1024/ElGamal 326ef111425d14a5 2017-07-20 [E]
       57f8ed6e5c197db63c60ffaf326ef111425d14a5
+sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 

--- a/src/tests/data/test_cli_rnpkeys/test_stream_key_load_keys
+++ b/src/tests/data/test_cli_rnpkeys/test_stream_key_load_keys
@@ -28,10 +28,10 @@ uid           ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-pub   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+pub   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
 pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SC]

--- a/src/tests/data/test_cli_rnpkeys/test_stream_key_load_keys_no_bp
+++ b/src/tests/data/test_cli_rnpkeys/test_stream_key_load_keys_no_bp
@@ -28,28 +28,28 @@ uid           ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
 
-pub   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+pub   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
 
-pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SCA]
+pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [INVALID]
       0633c5f72a198f51e650e4abd0c8a3daf9e0634a
-uid           ecc-bp256
-sub   256/ECDH 2edabb94d3055f76 2018-04-03 [E]
+uid           ecc-bp256 [INVALID]
+sub   256/ECDH 2edabb94d3055f76 2018-04-03 [INVALID]
       08192b478f740360b74c82cc2edabb94d3055f76
 
-pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [SCA]
+pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [INVALID]
       5b8a254c823ced98decd10ed6cf2dce85599ada2
-uid           ecc-bp384
-sub   384/ECDH cff1bb6f16d28191 2018-04-03 [E]
+uid           ecc-bp384 [INVALID]
+sub   384/ECDH cff1bb6f16d28191 2018-04-03 [INVALID]
       76969ce7033d990931df92b2cff1bb6f16d28191
 
-pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [SCA]
+pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [INVALID]
       4c59ab9272aa6a1f60b85bd0aa5c58d14f7b8f48
-uid           ecc-bp512
-sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [E]
+uid           ecc-bp512 [INVALID]
+sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [INVALID]
       270a7cd0dc6c2e01dce8603620cdaa1482ba79ce
 
 pub   255/EdDSA 941822a0fc1b30a5 2018-10-15 [SC]

--- a/src/tests/data/test_cli_rnpkeys/test_stream_key_load_sigs
+++ b/src/tests/data/test_cli_rnpkeys/test_stream_key_load_sigs
@@ -6,6 +6,7 @@ uid           dsa-eg
 sig           c8a10a7d78273e10 2019-02-02 dsa-eg
 sub   3072/ElGamal 02a5715c3537717e 2018-04-03 [E]
       3409f96f0c57242540702dba02a5715c3537717e
+sig           c8a10a7d78273e10 2019-02-02 dsa-eg
 
 pub   255/EdDSA cc786278981b0728 2018-04-03 [SC]
       21fc68274aae3b5de39a4277cc786278981b0728
@@ -18,6 +19,7 @@ uid           ecc-p256
 sig           23674f21b2441527 2019-02-02 ecc-p256
 sub   256/ECDH 37e285e9e9851491 2018-04-03 [E]
       40e608afbc8d62cdcc08904f37e285e9e9851491
+sig           23674f21b2441527 2019-02-02 ecc-p256
 
 pub   384/ECDSA 242a3aa5ea85f44a 2018-04-03 [SC]
       ab25cba042dd924c3acc3ed3242a3aa5ea85f44a
@@ -25,6 +27,7 @@ uid           ecc-p384
 sig           242a3aa5ea85f44a 2019-02-02 ecc-p384
 sub   384/ECDH e210e3d554a4fad9 2018-04-03 [E]
       cbc2ac55dcd8e4e34fb2f816e210e3d554a4fad9
+sig           242a3aa5ea85f44a 2019-02-02 ecc-p384
 
 pub   521/ECDSA 2092ca8324263b6a 2018-04-03 [SC]
       4fb39ff6fa4857a4bd7ef5b42092ca8324263b6a
@@ -32,13 +35,15 @@ uid           ecc-p521
 sig           2092ca8324263b6a 2019-02-02 ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
+sig           2092ca8324263b6a 2019-02-02 ecc-p521
 
-pub   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+pub   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-sig           2fb9179118898e8b 2019-02-02 [unknown]
-sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+sig           2fb9179118898e8b 2019-02-02 [unknown] [invalid]
+sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
+sig           2fb9179118898e8b 2019-02-02 [unknown] [invalid]
 
 pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SC]
       0633c5f72a198f51e650e4abd0c8a3daf9e0634a
@@ -46,6 +51,7 @@ uid           ecc-bp256
 sig           d0c8a3daf9e0634a 2019-02-02 ecc-bp256
 sub   256/ECDH 2edabb94d3055f76 2018-04-03 [E]
       08192b478f740360b74c82cc2edabb94d3055f76
+sig           d0c8a3daf9e0634a 2019-02-02 ecc-bp256
 
 pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [SC]
       5b8a254c823ced98decd10ed6cf2dce85599ada2
@@ -53,6 +59,7 @@ uid           ecc-bp384
 sig           6cf2dce85599ada2 2019-02-02 ecc-bp384
 sub   384/ECDH cff1bb6f16d28191 2018-04-03 [E]
       76969ce7033d990931df92b2cff1bb6f16d28191
+sig           6cf2dce85599ada2 2019-02-02 ecc-bp384
 
 pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [SC]
       4c59ab9272aa6a1f60b85bd0aa5c58d14f7b8f48
@@ -60,6 +67,7 @@ uid           ecc-bp512
 sig           aa5c58d14f7b8f48 2019-02-02 ecc-bp512
 sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [E]
       270a7cd0dc6c2e01dce8603620cdaa1482ba79ce
+sig           aa5c58d14f7b8f48 2019-02-02 ecc-bp512
 
 pub   255/EdDSA 941822a0fc1b30a5 2018-10-15 [SC]
       4c9738a6f2be4e1a796c9b7b941822a0fc1b30a5
@@ -67,6 +75,7 @@ uid           eddsa-x25519
 sig           941822a0fc1b30a5 2018-10-15 eddsa-x25519
 sub   255/ECDH c711187e594376af 2018-10-15 [E]
       cfdb2a1f8325cc949ce0b597c711187e594376af
+sig           941822a0fc1b30a5 2018-10-15 eddsa-x25519
 
 pub   256/ECDSA 3ea5bb6f9692c1a0 2018-04-03 [SC]
       81f772b57d4ebfe7000a66233ea5bb6f9692c1a0
@@ -74,6 +83,7 @@ uid           ecc-p256k1
 sig           3ea5bb6f9692c1a0 2019-02-02 ecc-p256k1
 sub   256/ECDH 7635401f90d3e533 2018-04-03 [E]
       c263ec4ce2b3772746ed53227635401f90d3e533
+sig           3ea5bb6f9692c1a0 2019-02-02 ecc-p256k1
 
 pub   2048/RSA bd860a52d1899c0f 2021-12-24 [SC]
       5aa9362aea07de23a726762cbd860a52d1899c0f
@@ -81,4 +91,5 @@ uid           rsa-rsa-2
 sig           bd860a52d1899c0f 2021-12-24 rsa-rsa-2
 sub   2048/RSA 8e08d46a37414996 2021-12-24 [E]
       ca3e4420cf3d3b62d9ee7c6e8e08d46a37414996
+sig           bd860a52d1899c0f 2021-12-24 rsa-rsa-2
 

--- a/src/tests/data/test_cli_rnpkeys/test_stream_key_load_sigs_no_bp
+++ b/src/tests/data/test_cli_rnpkeys/test_stream_key_load_sigs_no_bp
@@ -6,6 +6,7 @@ uid           dsa-eg
 sig           c8a10a7d78273e10 2019-02-02 dsa-eg
 sub   3072/ElGamal 02a5715c3537717e 2018-04-03 [E]
       3409f96f0c57242540702dba02a5715c3537717e
+sig           c8a10a7d78273e10 2019-02-02 dsa-eg
 
 pub   255/EdDSA cc786278981b0728 2018-04-03 [SC]
       21fc68274aae3b5de39a4277cc786278981b0728
@@ -18,6 +19,7 @@ uid           ecc-p256
 sig           23674f21b2441527 2019-02-02 ecc-p256
 sub   256/ECDH 37e285e9e9851491 2018-04-03 [E]
       40e608afbc8d62cdcc08904f37e285e9e9851491
+sig           23674f21b2441527 2019-02-02 ecc-p256
 
 pub   384/ECDSA 242a3aa5ea85f44a 2018-04-03 [SC]
       ab25cba042dd924c3acc3ed3242a3aa5ea85f44a
@@ -25,6 +27,7 @@ uid           ecc-p384
 sig           242a3aa5ea85f44a 2019-02-02 ecc-p384
 sub   384/ECDH e210e3d554a4fad9 2018-04-03 [E]
       cbc2ac55dcd8e4e34fb2f816e210e3d554a4fad9
+sig           242a3aa5ea85f44a 2019-02-02 ecc-p384
 
 pub   521/ECDSA 2092ca8324263b6a 2018-04-03 [SC]
       4fb39ff6fa4857a4bd7ef5b42092ca8324263b6a
@@ -32,34 +35,39 @@ uid           ecc-p521
 sig           2092ca8324263b6a 2019-02-02 ecc-p521
 sub   521/ECDH 9853df2f6d297442 2018-04-03 [E]
       a9297c86dd0de109e1ebae9c9853df2f6d297442
+sig           2092ca8324263b6a 2019-02-02 ecc-p521
 
-pub   3072/RSA 2fb9179118898e8b 2018-04-03 [ESCA]
+pub   3072/RSA 2fb9179118898e8b 2018-04-03 [INVALID]
       6bc04a5a3ddb35766b9a40d82fb9179118898e8b
-uid           rsa-rsa
-sig           2fb9179118898e8b 2019-02-02 [unknown]
-sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [ESCA]
+uid           rsa-rsa [INVALID]
+sig           2fb9179118898e8b 2019-02-02 [unknown] [invalid]
+sub   3072/RSA 6e2f73008f8b8d6e 2018-04-03 [INVALID]
       20fe5b1ab68c2d7210fb08aa6e2f73008f8b8d6e
+sig           2fb9179118898e8b 2019-02-02 [unknown] [invalid]
 
-pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [SCA]
+pub   256/ECDSA d0c8a3daf9e0634a 2018-04-03 [INVALID]
       0633c5f72a198f51e650e4abd0c8a3daf9e0634a
-uid           ecc-bp256
-sig           d0c8a3daf9e0634a 2019-02-02 [unknown]
-sub   256/ECDH 2edabb94d3055f76 2018-04-03 [E]
+uid           ecc-bp256 [INVALID]
+sig           d0c8a3daf9e0634a 2019-02-02 [unknown] [invalid]
+sub   256/ECDH 2edabb94d3055f76 2018-04-03 [INVALID]
       08192b478f740360b74c82cc2edabb94d3055f76
+sig           d0c8a3daf9e0634a 2019-02-02 [unknown] [invalid]
 
-pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [SCA]
+pub   384/ECDSA 6cf2dce85599ada2 2018-04-03 [INVALID]
       5b8a254c823ced98decd10ed6cf2dce85599ada2
-uid           ecc-bp384
-sig           6cf2dce85599ada2 2019-02-02 [unknown]
-sub   384/ECDH cff1bb6f16d28191 2018-04-03 [E]
+uid           ecc-bp384 [INVALID]
+sig           6cf2dce85599ada2 2019-02-02 [unknown] [invalid]
+sub   384/ECDH cff1bb6f16d28191 2018-04-03 [INVALID]
       76969ce7033d990931df92b2cff1bb6f16d28191
+sig           6cf2dce85599ada2 2019-02-02 [unknown] [invalid]
 
-pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [SCA]
+pub   512/ECDSA aa5c58d14f7b8f48 2018-04-03 [INVALID]
       4c59ab9272aa6a1f60b85bd0aa5c58d14f7b8f48
-uid           ecc-bp512
-sig           aa5c58d14f7b8f48 2019-02-02 [unknown]
-sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [E]
+uid           ecc-bp512 [INVALID]
+sig           aa5c58d14f7b8f48 2019-02-02 [unknown] [invalid]
+sub   512/ECDH 20cdaa1482ba79ce 2018-04-03 [INVALID]
       270a7cd0dc6c2e01dce8603620cdaa1482ba79ce
+sig           aa5c58d14f7b8f48 2019-02-02 [unknown] [invalid]
 
 pub   255/EdDSA 941822a0fc1b30a5 2018-10-15 [SC]
       4c9738a6f2be4e1a796c9b7b941822a0fc1b30a5
@@ -67,6 +75,7 @@ uid           eddsa-x25519
 sig           941822a0fc1b30a5 2018-10-15 eddsa-x25519
 sub   255/ECDH c711187e594376af 2018-10-15 [E]
       cfdb2a1f8325cc949ce0b597c711187e594376af
+sig           941822a0fc1b30a5 2018-10-15 eddsa-x25519
 
 pub   256/ECDSA 3ea5bb6f9692c1a0 2018-04-03 [SC]
       81f772b57d4ebfe7000a66233ea5bb6f9692c1a0
@@ -74,6 +83,7 @@ uid           ecc-p256k1
 sig           3ea5bb6f9692c1a0 2019-02-02 ecc-p256k1
 sub   256/ECDH 7635401f90d3e533 2018-04-03 [E]
       c263ec4ce2b3772746ed53227635401f90d3e533
+sig           3ea5bb6f9692c1a0 2019-02-02 ecc-p256k1
 
 pub   2048/RSA bd860a52d1899c0f 2021-12-24 [SC]
       5aa9362aea07de23a726762cbd860a52d1899c0f
@@ -81,4 +91,5 @@ uid           rsa-rsa-2
 sig           bd860a52d1899c0f 2021-12-24 rsa-rsa-2
 sub   2048/RSA 8e08d46a37414996 2021-12-24 [E]
       ca3e4420cf3d3b62d9ee7c6e8e08d46a37414996
+sig           bd860a52d1899c0f 2021-12-24 rsa-rsa-2
 


### PR DESCRIPTION
This PR:
- fixes #1528 by displaying whether uid/key/sig is valid
- prints information about the all signatures (binding, direct-key, etc), not just uid certifications
- adds FFI function `rnp_signature_get_key_fprint()`.

Should be merged only after the #1755 