### PR TITLE
Fix Warning: direct access ... to global weak symbol when building rnp_tests.

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -40,6 +40,7 @@ env:
   USE_STATIC_DEPENDENCIES: yes
   BOTAN_VERSION: 2.17.3 # NOTE: 2.18.x may need newer GCC versions to build
   DOWNLOAD_RUBYRNP: Off
+  #LSAN_OPTIONS: fast_unwind_on_malloc=0 # Very slow for sanitize builds, use for debugging.
 
 jobs:
   tests:

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -185,6 +185,12 @@ target_compile_definitions(rnp_tests
     RNP_RUN_TESTS
     RNP_STATIC
 )
+
+# Centos 7 with CLang 7.0.1 reports strange memory leak in GoogleTest, maybe there is a better solution
+if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0.1)
+  set_target_properties(rnp_tests PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
+
 gtest_discover_tests(rnp_tests
   PROPERTIES
     FIXTURES_REQUIRED testdata


### PR DESCRIPTION
Fixes #1185 

As there is some issue, most likely with old v7.0.1 CLang compiler/sanitizers, CMake define is disabled for this and older CLang versions. They also do not have "Warning: direct access".

