### PR TITLE
[#1612] FFI: add option to export armored revocation

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1058,7 +1058,7 @@ RNP_API rnp_result_t rnp_key_export_autocrypt(rnp_key_handle_t key,
  *            searched for the authorized to issue revocation signature secret key. If secret
  *            key is locked then password will be asked via password provider.
  * @param output signature contents will be saved here.
- * @param flags currently must be 0.
+ * @param flags must be RNP_KEY_EXPORT_ARMORED or 0.
  * @param hash hash algorithm used to calculate signature. Pass NULL for default algorithm
  *             selection.
  * @param code reason for revocation code. Possible values: 'no', 'superseded', 'compromised',

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -4058,6 +4058,8 @@ try {
     if (!key || !key->ffi || !output) {
         return RNP_ERROR_NULL_POINTER;
     }
+    bool need_armor = flags & RNP_KEY_EXPORT_ARMORED;
+    flags &= ~RNP_KEY_EXPORT_ARMORED;
     if (flags) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -4079,9 +4081,16 @@ try {
         return ret;
     }
 
-    sig.write(output->dst);
-    ret = output->dst.werr;
-    dst_flush(&output->dst);
+    if (need_armor) {
+        rnp::ArmoredDest armor(output->dst, PGP_ARMORED_PUBLIC_KEY);
+        sig.write(armor.dst());
+        ret = armor.werr();
+        dst_flush(&armor.dst());
+    } else {
+        sig.write(output->dst);
+        ret = output->dst.werr;
+        dst_flush(&output->dst);
+    }
     output->keep = !ret;
     return ret;
 }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -2172,7 +2172,6 @@ cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key)
         return false;
     }
     rnp_output_t output = NULL;
-    rnp_output_t armored = NULL;
     bool         result = false;
 
     output = cli_rnp_output_to_specifier(*rnp, rnp->cfg().get_str(CFG_OUTFILE));
@@ -2180,19 +2179,13 @@ cli_rnp_export_revocation(cli_rnp_t *rnp, const char *key)
         goto done;
     }
 
-    /* export it armored by default */
-    if (rnp_output_to_armor(output, &armored, "public key")) {
-        goto done;
-    }
-
     result = !rnp_key_export_revocation(keys[0],
-                                        armored,
-                                        0,
+                                        output,
+                                        RNP_KEY_EXPORT_ARMORED,
                                         rnp->cfg().get_cstr(CFG_HASH),
                                         rnp->cfg().get_cstr(CFG_REV_TYPE),
                                         rnp->cfg().get_cstr(CFG_REV_REASON));
 done:
-    rnp_output_destroy(armored);
     rnp_output_destroy(output);
     clear_key_handles(keys);
     return result;

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -167,8 +167,9 @@ r'Secret subkey packet.*' \
 r'secret key material:.*' \
 r'encrypted secret key data:.*$'
 
-RE_RNP_REVOCATION_SIG = r'(?s)^.*' \
-r'packet header .* \(tag 2, len .*' \
+RE_RNP_REVOCATION_SIG = r'(?s)' \
+r':armored input\n' \
+r':off 0: packet header .* \(tag 2, len .*' \
 r'Signature packet.*' \
 r'version: 4.*' \
 r'type: 32 \(Key revocation signature\).*' \
@@ -1272,6 +1273,8 @@ class Keystore(unittest.TestCase):
         os.close(pipe)
         self.assertEqual(ret, 0)
         self.assertTrue(os.path.isfile(OUT_ALICE_REV))
+        with open(OUT_ALICE_REV, "rb") as armored:
+            self.assertRegex(armored.read().decode('utf-8'), r'-----END PGP PUBLIC KEY BLOCK-----\r\n$', 'Armor tail not found')
         # Check revocation contents
         ret, out, _ = run_proc(RNP, ['--homedir', RNPDIR, '--list-packets', OUT_ALICE_REV])
         self.assertEqual(ret, 0)
@@ -1333,6 +1336,8 @@ class Keystore(unittest.TestCase):
             self.assertEqual(ret, 0, 'Failed to export revocation with code ' + revcode)
             self.assertTrue(os.path.isfile(OUT_ALICE_REV), 'Failed to export revocation with code ' + revcode)
             # Check revocation contents
+            with open(OUT_ALICE_REV, "rb") as armored:
+                self.assertRegex(armored.read().decode('utf-8'), r'-----END PGP PUBLIC KEY BLOCK-----\r\n$', 'Armor tail not found')
             ret, out, _ = run_proc(RNP, ['--homedir', RNPDIR, '--list-packets', OUT_ALICE_REV])
             self.assertEqual(ret, 0, 'Failed to list exported revocation packets')
             self.assertNotEqual(len(out), 0, 'Failed to list exported revocation packets')


### PR DESCRIPTION
This addresses #1612.

No extra tests introduced so far, because this is a low-risk change and there are already existing tests for both
- FFI used to generate non-armored revocation signatures;
- CLI used to generate armored ones.
I guess we could introduce tests which compare the results with reference results, because currently the FFI tests discard the output without any checks due to `rnp_output_to_null()`.