### PR TITLE
[#1836] fail operations on SM{2,3,4} if configured disabled

### DIFF
--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -55,26 +55,32 @@ jobs:
             GPG_VERSION: stable
             CC: gcc
             CXX: g++
+            ENABLE_SM2: On
           - BUILD_MODE: normal
             GPG_VERSION: beta
             CC: gcc
             CXX: g++
+            ENABLE_SM2: On
           - BUILD_MODE: normal
             GPG_VERSION: 2.3.1
             CC: gcc
             CXX: g++
+            ENABLE_SM2: On
           - BUILD_MODE: normal
             GPG_VERSION: stable
             CC: clang
             CXX: clang++
+            ENABLE_SM2: On
           - BUILD_MODE: normal
             GPG_VERSION: beta
             CC: clang
             CXX: clang++
+            ENABLE_SM2: On
           - BUILD_MODE: normal
             GPG_VERSION: 2.3.1
             CC: clang
             CXX: clang++
+            ENABLE_SM2: On
 # Coverage can only been tested with the GNU compiler
 # Upload only single report to the codecov to avoid mess
           - BUILD_MODE: coverage
@@ -82,18 +88,26 @@ jobs:
             RNP_TESTS: ".*"
             CC: gcc
             CXX: g++
+            ENABLE_SM2: On
 # Sanitize is only tested with the clang compiler
 # see env-common.inc.sh
           - BUILD_MODE: sanitize
             GPG_VERSION: stable
             CC: clang
             CXX: clang++
+            ENABLE_SM2: On
           - BUILD_MODE: sanitize
             GPG_VERSION: beta
             CC: clang
             CXX: clang++
+            ENABLE_SM2: On
+          - BUILD_MODE: normal
+            GPG_VERSION: stable
+            CC: gcc
+            CXX: g++
+            ENABLE_SM2: Off
     env: ${{ matrix.env }}
-    name: centos:stream8 Botan [test type ${{ matrix.env.RNP_TESTS }}; mode ${{ matrix.env.BUILD_MODE }}; CC ${{ matrix.env.CC }}; GnuPG ${{ matrix.env.GPG_VERSION }}]
+    name: centos:stream8 Botan [test type ${{ matrix.env.RNP_TESTS }}; mode ${{ matrix.env.BUILD_MODE }}; CC ${{ matrix.env.CC }}; GnuPG ${{ matrix.env.GPG_VERSION }}; SM2 ${{ matrix.env.ENABLE_SM2 }}]
     steps:
       - run: |
           yum -y install git
@@ -115,7 +129,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-sm2-${{ matrix.env.ENABLE_SM2 }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
       - name: Build cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -85,6 +85,7 @@ main() {
     -DBUILD_SHARED_LIBS=yes
     -DCMAKE_INSTALL_PREFIX="${RNP_INSTALL}"
     -DCMAKE_PREFIX_PATH="${BOTAN_INSTALL};${JSONC_INSTALL};${GPG_INSTALL}"
+    -DENABLE_SM2="${ENABLE_SM2:-On}"
   )
   [[ ${SKIP_TESTS} = 1 ]] && cmakeopts+=(-DBUILD_TESTING=OFF)
   [[ "${BUILD_MODE}" = "coverage" ]] && cmakeopts+=(-DENABLE_COVERAGE=yes)

--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -36,7 +36,9 @@ static const id_str_pair botan_alg_map[] = {
   {PGP_HASH_SHA384, "SHA-384"},
   {PGP_HASH_SHA512, "SHA-512"},
   {PGP_HASH_SHA224, "SHA-224"},
+#if defined(ENABLE_SM2)
   {PGP_HASH_SM3, "SM3"},
+#endif
   {PGP_HASH_SHA3_256, "SHA-3(256)"},
   {PGP_HASH_SHA3_512, "SHA-3(512)"},
   {0, NULL},


### PR DESCRIPTION
This changeset aims to make the codebase conformant to tests' expectations that any SMx operation fails when `ENABLE_SM2=Off`. It also adds CI coverage for this case.

The new CI run fails without the code patches: https://github.com/rnpgp/rnp/runs/6796644858

The new CI run passes with the patches: https://github.com/rnpgp/rnp/runs/6794059647

Bug: https://github.com/rnpgp/rnp/issues/1836