### PR TITLE
CLI: do not double-check absence of arguments.

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -997,6 +997,19 @@ cli_rnp_set_hash(rnp_cfg &cfg, const std::string &hash)
     return true;
 }
 
+bool
+cli_rnp_set_cipher(rnp_cfg &cfg, const std::string &cipher)
+{
+    bool  supported = false;
+    auto &alg = cli_rnp_alg_to_ffi(cipher);
+    if (rnp_supports_feature(RNP_FEATURE_SYMM_ALG, alg.c_str(), &supported) || !supported) {
+        ERR_MSG("Unsupported encryption algorithm: %s", cipher.c_str());
+        return false;
+    }
+    cfg.set_str(CFG_CIPHER, alg);
+    return true;
+}
+
 #ifndef RNP_USE_STD_REGEX
 static std::string
 cli_rnp_unescape_for_regcomp(const std::string &src)

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -151,7 +151,7 @@ rnp_win_substitute_cmdline_args(int *argc, char ***argv)
         auto argv_utf8_strings = get_utf8_args();
         argc_utf8 = argv_utf8_strings.size();
         *argc = argc_utf8;
-        argv_utf8_cstrs = new (std::nothrow) char *[argc_utf8]();
+        argv_utf8_cstrs = new (std::nothrow) char *[argc_utf8 + 1]();
         if (!argv_utf8_cstrs) {
             throw std::bad_alloc();
         }
@@ -162,6 +162,8 @@ rnp_win_substitute_cmdline_args(int *argc, char ***argv)
             }
             argv_utf8_cstrs[i] = arg_utf8;
         }
