### PR TITLE
Add FFI API and CLI options to override current time.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -551,6 +551,20 @@ RNP_API rnp_result_t rnp_request_password(rnp_ffi_t        ffi,
                                           const char *     context,
                                           char **          password);
 
+/**
+ * @brief Set timestamp, used in all operations instead of system's time. These operations
+ *        include key/signature generation (this timestamp will be used as signature/key
+ *        creation date), verification of the keys and signatures (this timestamp will be used
+ *        as 'current' time).
+ *        Please note, that exactly this timestamp will be used during the whole ffi lifetime.
+ *
+ * @param ffi initialized FFI structure
+ * @param time non-zero timestamp to be used. Zero value restores original behaviour and uses
+ *             system's time.
+ * @return RNP_SUCCESS or other value on error.
+ */
+RNP_API rnp_result_t rnp_set_timestamp(rnp_ffi_t ffi, uint64_t time);
+
 /** load keys
  *
  * Note that for G10, the input must be a directory (which must already exist).

--- a/src/lib/crypto.cpp
+++ b/src/lib/crypto.cpp
@@ -88,7 +88,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t &crypto,
     /* populate pgp key structure */
     seckey = {};
     seckey.version = PGP_V4;
-    seckey.creation_time = time(NULL);
+    seckey.creation_time = crypto.ctx->time();
     seckey.alg = crypto.key_alg;
     seckey.material.alg = crypto.key_alg;
     seckey.tag = primary ? PGP_PKT_SECRET_KEY : PGP_PKT_SECRET_SUBKEY;

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -91,7 +91,7 @@ load_generated_g10_key(pgp_key_t *           dst,
     }
     /* Write g10 seckey */
     rnp::MemoryDest memdst(NULL, 0);
