### PR TITLE
Add functions and C++ wrapper to temporary disable logging in certain cases

### DIFF
--- a/src/lib/logging.cpp
+++ b/src/lib/logging.cpp
@@ -39,6 +39,9 @@ static int8_t _rnp_log_switch =
 #endif
   ;
 
+/* Temporary disable logging */
+static size_t _rnp_log_disable = 0;
+
 void
 set_rnp_log_switch(int8_t value)
 {
@@ -52,5 +55,21 @@ rnp_log_switch()
         const char *var = getenv(RNP_LOG_CONSOLE);
         _rnp_log_switch = (var && strcmp(var, "0")) ? 1 : 0;
     }
-    return !!_rnp_log_switch;
+    return !_rnp_log_disable && !!_rnp_log_switch;
+}
+
+void
+rnp_log_stop()
+{
+    if (_rnp_log_disable < SIZE_MAX) {
+        _rnp_log_disable++;
+    }
+}
+
+void
+rnp_log_continue()
+{
+    if (_rnp_log_disable) {
+        _rnp_log_disable--;
+    }
 }

--- a/src/lib/logging.h
+++ b/src/lib/logging.h
@@ -35,6 +35,22 @@ static const char RNP_LOG_CONSOLE[] = "RNP_LOG_CONSOLE";
 
 bool rnp_log_switch();
 void set_rnp_log_switch(int8_t);
+void rnp_log_stop();
+void rnp_log_continue();
+
+namespace rnp {
+class LogStop {
+  public:
+    LogStop()
+    {
+        rnp_log_stop();
+    }
+    ~LogStop()
+    {
+        rnp_log_continue();
+    }
+};
+} // namespace rnp
 
 #define RNP_LOG_FD(fd, ...)                                                  \
     do {                                                                     \


### PR DESCRIPTION
This PR is a proposed solution for the discussion at https://github.com/rnpgp/rnp/pull/1792#pullrequestreview-933360473 , and allows to temporary disable logging. C++ wrapper should be handy for the cases with mixed C/C++ code.