### PR TITLE
CLI: strip known extensions from the processed data.

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -2325,9 +2325,10 @@ has_extension(const std::string &path, const std::string &ext)
 }
 
 static std::string
-output_extension(const rnp_cfg &cfg, const std::string &op)
+output_extension(const rnp_cfg &cfg, Operation op)
 {
-    if (op == "encrypt_sign") {
+    switch (op) {
+    case Operation::EncryptOrSign: {
         bool armor = cfg.get_bool(CFG_ARMOR);
         if (cfg.get_bool(CFG_DETACHED)) {
             return armor ? EXT_ASC : EXT_SIG;
@@ -2337,10 +2338,11 @@ output_extension(const rnp_cfg &cfg, const std::string &op)
         }
         return armor ? EXT_ASC : EXT_PGP;
     }
-    if (op == "armor") {
+    case Operation::Enarmor:
         return EXT_ASC;
+    default:
+        return "";
     }
-    return "";
 }
 
 static std::string
@@ -2353,16 +2355,13 @@ extract_filename(const std::string path)
     return path.substr(lpos + 1);
 }
 
-static bool
-cli_rnp_init_io(const std::string &op,
-                rnp_input_t *      input,
-                rnp_output_t *     output,
-                cli_rnp_t *        rnp)
+bool
+cli_rnp_t::init_io(Operation op, rnp_input_t *input, rnp_output_t *output)
 {
-    const std::string &in = rnp->cfg().get_str(CFG_INFILE);
+    const std::string &in = cfg().get_str(CFG_INFILE);
     bool               is_pathin = true;
     if (input) {
-        *input = cli_rnp_input_from_specifier(*rnp, in, &is_pathin);
+        *input = cli_rnp_input_from_specifier(*this, in, &is_pathin);
         if (!*input) {
             return false;
         }
@@ -2371,17 +2370,17 @@ cli_rnp_init_io(const std::string &op,
     if (!output) {
         return true;
     }
-    std::string out = rnp->cfg().get_str(CFG_OUTFILE);
-    bool discard = (op == "verify") && out.empty() && rnp->cfg().get_bool(CFG_NO_OUTPUT);
+    std::string out = cfg().get_str(CFG_OUTFILE);
+    bool discard = (op == Operation::Verify) && out.empty() && cfg().get_bool(CFG_NO_OUTPUT);
 
     if (out.empty() && is_pathin && !discard) {
-        std::string ext = output_extension(rnp->cfg(), op);
+        std::string ext = output_extension(cfg(), op);
         if (!ext.empty()) {
             out = in + ext;
         }
     }
 
-    *output = cli_rnp_output_to_specifier(*rnp, out, discard);
+    *output = cli_rnp_output_to_specifier(*this, out, discard);
     if (!*output && input) {
         rnp_input_destroy(*input);
         *input = NULL;
@@ -2411,7 +2410,7 @@ cli_rnp_dump_file(cli_rnp_t *rnp)
     }
 
     rnp_result_t ret = 0;
-    if (!cli_rnp_init_io("dump", &input, &output, rnp)) {
+    if (!rnp->init_io(Operation::Dump, &input, &output)) {
         ERR_MSG("failed to open source or create output");
         ret = 1;
         goto done;
@@ -2451,7 +2450,7 @@ cli_rnp_armor_file(cli_rnp_t *rnp)
     rnp_input_t  input = NULL;
     rnp_output_t output = NULL;
 
-    if (!cli_rnp_init_io("armor", &input, &output, rnp)) {
+    if (!rnp->init_io(Operation::Enarmor, &input, &output)) {
         ERR_MSG("failed to open source or create output");
         return false;
     }
@@ -2467,7 +2466,7 @@ cli_rnp_dearmor_file(cli_rnp_t *rnp)
     rnp_input_t  input = NULL;
     rnp_output_t output = NULL;
 
-    if (!cli_rnp_init_io("dearmor", &input, &output, rnp)) {
+    if (!rnp->init_io(Operation::Dearmor, &input, &output)) {
         ERR_MSG("failed to open source or create output");
         return false;
     }
@@ -2699,7 +2698,7 @@ cli_rnp_protect_file(cli_rnp_t *rnp)
     rnp_input_t  input = NULL;
     rnp_output_t output = NULL;
 
-    if (!cli_rnp_init_io("encrypt_sign", &input, &output, rnp)) {
+    if (!rnp->init_io(Operation::EncryptOrSign, &input, &output)) {
         ERR_MSG("failed to open source or create output");
         return false;
     }
@@ -2831,7 +2830,7 @@ bool
 cli_rnp_process_file(cli_rnp_t *rnp)
 {
     rnp_input_t input = NULL;
-    if (!cli_rnp_init_io("verify", &input, NULL, rnp)) {
+    if (!rnp->init_io(Operation::Verify, &input, NULL)) {
         ERR_MSG("failed to open source");
         return false;
     }
@@ -2877,7 +2876,7 @@ cli_rnp_process_file(cli_rnp_t *rnp)
 
         ret = rnp_op_verify_detached_create(&verify, rnp->ffi, source, input);
     } else {
-        if (!cli_rnp_init_io("verify", NULL, &output, rnp)) {
+        if (!rnp->init_io(Operation::Verify, NULL, &output)) {
             ERR_MSG("Failed to create output stream.");
             goto done;
         }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -2059,7 +2059,11 @@ cli_rnp_output_to_specifier(cli_rnp_t &rnp, const std::string &spec, bool discar
     } else if (is_stdinout_spec(spec)) {
         res = rnp_output_to_callback(&output, stdout_writer, NULL, NULL);
     } else if (!rnp_get_output_filename(spec, path, rnp)) {
-        ERR_MSG("Operation failed: file '%s' already exists.", spec.c_str());
+        if (spec.empty()) {
+            ERR_MSG("Operation failed: no output filename specified");
+        } else {
+            ERR_MSG("Operation failed: file '%s' already exists.", spec.c_str());
+        }
         res = RNP_ERROR_BAD_PARAMETERS;
     } else {
         res = rnp_output_to_file(&output, path.c_str(), RNP_OUTPUT_FILE_OVERWRITE);

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -36,6 +36,8 @@
 #include "rnpcfg.h"
 #include "json.h"
 
+enum class Operation { EncryptOrSign, Verify, Enarmor, Dearmor, Dump };
+
 class cli_rnp_t {
   private:
     rnp_cfg cfg_{};
@@ -57,6 +59,8 @@ class cli_rnp_t {
 
     bool init(const rnp_cfg &cfg);
     void end();
+
+    bool init_io(Operation op, rnp_input_t *input, rnp_output_t *output);
 
     bool load_keyrings(bool loadsecret = false);
 

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -35,8 +35,10 @@ There are some special cases for _INPUT_FILE_ :
 Depending on the input, output may be written:
 
 * if *--output* option is given output is written to the path specified (or to the *stdout* if *-* is used)
-* to the _INPUT_FILE_ with a removed or added file extension (_.pgp_, _.asc_, _.sig_); or
+* to the _INPUT_FILE_ with a removed or added file extension (_.pgp_, _.gpg_, _.asc_, _.sig_), depending on operation.
 * to the _stdout_ if input was read from the _stdin_.
+
+If output file already exists, it will *not* be overwritten, unless *--overwrite* option is given.
 
 Without the *--armor* option, output will be in binary.
 
@@ -132,7 +134,7 @@ If the data is signed, signature verification information will be printed to _st
 Additional options:
 
 *--output*:::
-Output, if not overridden with this option, will be written to the file with stripped _.pgp_ extension or stdout. If _INPUT_FILE_ does not end with the _.pgp_ extension, then output file name will be asked via _stdin_/_tty_.
+Override the default output selection with a file name or stdout specifier (*_-_*). For the default output path selection see the *BASICS* section.
 
 *--password*, *--pass-fd*:::
 Depending on encryption options, you may be asked for the password of one of your secret keys, or for the encryption password. These options override that behavior such that you can input the password through automated means.

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -139,6 +139,8 @@ TEST_F(rnp_tests, test_cli_rnp_keyfile)
                    "password",
                    "-d",
                    FILES "/hello.txt.pgp",
+                   "--output",
+                   "-",
                    NULL);
     assert_int_equal(ret, 0);
     assert_int_equal(rnp_unlink(FILES "/hello.txt.pgp"), 0);
@@ -175,6 +177,8 @@ TEST_F(rnp_tests, test_cli_rnp_keyfile)
                    "password",
                    "-d",
                    FILES "/hello.txt.asc",
+                   "--output",
+                   "-",
                    NULL);
     assert_int_not_equal(ret, 0);
     /* decrypt correctly with seckey + subkeys */
@@ -185,6 +189,8 @@ TEST_F(rnp_tests, test_cli_rnp_keyfile)
                    "password",
                    "-d",
                    FILES "/hello.txt.asc",
+                   "--output",
+                   "-",
                    NULL);
     assert_int_equal(ret, 0);
     assert_int_equal(rnp_unlink(FILES "/hello.txt.asc"), 0);
@@ -210,7 +216,8 @@ test_cli_g10_key_sign(const char *userid)
     }
 
     /* verify back */
-    ret = call_rnp("rnp", "--homedir", G10KEYS, "-v", FILES "/hello.txt.pgp", NULL);
+    ret = call_rnp(
+      "rnp", "--homedir", G10KEYS, "-v", FILES "/hello.txt.pgp", "--output", "-", NULL);
     rnp_unlink(FILES "/hello.txt.pgp");
     return !ret;
 }
@@ -234,6 +241,8 @@ test_cli_g10_key_encrypt(const char *userid)
                    "password",
                    "-d",
                    FILES "/hello.txt.pgp",
+                   "--output",
+                   "-",
                    NULL);
     rnp_unlink(FILES "/hello.txt.pgp");
     return !ret;
@@ -265,6 +274,8 @@ TEST_F(rnp_tests, test_cli_g10_operations)
                    "password",
                    "-d",
                    FILES "/hello.txt.pgp",
+                   "--output",
+                   "-",
                    NULL);
     assert_int_equal(ret, 0);
     assert_int_equal(rnp_unlink(FILES "/hello.txt.pgp"), 0);
@@ -515,6 +526,8 @@ TEST_F(rnp_tests, test_cli_rnp)
                    "password",
                    "--decrypt",
                    FILES "/hello.txt.pgp",
+                   "--output",
+                   "-",
                    NULL);
     assert_int_equal(ret, 0);
 }


### PR DESCRIPTION
While issue #1805 was mostly about the incorrect man page, it ended up in correcting CLI behaviour as it would be more convenient for the user to get `data.txt` from `data.txt.pgp`.

Fixes #1805 