-    if (!g10_write_seckey(&memdst.dst(), newkey, NULL, ctx.rng)) {
+    if (!g10_write_seckey(&memdst.dst(), newkey, NULL, ctx)) {
         RNP_LOG("failed to write generated seckey");
         return false;
     }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1300,7 +1300,7 @@ FFI_GUARD
 
 rnp_result_t
 rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
-{
+try {
     if (!ffi || !password || !ffi->getpasscb) {
         return RNP_ERROR_NULL_POINTER;
     }
@@ -1319,6 +1319,7 @@ rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, c
     memcpy(*password, pass.data(), pass_len);
     return RNP_SUCCESS;
 }
+FFI_GUARD
 
 static rnp_result_t
 load_keys_from_input(rnp_ffi_t ffi, rnp_input_t input, rnp_key_store_t *store)

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1321,6 +1321,17 @@ try {
 }
 FFI_GUARD
 
+rnp_result_t
+rnp_set_timestamp(rnp_ffi_t ffi, uint64_t time)
+try {
+    if (!ffi) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    ffi->context.set_time(time);
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
 static rnp_result_t
 load_keys_from_input(rnp_ffi_t ffi, rnp_input_t input, rnp_key_store_t *store)
 {
@@ -4147,7 +4158,7 @@ try {
         FFI_LOG(key->ffi, "Failed to tweak 25519 key bits.");
         return RNP_ERROR_BAD_STATE;
     }
-    if (!seckey->write_sec_rawpkt(seckey->pkt(), "", key->ffi->rng())) {
+    if (!seckey->write_sec_rawpkt(seckey->pkt(), "", key->ffi->context)) {
         FFI_LOG(key->ffi, "Failed to update rawpkt.");
         return RNP_ERROR_BAD_STATE;
     }
@@ -7131,9 +7142,9 @@ try {
         pgp_password_provider_t prov = {
           .callback = rnp_password_provider_string,
           .userdata = reinterpret_cast<void *>(const_cast<char *>(password))};
-        ok = key->unprotect(prov, handle->ffi->rng());
+        ok = key->unprotect(prov, handle->ffi->context);
     } else {
-        ok = key->unprotect(handle->ffi->pass_provider, handle->ffi->rng());
+        ok = key->unprotect(handle->ffi->pass_provider, handle->ffi->context);
     }
     if (!ok) {
         // likely a bad password

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -27,6 +27,7 @@
 #include "sec_profile.hpp"
 #include "types.h"
 #include "defaults.h"
+#include <ctime>
 #include <algorithm>
 
 namespace rnp {
@@ -154,7 +155,7 @@ SecurityProfile::def_level() const
     return SecurityLevel::Default;
 };
 
-SecurityContext::SecurityContext() : rng(RNG::Type::DRBG)
+SecurityContext::SecurityContext() : time_(0), rng(RNG::Type::DRBG)
 {
     /* Mark SHA-1 insecure since 2019-01-19, as GnuPG does */
     profile.add_rule(
@@ -172,6 +173,18 @@ SecurityContext::s2k_iterations(pgp_hash_alg_t halg)
           pgp_s2k_compute_iters(halg, DEFAULT_S2K_MSEC, DEFAULT_S2K_TUNE_MSEC);
     }
     return s2k_iterations_[halg];
+}
+
+void
+SecurityContext::set_time(uint64_t time) noexcept
+{
+    time_ = time;
+}
+
+uint64_t
+SecurityContext::time() const noexcept
+{
+    return time_ ? time_ : ::time(NULL);
 }
 
 } // namespace rnp

--- a/src/lib/sec_profile.hpp
+++ b/src/lib/sec_profile.hpp
@@ -72,6 +72,7 @@ class SecurityProfile {
 
 class SecurityContext {
     std::unordered_map<int, size_t> s2k_iterations_;
+    uint64_t                        time_;
 
   public:
     SecurityProfile profile;
@@ -80,6 +81,9 @@ class SecurityContext {
     SecurityContext();
 
     size_t s2k_iterations(pgp_hash_alg_t halg);
+
+    void     set_time(uint64_t time) noexcept;
+    uint64_t time() const noexcept;
 };
 } // namespace rnp
 

--- a/src/librekey/g10_sexp.hpp
+++ b/src/librekey/g10_sexp.hpp
@@ -108,9 +108,9 @@ class s_exp_t : public s_exp_element_t {
     void add_curve(const std::string &name, const pgp_ec_key_t &key);
     void add_pubkey(const pgp_key_pkt_t &key);
     void add_seckey(const pgp_key_pkt_t &key);
-    void add_protected_seckey(pgp_key_pkt_t &    seckey,
-                              const std::string &password,
-                              rnp::RNG &         rng);
+    void add_protected_seckey(pgp_key_pkt_t &       seckey,
+                              const std::string &   password,
+                              rnp::SecurityContext &ctx);
 
     void clear();
 };

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -31,10 +31,10 @@
 
 bool rnp_key_store_g10_from_src(rnp_key_store_t *, pgp_source_t *, const pgp_key_provider_t *);
 bool rnp_key_store_g10_key_to_dst(pgp_key_t *, pgp_dest_t *);
-bool g10_write_seckey(pgp_dest_t *   dst,
-                      pgp_key_pkt_t *seckey,
-                      const char *   password,
-                      rnp::RNG &     rng);
+bool g10_write_seckey(pgp_dest_t *          dst,
+                      pgp_key_pkt_t *       seckey,
+                      const char *          password,
+                      rnp::SecurityContext &ctx);
 pgp_key_pkt_t *g10_decrypt_seckey(const pgp_rawpacket_t &raw,
                                   const pgp_key_pkt_t &  pubkey,
                                   const char *           password);

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -470,7 +470,7 @@ static bool
 rnp_key_store_kbx_write_header(rnp_key_store_t *key_store, pgp_dest_t *dst)
 {
     uint16_t flags = 0;
-    uint32_t file_created_at = time(NULL);
+    uint32_t file_created_at = key_store->secctx.time();
 
     if (!key_store->blobs.empty() && (key_store->blobs[0]->type() == KBX_HEADER_BLOB)) {
         kbx_header_blob_t &blob = dynamic_cast<kbx_header_blob_t &>(*key_store->blobs[0]);
@@ -481,7 +481,8 @@ rnp_key_store_kbx_write_header(rnp_key_store_t *key_store, pgp_dest_t *dst)
              !pu8(dst, 1)                                                   // version
              || !pu16(dst, flags) || !pbuf(dst, "KBXf", 4) || !pu32(dst, 0) // RFU
              || !pu32(dst, 0)                                               // RFU
-             || !pu32(dst, file_created_at) || !pu32(dst, time(NULL)) || !pu32(dst, 0)); // RFU
+             || !pu32(dst, file_created_at) || !pu32(dst, key_store->secctx.time()) ||
+             !pu32(dst, 0)); // RFU
 }
 
 static bool
@@ -587,8 +588,8 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
         return false;
     }
 
-    if (!pu32(&mem.dst(), time(NULL)) ||
-        !pu32(&mem.dst(), time(NULL))) { // Latest timestamp && created
+    if (!pu32(&mem.dst(), key_store->secctx.time()) ||
+        !pu32(&mem.dst(), key_store->secctx.time())) { // Latest timestamp && created
         return false;
     }
 

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1145,11 +1145,11 @@ signed_write_signature(pgp_dest_signed_param_t *param,
     try {
         pgp_signature_t sig;
         if (signer->onepass.version) {
-            signer->key->sign_init(sig, signer->onepass.halg);
+            signer->key->sign_init(sig, signer->onepass.halg, param->ctx->ctx->time());
             sig.palg = signer->onepass.palg;
             sig.set_type(signer->onepass.type);
         } else {
-            signer->key->sign_init(sig, signer->halg);
+            signer->key->sign_init(sig, signer->halg, param->ctx->ctx->time());
             /* line below should be checked */
             sig.set_type(param->ctx->detached ? PGP_SIG_BINARY : PGP_SIG_TEXT);
         }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -592,6 +592,10 @@ cli_rnp_t::init(const rnp_cfg &cfg)
             goto done;
         }
     }
+    // setup current time if requested
+    if (cfg_.has(CFG_CURTIME)) {
+        rnp_set_timestamp(ffi, cfg_.time());
+    }
     pswdtries = MAX_PASSWORD_ATTEMPTS;
     res = true;
 done:

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -290,11 +290,9 @@ While not commonly used, you may encrypt a message to any reasonable number of p
 *--creation* _TIME_::
 Override signature creation time. +
 +
-By default, creation time is set to current local computer time. +
+By default, creation time is set to the current local computer time. +
 +
-A specific time could be specified in the
-ISO 8601-1:2019 date format (_yyyy-mm-dd_),
-or in the UNIX timestamp format.
+*TIME* could be specified in the ISO 8601-1:2019 date format (_yyyy-mm-dd_), or in the UNIX timestamp format.
 
 *--expiration* _TIME_::
 Set signature expiration time, counting from the creation time. +
@@ -320,6 +318,13 @@ Disable use of tty. +
 By default RNP would detect whether TTY is attached and use it for user prompts. +
 +
 This option overrides default behaviour so user input may be passed in batch mode.
+
+*--current-time* _TIME_::
+Override system's time with a specified value. +
++
+By default RNP uses system's time in all signature/key checks, however in some scenarios it could be needed to override this. +
++
+*TIME* may be specified in the same way as *--creation*.
 
 == EXIT STATUS
 

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -92,6 +92,7 @@ static const char *usage =
   "  --password           Password used during operation.\n"
   "  --pass-fd num        Read password(s) from the file descriptor.\n"
   "  --notty              Do not output anything to the TTY.\n"
+  "  --current-time       Override system's time.\n"
   "\n"
   "See man page for a detailed listing and explanation.\n"
   "\n";
@@ -148,6 +149,7 @@ enum optdefs {
     OPT_NOTTY,
     OPT_SOURCE,
     OPT_NOWRAP,
+    OPT_CURTIME,
 
     /* debug */
     OPT_DEBUG
@@ -210,6 +212,7 @@ static struct option options[] = {
   {"notty", no_argument, NULL, OPT_NOTTY},
   {"source", required_argument, NULL, OPT_SOURCE},
   {"no-wrap", no_argument, NULL, OPT_NOWRAP},
+  {"current-time", required_argument, NULL, OPT_CURTIME},
 
   {NULL, 0, NULL, 0},
 };
@@ -478,6 +481,9 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
     case OPT_NOWRAP:
         cfg.set_bool(CFG_NOWRAP, true);
         cfg.set_int(CFG_ZLEVEL, 0);
+        return true;
+    case OPT_CURTIME:
+        cfg.set_str(CFG_CURTIME, arg);
         return true;
     case OPT_DEBUG:
         ERR_MSG("Option --debug is deprecated, ignoring.");

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -88,7 +88,8 @@
 #define CFG_FIX_25519_BITS "fix-25519-bits"   /* fix Cv25519 secret key via --edit-key */
 #define CFG_CHK_25519_BITS "check-25519-bits" /* check Cv25519 secret key bits */
 #define CFG_SOURCE "source"                   /* source for the detached signature */
-#define CFG_NOWRAP "no-wrap" /* do not wrap the output in a literal data packet */
+#define CFG_NOWRAP "no-wrap"  /* do not wrap the output in a literal data packet */
+#define CFG_CURTIME "curtime" /* date or timestamp to override the system's time */
 
 /* rnp keyring setup variables */
 #define CFG_KR_PUB_FORMAT "kr-pub-format"
@@ -128,6 +129,7 @@ class rnp_cfg {
      *  @return true when parsed successfully or false otherwise
      */
     bool parse_date(const std::string &s, uint64_t &t) const;
+    bool extract_timestamp(const std::string &st, uint64_t &t) const;
 
   public:
     /** @brief load default settings */
@@ -190,6 +192,13 @@ class rnp_cfg {
      *  @return timestamp of the signature creation.
      */
     uint64_t get_sig_creation() const;
+
+    /** @brief Get current time from the config.
+     *
+     * @return timestamp which should be considered as current time.
+     */
+    uint64_t time() const;
+
     /** @brief copy or override a configuration.
      *  @param src vals will be overridden (if key exist) or copied (if not) from this object
      */

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -371,6 +371,13 @@ By default RNP would detect whether TTY is attached and use it for user prompts.
 +
 This option overrides default behaviour so user input may be passed in batch mode.
 
+*--current-time* _TIME_::
+Override system's time with a specified value. +
++
+By default RNP uses system's time in all signature/key checks, however in some scenarios it could be needed to override this. +
++
+*TIME* could be specified in the ISO 8601-1:2019 date format (_yyyy-mm-dd_), or in the UNIX timestamp format.
+
 == EXIT STATUS
 
 _0_::

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -79,6 +79,7 @@ const char *usage =
   "  --output [file, -]     Write data to the specified file or stdout.\n"
   "  --overwrite            Overwrite output file without a prompt.\n"
   "  --notty                Do not write anything to the TTY.\n"
+  "  --current-time         Override system's time.\n"
   "\n"
   "See man page for a detailed listing and explanation.\n"
   "\n";
@@ -132,6 +133,7 @@ struct option options[] = {
   {"notty", no_argument, NULL, OPT_NOTTY},
   {"fix-cv25519-bits", no_argument, NULL, OPT_FIX_25519_BITS},
   {"check-cv25519-bits", no_argument, NULL, OPT_CHK_25519_BITS},
+  {"current-time", required_argument, NULL, OPT_CURTIME},
   {NULL, 0, NULL, 0},
 };
 
@@ -567,6 +569,9 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     case OPT_CHK_25519_BITS:
         cfg.set_bool(CFG_CHK_25519_BITS, true);
+        return true;
+    case OPT_CURTIME:
+        cfg.set_str(CFG_CURTIME, arg);
         return true;
     default:
         *cmd = CMD_HELP;

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -53,6 +53,7 @@ typedef enum {
     OPT_NOTTY,
     OPT_FIX_25519_BITS,
     OPT_CHK_25519_BITS,
+    OPT_CURTIME,
 
     /* debug */
     OPT_DEBUG

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -86,15 +86,15 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
     // try to unprotect with a failing password provider
     pgp_password_provider_t pprov = {.callback = failing_password_callback, .userdata = NULL};
-    assert_false(key->unprotect(pprov, global_ctx.rng));
+    assert_false(key->unprotect(pprov, global_ctx));
 
     // try to unprotect with an incorrect password
     pprov = {.callback = string_copy_password_callback, .userdata = (void *) "badpass"};
-    assert_false(key->unprotect(pprov, global_ctx.rng));
+    assert_false(key->unprotect(pprov, global_ctx));
 
     // unprotect with the correct password
     pprov = {.callback = string_copy_password_callback, .userdata = (void *) "password"};
-    assert_true(key->unprotect(pprov, global_ctx.rng));
+    assert_true(key->unprotect(pprov, global_ctx));
     assert_false(key->is_protected());
 
     // should still be locked
@@ -325,8 +325,8 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_int_not_equal(memcmp(raw_skey, skey.pkt().sec_data, 32), 0);
     assert_int_not_equal(memcmp(raw_ssub, ssub.pkt().sec_data, 32), 0);
     /* unprotect key */
-    assert_true(skey.unprotect(pprov, global_ctx.rng));
-    assert_true(ssub.unprotect(pprov, global_ctx.rng));
+    assert_true(skey.unprotect(pprov, global_ctx));
+    assert_true(ssub.unprotect(pprov, global_ctx));
     assert_int_equal(memcmp(raw_skey, skey.pkt().sec_data, 32), 0);
     assert_int_equal(memcmp(raw_ssub, ssub.pkt().sec_data, 32), 0);
     /* protect it back  with another password */


### PR DESCRIPTION
This PR changes code to redirect all time request calls into the security context, allowing to override the current time. This would be useful for debugging and for test artifact creation.
