### PR TITLE
Trivial spelling cleanup

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words-list = fpr,keypair,keypairs
+skip = src/tests/data/**

--- a/LICENSE-OCB.md
+++ b/LICENSE-OCB.md
@@ -6,7 +6,7 @@ users of [`rnp`](https://github.com/rnpgp/rnp) to utilize the patented
 [OCB](http://web.cs.ucdavis.edu/~rogaway/ocb/) blockcipher mode of operation,
 which simultaneously provides privacy and authenticity.
 
-The license text is presented below in plain text form purely for referencial
+The license text is presented below in plain text form purely for referential
 purposes. The original signed license is available on request from Ribose Inc.,
 reachable at open.source@ribose.com.
 

--- a/cmake/Modules/FindWindowsSDK.cmake
+++ b/cmake/Modules/FindWindowsSDK.cmake
@@ -229,7 +229,7 @@ function(_winsdk_check_win10_kits _winkit_build)
 	endif()
 endfunction()
 
-# Given a name for indentification purposes, the build number, and the associated package GUID,
+# Given a name for identification purposes, the build number, and the associated package GUID,
 # look in the registry under both HKLM and HKCU in \\SOFTWARE\\Microsoft\\MicrosoftSDK\\InstalledSDKs\\
 # for that guid and the SDK it points to.
 function(_winsdk_check_platformsdk_registry _platformsdkname _build _platformsdkguid)

--- a/cmake/Modules/findopensslfeatures.c
+++ b/cmake/Modules/findopensslfeatures.c
@@ -50,9 +50,9 @@ list_hashes()
 }
 
 static void
-print_cipher(const EVP_CIPHER *ciph, const char *from, const char *to, void *x)
+print_cipher(const EVP_CIPHER *cipher, const char *from, const char *to, void *x)
 {
-    if (!ciph) {
+    if (!cipher) {
         return;
     }
     printf("%s\n", from);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -2492,7 +2492,7 @@ pgp_key_t::refresh_data(const rnp::SecurityContext &ctx)
             uid.valid = false;
         }
     }
-    /* primary userid: use latest one which is not overriden by later non-primary selfsig */
+    /* primary userid: use latest one which is not overridden by later non-primary selfsig */
     uid0_set_ = false;
     if (prisig && get_uid(prisig->uid).valid) {
         uid0_ = prisig->uid;

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -641,7 +641,7 @@ parse_protected_seckey(pgp_key_pkt_t &seckey, s_exp_t &s_exp, const char *passwo
     }
     if (protected_key->size() != 4 || !protected_key->at(1).is_block() ||
         protected_key->at(2).is_block() || !protected_key->at(3).is_block()) {
-        RNP_LOG("Wrong protected format, expected: (protected mode (parms) "
+        RNP_LOG("Wrong protected format, expected: (protected mode (params) "
                 "encrypted_octet_string)\n");
         return false;
     }

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -177,7 +177,7 @@ class rnp_cfg {
      *  - 2017-07-12 : as the exact date
      *  - 60000 : number of seconds
      *
-     *  @param seconds On successfull return result will be placed here
+     *  @param seconds On successful return result will be placed here
      *  @return true on success or false otherwise
      */
     bool get_expiration(const std::string &key, uint32_t &seconds) const;

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -194,7 +194,7 @@ import_keys(cli_rnp_t *rnp, rnp_input_t input, const std::string &inname)
             break;
         }
         if (ret && updated) {
-            /* some keys were imported, but then error occured */
+            /* some keys were imported, but then error occurred */
             ERR_MSG("warning: not all data was processed.");
             res = true;
             break;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
   )
   # maintain compiler/linker settings on Windows
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  # explicitely disable unneeded gmock build
+  # explicitly disable unneeded gmock build
   set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)
   set(GTestMain gtest_main)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1420,7 +1420,7 @@ class Keystore(unittest.TestCase):
             f.truncate(10)
         ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export-key', 'alice', '--output', kpub, '--overwrite'])
         self.assertEqual(ret, 0)
-        # Re-import it, making sure file was correctly overwriten
+        # Re-import it, making sure file was correctly overwritten
         ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import', kpub])
         self.assertEqual(ret, 0)
         # Enter 'y' in ovewrite prompt
@@ -2798,7 +2798,7 @@ class Misc(unittest.TestCase):
         clear_workfiles()
     
     def test_verify_detached_source(self):
-        # Test --source paramater for the detached signature verification.
+        # Test --source parameter for the detached signature verification.
         src = data_path('test_messages/message.txt')
         sig = data_path('test_messages/message.txt.sig')
         sigasc = data_path('test_messages/message.txt.asc')
@@ -3243,7 +3243,7 @@ class Encryption(unittest.TestCase):
         self.assertNotRegex(err, BITS_MSG)
         ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--remove-key', 'eddsa-25519-non-tweaked', '--force'])
         self.assertEqual(ret, 0)
-        # Due to issue in GnuPG it reports successfull import of non-tweaked secret key in batch mode
+        # Due to issue in GnuPG it reports successful import of non-tweaked secret key in batch mode
         ret, _, _ = run_proc(GPG, ['--batch', '--homedir', GPGHOME, '--import', data_path(KEY_25519_NOTWEAK_SEC)])
         self.assertEqual(ret, 0)
         ret, _, _ = run_proc(GPG, ['--batch', '--homedir', GPGHOME, '-d', data_path(MSG_ES_25519)])

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1302,7 +1302,7 @@ TEST_F(rnp_tests, test_y2k38)
     /* clean up and flush the file */
     rnp.end();
 
-    /* check the file for presense of correct dates */
+    /* check the file for presence of correct dates */
     auto        output = file_to_str("stderr.dat");
     time_t      crtime = 0xC0000000;
     std::string correctMade = "signature made ";


### PR DESCRIPTION
This also prepare for using codespell to help avoid trivial orthographic issues going forward, with:

```
codespell *
```