### PR TITLE
CLI: do not confuse user with 'no keyring file' messages and default gnupg key.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -380,18 +380,19 @@ RNP_API rnp_result_t rnp_ffi_set_pass_provider(rnp_ffi_t       ffi,
  */
 RNP_API rnp_result_t rnp_get_default_homedir(char **homedir);
 
-/** try to detect the formats and paths of the homedir keyrings
- *
+/** Try to detect the formats and paths of the homedir keyrings.
  * @param homedir the path to the home directory (example: /home/user/.rnp)
  * @param pub_format pointer that will be set to the format of the public keyring.
  *        The caller should free this with rnp_buffer_destroy.
+ *        Note: this and below may be set to NULL in case of no known format is found.
  * @param pub_path pointer that will be set to the path to the public keyring.
  *        The caller should free this with rnp_buffer_destroy.
  * @param sec_format pointer that will be set to the format of the secret keyring.
  *        The caller should free this with rnp_buffer_destroy.
  * @param sec_path pointer that will be set to the path to the secret keyring.
  *        The caller should free this with rnp_buffer_destroy.
- * @return RNP_SUCCESS on success, or any other value on error
+ * @return RNP_SUCCESS on success (even if no known format was found), or any other value on
+ *         error.
  */
 RNP_API rnp_result_t rnp_detect_homedir_info(
   const char *homedir, char **pub_format, char **pub_path, char **sec_format, char **sec_path);

--- a/src/common/file-utils.cpp
+++ b/src/common/file-utils.cpp
@@ -327,11 +327,10 @@ std::string
 HOME(const std::string &sdir)
 {
     const char *home = getenv("HOME");
-    std::string res = home ? home : "";
-    if (!sdir.empty()) {
-        res = append(res, sdir);
+    if (!home) {
+        return "";
     }
-    return res;
+    return sdir.empty() ? home : append(home, sdir);
 }
 
 static bool

--- a/src/common/file-utils.cpp
+++ b/src/common/file-utils.cpp
@@ -314,6 +314,26 @@ exists(const std::string &path, bool is_dir)
     return is_dir ? rnp_dir_exists(path.c_str()) : rnp_file_exists(path.c_str());
 }
 
+bool
+empty(const std::string &path)
+{
+    auto dir = rnp_opendir(path.c_str());
+    bool empty = !dir || rnp_readdir_name(dir).empty();
+    rnp_closedir(dir);
+    return empty;
+}
+
+std::string
+HOME(const std::string &sdir)
+{
+    const char *home = getenv("HOME");
+    std::string res = home ? home : "";
+    if (!sdir.empty()) {
+        res = append(res, sdir);
+    }
+    return res;
+}
+
 static bool
 has_forward_slash(const std::string &path)
 {

--- a/src/common/file-utils.h
+++ b/src/common/file-utils.h
@@ -80,6 +80,8 @@ namespace rnp {
 namespace path {
 inline char separator();
 bool        exists(const std::string &path, bool is_dir = false);
+bool        empty(const std::string &path);
+std::string HOME(const std::string &sdir = "");
 std::string append(const std::string &path, const std::string &name);
 } // namespace path
 } // namespace rnp

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -817,11 +817,11 @@ try {
     }
 
     // get the users home dir
-    char *home = getenv("HOME");
-    if (!home) {
+    auto home = rnp::path::HOME(".rnp");
+    if (home.empty()) {
         return RNP_ERROR_NOT_SUPPORTED;
     }
-    *homedir = strdup(rnp::path::append(home, ".rnp").c_str());
+    *homedir = strdup(home.c_str());
     if (!*homedir) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -184,7 +184,7 @@ set_pass_fd(FILE **file, int passfd)
     }
     *file = rnp_fdopen(passfd, "r");
     if (!*file) {
-        ERR_MSG("cannot open fd %d for reading", passfd);
+        ERR_MSG("Cannot open fd %d for reading", passfd);
         return false;
     }
     return true;
@@ -562,7 +562,7 @@ cli_rnp_t::init(const rnp_cfg &cfg)
     } else if (ress == "<stdout>") {
         resfp = stdout;
     } else if (!(resfp = rnp_fopen(ress.c_str(), "w"))) {
-        ERR_MSG("cannot open results %s for writing", ress.c_str());
+        ERR_MSG("Cannot open results %s for writing", ress.c_str());
         return false;
     }
 
@@ -574,7 +574,7 @@ cli_rnp_t::init(const rnp_cfg &cfg)
         return false;
     }
     if (rnp_ffi_create(&ffi, pformat.c_str(), sformat.c_str())) {
-        ERR_MSG("failed to initialize FFI");
+        ERR_MSG("Failed to initialize FFI");
         return false;
     }
 

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -400,6 +400,13 @@ To import all secret keys the following command should be used (please note, tha
 
 *gpg* *-a* *--export-secret-keys* | *rnpkeys* *--import* _-_
 
+=== EXAMPLE 2: GENERATE A NEW KEY
+
+This example generates a new key with specified userid and expiration.
+Also it enables "expert" mode, allowing the selection of key/subkey algorithms.
+
+*rnpkeys* *--generate* *--userid* *"john@doe.com"* *--expert* *--expiration* *1y*
+
 == BUGS
 
 Please report _issues_ via the RNP public issue tracker at:


### PR DESCRIPTION
This PR changes CLI behaviour on non-existent keyrings to the following:
- do not display `warning: keyring at path '/Users/user/.rnp/pubring.gpg' doesn't exist.` message on empty homedir
- do not parse GnuPG conf, extracting the default key as it may not exist in RNP's keyring
- if homedir is empty then display message about key generation/import from the GnuPG.

Fixes #1558 
Fixes #1559 