### PR TITLE
Fix incorrectly displayed warning message for non-x25519 ECC keys.

### DIFF
--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1475,7 +1475,8 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
             RNP_LOG("ECDH fingerprint calculation failed");
             return false;
         }
-        if (!x25519_bits_tweaked(keymaterial->ec)) {
+        if ((keymaterial->ec.curve == PGP_CURVE_25519) &&
+            !x25519_bits_tweaked(keymaterial->ec)) {
             RNP_LOG("Warning: bits of 25519 secret key are not tweaked.");
         }
         declen = decbuf.size();

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -3256,6 +3256,15 @@ class Encryption(unittest.TestCase):
         # Decrypt and verify with RNP
         rnp_decrypt_file(dst, dec, 'password')
         self.assertEqual(file_text(src), file_text(dec))
+        # Encrypt/decrypt using the p256 key, making sure message is not displayed
+        key = data_path('test_stream_key_load/ecc-p256-sec.asc')
+        remove_files(dst, dec)
+        ret, _, err = run_proc(RNP, ['--keyfile', key, '-es', '-r', 'ecc-p256', '-u', 'ecc-p256', '--password', PASSWORD, src, '--output', dst])
+        self.assertEqual(ret, 0)
+        self.assertNotRegex(err, BITS_MSG)
+        ret, _, err = run_proc(RNP, ['--keyfile', key, '-d', '--password', PASSWORD, dst, '--output', dec])
+        self.assertEqual(ret, 0)
+        self.assertNotRegex(err, BITS_MSG)
         # Cleanup
         clear_workfiles()
 


### PR DESCRIPTION
As title says, could confuse users (so did to me once spotted).