### PR TITLE
Use windows-2019 instead of windows-latest for the Github workflows.

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -39,11 +39,11 @@ jobs:
         arch: [x64, Win32]
         include:
           - arch: x64
-            os: windows-latest
+            os: windows-2019
             triplet: x64-windows
             vcpkg_dir: 'C:\\vcpkg'
           - arch: Win32
-            os: windows-latest
+            os: windows-2019
             triplet: x86-windows
             vcpkg_dir: 'C:\\vcpkg'
     steps:


### PR DESCRIPTION
Windows-latest now uses Windows 2022 with corresponding Visual Studiom which is not handled well by CI scripts.