+        /* argv must be terminated with NULL string */
+        argv_utf8_cstrs[argc_utf8] = NULL;
     } catch (...) {
         if (argv_utf8_cstrs) {
             rnp_win_clear_args(argc_utf8, argv_utf8_cstrs);

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -984,6 +984,19 @@ cli_rnp_alg_to_ffi(const std::string alg)
     return alg;
 }
 
+bool
+cli_rnp_set_hash(rnp_cfg &cfg, const std::string &hash)
+{
+    bool  supported = false;
+    auto &alg = cli_rnp_alg_to_ffi(hash);
+    if (rnp_supports_feature(RNP_FEATURE_HASH_ALG, alg.c_str(), &supported) || !supported) {
+        ERR_MSG("Unsupported hash algorithm: %s", hash.c_str());
+        return false;
+    }
+    cfg.set_str(CFG_HASH, alg);
+    return true;
+}
+
 #ifndef RNP_USE_STD_REGEX
 static std::string
 cli_rnp_unescape_for_regcomp(const std::string &src)

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -226,6 +226,15 @@ const std::string cli_rnp_alg_to_ffi(const std::string alg);
  */
 bool cli_rnp_set_hash(rnp_cfg &cfg, const std::string &hash);
 
+/**
+ * @brief Attempt to set symmetric cipher algorithm using the value provided.
+ *
+ * @param cfg config
+ * @param cipher algorithm name.
+ * @return true if algorithm is supported and set correctly, or false otherwise.
+ */
+bool cli_rnp_set_cipher(rnp_cfg &cfg, const std::string &cipher);
+
 void clear_key_handles(std::vector<rnp_key_handle_t> &keys);
 
 const char *json_obj_get_str(json_object *obj, const char *key);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -217,6 +217,15 @@ void        cli_rnp_print_feature(FILE *fp, const char *type, const char *printe
  */
 const std::string cli_rnp_alg_to_ffi(const std::string alg);
 
+/**
+ * @brief Attempt to set hash algorithm using the value provided.
+ *
+ * @param cfg config
+ * @param hash algorithm name.
+ * @return true if algorithm is supported and set correctly, or false otherwise.
+ */
+bool cli_rnp_set_hash(rnp_cfg &cfg, const std::string &hash);
+
 void clear_key_handles(std::vector<rnp_key_handle_t> &keys);
 
 const char *json_obj_get_str(json_object *obj, const char *key);

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -304,22 +304,18 @@ setcmd(rnp_cfg &cfg, int cmd, const char *arg)
         cfg.set_bool(CFG_KEYSTORE_DISABLED, true);
         break;
     case CMD_ENARMOR: {
-        std::string msgt = "";
-
-        if (arg) {
-            msgt = arg;
-            if (msgt == "msg") {
-                msgt = "message";
-            } else if (msgt == "pubkey") {
-                msgt = "public key";
-            } else if (msgt == "seckey") {
-                msgt = "secret key";
-            } else if (msgt == "sign") {
-                msgt = "signature";
-            } else {
-                ERR_MSG("Wrong enarmor argument: %s", arg);
-                return false;
-            }
+        std::string msgt = arg;
+        if (msgt == "msg") {
+            msgt = "message";
+        } else if (msgt == "pubkey") {
+            msgt = "public key";
+        } else if (msgt == "seckey") {
+            msgt = "secret key";
+        } else if (msgt == "sign") {
+            msgt = "signature";
+        } else {
+            ERR_MSG("Wrong enarmor argument: %s", arg);
+            return false;
         }
 
         if (!msgt.empty()) {
@@ -367,24 +363,12 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         cfg.set_bool(CFG_COREDUMPS, true);
         return true;
     case OPT_KEY_STORE_FORMAT:
-        if (!arg) {
-            ERR_MSG("No keyring format argument provided");
-            return false;
-        }
         cfg.set_str(CFG_KEYSTOREFMT, arg);
         return true;
     case OPT_USERID:
-        if (!arg) {
-            ERR_MSG("No userid argument provided");
-            return false;
-        }
         cfg.add_str(CFG_SIGNERS, arg);
         return true;
     case OPT_RECIPIENT:
-        if (!arg) {
-            ERR_MSG("No recipient argument provided");
-            return false;
-        }
         cfg.add_str(CFG_RECIPIENTS, arg);
         return true;
     case OPT_ARMOR:
@@ -394,25 +378,13 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         cfg.set_bool(CFG_DETACHED, true);
         return true;
     case OPT_HOMEDIR:
-        if (!arg) {
-            ERR_MSG("No home directory argument provided");
-            return false;
-        }
         cfg.set_str(CFG_HOMEDIR, arg);
         return true;
     case OPT_KEYFILE:
-        if (!arg) {
-            ERR_MSG("No keyfile argument provided");
-            return false;
-        }
         cfg.set_str(CFG_KEYFILE, arg);
         cfg.set_bool(CFG_KEYSTORE_DISABLED, true);
         return true;
     case OPT_HASH_ALG: {
-        if (!arg) {
-            ERR_MSG("No hash algorithm argument provided");
-            return false;
-        }
         bool               supported = false;
         const std::string &alg = cli_rnp_alg_to_ffi(arg);
         if (rnp_supports_feature(RNP_FEATURE_HASH_ALG, alg.c_str(), &supported) ||
@@ -424,24 +396,12 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         return true;
     }
     case OPT_PASSWDFD:
-        if (!arg) {
-            ERR_MSG("No pass-fd argument provided");
-            return false;
-        }
         cfg.set_str(CFG_PASSFD, arg);
         return true;
     case OPT_PASSWD:
-        if (!arg) {
-            ERR_MSG("No password argument provided");
-            return false;
-        }
         cfg.set_str(CFG_PASSWD, arg);
         return true;
     case OPT_PASSWORDS: {
-        if (!arg) {
-            ERR_MSG("You must provide a number with --passwords option");
-            return false;
-        }
         int count = 0;
         if (!rnp::str_to_int(arg, count) || (count <= 0)) {
             ERR_MSG("Incorrect value for --passwords option: %s", arg);
@@ -453,17 +413,9 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         return true;
     }
     case OPT_OUTPUT:
-        if (!arg) {
-            ERR_MSG("No output filename argument provided");
-            return false;
-        }
         cfg.set_str(CFG_OUTFILE, arg);
         return true;
     case OPT_RESULTS:
-        if (!arg) {
-            ERR_MSG("No output filename argument provided");
-            return false;
-        }
         cfg.set_str(CFG_RESULTS, arg);
         return true;
     case OPT_EXPIRATION:
@@ -473,10 +425,6 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         cfg.set_str(CFG_CREATION, arg);
         return true;
     case OPT_CIPHER: {
-        if (!arg) {
-            ERR_MSG("No encryption algorithm argument provided");
-            return false;
-        }
         bool               supported = false;
         const std::string &alg = cli_rnp_alg_to_ffi(arg);
         if (rnp_supports_feature(RNP_FEATURE_SYMM_ALG, alg.c_str(), &supported) ||
@@ -513,10 +461,6 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         return true;
     }
     case OPT_AEAD_CHUNK: {
-        if (!arg) {
-            ERR_MSG("Option aead-chunk-bits requires parameter");
-            return false;
-        }
         int bits = 0;
         if (!rnp::str_to_int(arg, bits) || (bits < 0) || (bits > 16)) {
             ERR_MSG("Wrong argument value %s for aead-chunk-bits, must be 0..16.", arg);
@@ -619,7 +563,7 @@ rnp_main(int argc, char **argv)
                 cmd = CMD_VERIFY;
                 break;
             case 'r':
-                if (strlen(optarg) < 1) {
+                if (!strlen(optarg)) {
                     ERR_MSG("Recipient should not be empty");
                 } else {
                     cfg.add_str(CFG_RECIPIENTS, optarg);

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -415,17 +415,8 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
     case OPT_CREATION:
         cfg.set_str(CFG_CREATION, arg);
         return true;
-    case OPT_CIPHER: {
-        bool               supported = false;
-        const std::string &alg = cli_rnp_alg_to_ffi(arg);
-        if (rnp_supports_feature(RNP_FEATURE_SYMM_ALG, alg.c_str(), &supported) ||
-            !supported) {
-            ERR_MSG("Unsupported encryption algorithm: %s", arg);
-            return false;
-        }
-        cfg.set_str(CFG_CIPHER, alg);
-        return true;
-    }
+    case OPT_CIPHER:
+        return cli_rnp_set_cipher(cfg, arg);
     case OPT_NUMTRIES:
         cfg.set_str(CFG_NUMTRIES, arg);
         return true;

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -384,17 +384,8 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         cfg.set_str(CFG_KEYFILE, arg);
         cfg.set_bool(CFG_KEYSTORE_DISABLED, true);
         return true;
-    case OPT_HASH_ALG: {
-        bool               supported = false;
-        const std::string &alg = cli_rnp_alg_to_ffi(arg);
-        if (rnp_supports_feature(RNP_FEATURE_HASH_ALG, alg.c_str(), &supported) ||
-            !supported) {
-            ERR_MSG("Unsupported hash algorithm: %s", arg);
-            return false;
-        }
-        cfg.set_str(CFG_HASH, alg);
-        return true;
-    }
+    case OPT_HASH_ALG:
+        return cli_rnp_set_hash(cfg, arg);
     case OPT_PASSWDFD:
         cfg.set_str(CFG_PASSFD, arg);
         return true;

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -76,7 +76,7 @@ rnpkeys_main(int argc, char **argv)
         if (ch >= CMD_LIST_KEYS) {
             /* getopt_long returns 0 for long options */
             if (!setoption(cfg, &cmd, options[optindex].val, optarg)) {
-                ERR_MSG("Bad setoption result %d", ch);
+                ERR_MSG("Failed to process argument --%s", options[optindex].name);
                 goto end;
             }
         } else {

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -509,17 +509,8 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
     case OPT_RESULTS:
         cfg.set_str(CFG_IO_RESS, arg);
         return true;
-    case OPT_CIPHER: {
-        bool               supported = false;
-        const std::string &alg = cli_rnp_alg_to_ffi(arg);
-        if (rnp_supports_feature(RNP_FEATURE_SYMM_ALG, alg.c_str(), &supported) ||
-            !supported) {
-            ERR_MSG("Unsupported symmetric algorithm: %s", arg);
-            return false;
-        }
-        cfg.set_str(CFG_CIPHER, alg);
-        return true;
-    }
+    case OPT_CIPHER:
+        return cli_rnp_set_cipher(cfg, arg);
     case OPT_DEBUG:
         ERR_MSG("Option --debug is deprecated, ignoring.");
         return true;

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -459,31 +459,15 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     /* options */
     case OPT_KEY_STORE_FORMAT:
-        if (!arg) {
-            ERR_MSG("No keyring format argument provided");
-            return false;
-        }
         cfg.set_str(CFG_KEYSTOREFMT, arg);
         return true;
     case OPT_USERID:
-        if (!arg) {
-            ERR_MSG("no userid argument provided");
-            return false;
-        }
         cfg.add_str(CFG_USERID, arg);
         return true;
     case OPT_HOMEDIR:
-        if (!arg) {
-            ERR_MSG("no home directory argument provided");
-            return false;
-        }
         cfg.set_str(CFG_HOMEDIR, arg);
         return true;
     case OPT_NUMBITS: {
-        if (!arg) {
-            ERR_MSG("no number of bits argument provided");
-            return false;
-        }
         int bits = 0;
         if (!rnp::str_to_int(arg, bits) || (bits < 1024) || (bits > 16384)) {
             ERR_MSG("wrong bits value: %s", arg);
@@ -493,10 +477,6 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     }
     case OPT_HASH_ALG: {
-        if (!arg) {
-            ERR_MSG("No hash algorithm argument provided");
-            return false;
-        }
         bool               supported = false;
         const std::string &alg = cli_rnp_alg_to_ffi(arg);
         if (rnp_supports_feature(RNP_FEATURE_HASH_ALG, alg.c_str(), &supported) ||
@@ -508,10 +488,6 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     }
     case OPT_S2K_ITER: {
-        if (!arg) {
-            ERR_MSG("No s2k iteration argument provided");
-            return false;
-        }
         int iterations = atoi(arg);
         if (!iterations) {
             ERR_MSG("Wrong iterations value: %s", arg);
@@ -525,10 +501,6 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         cfg.set_str(CFG_KG_SUBKEY_EXPIRATION, arg);
         return true;
     case OPT_S2K_MSEC: {
-        if (!arg) {
-            ERR_MSG("No s2k msec argument provided");
-            return false;
-        }
         int msec = 0;
         if (!rnp::str_to_int(arg, msec) || !msec) {
             ERR_MSG("Invalid s2k msec value: %s", arg);
@@ -538,24 +510,12 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     }
     case OPT_PASSWDFD:
-        if (!arg) {
-            ERR_MSG("no pass-fd argument provided");
-            return false;
-        }
         cfg.set_str(CFG_PASSFD, arg);
         return true;
     case OPT_PASSWD:
-        if (!arg) {
-            ERR_MSG("No password argument provided");
-            return false;
-        }
         cfg.set_str(CFG_PASSWD, arg);
         return true;
     case OPT_RESULTS:
-        if (!arg) {
-            ERR_MSG("No output filename argument provided");
-            return false;
-        }
         cfg.set_str(CFG_IO_RESS, arg);
         return true;
     case OPT_CIPHER: {
@@ -592,10 +552,6 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         cfg.set_bool(CFG_WITH_SIGS, true);
         return true;
     case OPT_REV_TYPE: {
-        if (!arg) {
-            ERR_MSG("No revocation type argument provided");
-            return false;
-        }
         std::string revtype = arg;
         if (revtype == "0") {
             revtype = "no";
@@ -610,10 +566,6 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     }
     case OPT_REV_REASON:
-        if (!arg) {
-            ERR_MSG("No revocation reason argument provided");
-            return false;
-        }
         cfg.set_str(CFG_REV_REASON, arg);
         return true;
     case OPT_PERMISSIVE:

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -476,17 +476,8 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         cfg.set_int(CFG_NUMBITS, bits);
         return true;
     }
-    case OPT_HASH_ALG: {
-        bool               supported = false;
-        const std::string &alg = cli_rnp_alg_to_ffi(arg);
-        if (rnp_supports_feature(RNP_FEATURE_HASH_ALG, alg.c_str(), &supported) ||
-            !supported) {
-            ERR_MSG("Unsupported hash algorithm: %s", arg);
-            return false;
-        }
-        cfg.set_str(CFG_HASH, alg);
-        return true;
-    }
+    case OPT_HASH_ALG:
+        return cli_rnp_set_hash(cfg, arg);
     case OPT_S2K_ITER: {
         int iterations = atoi(arg);
         if (!iterations) {

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -134,6 +134,7 @@ def run_proc_windows(proc, params, stdin=None):
         pass_fl = os.open(pass_path, os.O_RDONLY | os.O_BINARY)
         pass_cp = os.dup(passfd)
 
+    retcode = -1
     try:
         os.dup2(stdout_fl, stdout_no)
         os.close(stdout_fl)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1005,7 +1005,7 @@ class Keystore(unittest.TestCase):
         ret, _, err = run_proc(RNPK, ['--cipher', 'WRONG_AES', '--homedir', RNPDIR, '--password', 'password', 
                                       '--userid', 'wrong_aes', '--generate-key'])
         self.assertNotEqual(ret, 0)
-        self.assertRegex(err, r'(?s)^.*Unsupported symmetric algorithm: WRONG_AES.*')
+        self.assertRegex(err, r'(?s)^.*Unsupported encryption algorithm: WRONG_AES.*Failed to process argument --cipher.*')
 
     def test_generate_multiple_rsa_key__check_if_available(self):
         '''

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2747,6 +2747,10 @@ class Misc(unittest.TestCase):
         ret, _, err = run_proc(RNP, ['--homedir', keys, '-v', sigasc])
         self.assertEqual(ret, 0)
         self.assertRegex(err, r'(?s)^.*Good signature made.*e95a3cbf583aa80a2ccc53aa7bc6709b15c23a4a.*')
+        # Do not provide source
+        ret, _, err = run_proc(RNP, ['--homedir', keys, '-v', sig, '--source'])
+        self.assertEqual(ret, 1)
+        self.assertRegex(err, r'(?s)^.*rnp(|\.exe): option .--source. requires an argument.*Usage: rnp --command \[options\] \[files\].*')
         # Verify by specifying the correct path
         ret, _, err = run_proc(RNP, ['--homedir', keys, '--source', src, '-v', sig])
         self.assertEqual(ret, 0)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2395,7 +2395,8 @@ class Misc(unittest.TestCase):
             f.write('Hello world')
         # Encrypt file but forget to pass cipher name
         ret, _, err = run_proc(RNP, ['-c', src, '--password', 'password', '--cipher'])
-        self.assertNotEqual(ret, 0)
+        self.assertEqual(ret, 1)
+        self.assertRegex(err, r'(?s)^.*rnp(|\.exe): option( .--cipher.|) requires an argument.*Usage: rnp --command \[options\] \[files\].*')
         # Encrypt file using the unknown symmetric algorithm
         ret, _, err = run_proc(RNP, ['-c', src, '--cipher', 'bad', '--password', 'password'])
         self.assertNotEqual(ret, 0)
@@ -2750,7 +2751,7 @@ class Misc(unittest.TestCase):
         # Do not provide source
         ret, _, err = run_proc(RNP, ['--homedir', keys, '-v', sig, '--source'])
         self.assertEqual(ret, 1)
-        self.assertRegex(err, r'(?s)^.*rnp(|\.exe): option .--source. requires an argument.*Usage: rnp --command \[options\] \[files\].*')
+        self.assertRegex(err, r'(?s)^.*rnp(|\.exe): option( .--source.|) requires an argument.*Usage: rnp --command \[options\] \[files\].*')
         # Verify by specifying the correct path
         ret, _, err = run_proc(RNP, ['--homedir', keys, '--source', src, '-v', sig])
         self.assertEqual(ret, 0)


### PR DESCRIPTION
This PR:
- removes redundant NULL checks for CLI arguments which has `required_argument`.
- refactors duplicate code for settings hash/cipher algorithm.