### PR TITLE
Support absolute libdir, includedir in librnp.pc

### DIFF
--- a/cmake/librnp.pc.in
+++ b/cmake/librnp.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@PKGCONFIG_LIBDIR@
+includedir=@PKGCONFIG_INCLUDEDIR@
 
 Name: rnp
 Description: @PACKAGE_DESCRIPTION_SHORT@

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -463,6 +463,18 @@ set(LIBRNP_PRIVATE_LIBS ${linkercmd})
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
   get_target_property(LIBRNP_OUTPUT_NAME librnp OUTPUT_NAME)
+
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PKGCONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+  else()
+    set(PKGCONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PKGCONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  else()
+    set(PKGCONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+
   configure_file(
     "${PROJECT_SOURCE_DIR}/cmake/librnp.pc.in"
     "${PROJECT_BINARY_DIR}/librnp.pc"


### PR DESCRIPTION
Notably, NixOS supplies absolute paths in these.

Bug: https://github.com/rnpgp/rnp/issues/1835