### PR TITLE
Add and use function rnp_fdopen which would not cause AV with wrong fd on Windows.

### DIFF
--- a/src/common/file-utils.cpp
+++ b/src/common/file-utils.cpp
@@ -110,6 +110,16 @@ rnp_fopen(const char *filename, const char *mode)
 #endif
 }
 
+FILE *
+rnp_fdopen(int fildes, const char *mode)
+{
+#ifdef _WIN32
+    return _fdopen(fildes, mode);
+#else
+    return fdopen(fildes, mode);
+#endif
+}
+
 int
 rnp_access(const char *path, int mode)
 {

--- a/src/common/file-utils.h
+++ b/src/common/file-utils.h
@@ -37,6 +37,7 @@ bool    rnp_dir_exists(const char *path);
 int64_t rnp_filemtime(const char *path);
 int     rnp_open(const char *filename, int oflag, int pmode);
 FILE *  rnp_fopen(const char *filename, const char *mode);
+FILE *  rnp_fdopen(int fildes, const char *mode);
 int     rnp_access(const char *path, int mode);
 int     rnp_stat(const char *filename, struct stat *statbuf);
 int     rnp_rename(const char *oldpath, const char *newpath);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -587,7 +587,7 @@ try {
     }
 
     // open
-    FILE *errs = fdopen(fd, "a");
+    FILE *errs = rnp_fdopen(fd, "a");
     if (!errs) {
         return RNP_ERROR_ACCESS;
     }

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -182,7 +182,7 @@ set_pass_fd(FILE **file, int passfd)
     if (!file) {
         return false;
     }
-    *file = fdopen(passfd, "r");
+    *file = rnp_fdopen(passfd, "r");
     if (!*file) {
         ERR_MSG("cannot open fd %d for reading", passfd);
         return false;

--- a/src/rnpkeys/tui.cpp
+++ b/src/rnpkeys/tui.cpp
@@ -35,6 +35,7 @@
 #include "rnp/rnpcfg.h"
 #include "rnpkeys.h"
 #include "defaults.h"
+#include "file-utils.h"
 #include "logging.h"
 
 /* -----------------------------------------------------------------------------
@@ -270,7 +271,7 @@ cli_rnp_set_generate_params(rnp_cfg &cfg)
         if (cfg.has(CFG_USERINPUTFD)) {
             int inputfd = dup(cfg.get_int(CFG_USERINPUTFD));
             if (inputfd != -1) {
-                input = fdopen(inputfd, "r");
+                input = rnp_fdopen(inputfd, "r");
                 if (!input) {
                     close(inputfd);
                 }

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5636,11 +5636,7 @@ TEST_F(rnp_tests, test_ffi_set_log_fd)
     rnp_ffi_t ffi = NULL;
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
     assert_rnp_failure(rnp_ffi_set_log_fd(NULL, 0));
-#ifndef _WIN32
-    /* on windows one below will terminate processing due to invalid parameters to fdopen()
-     * until we use _set_invalid_parameter_handler */
     assert_rnp_failure(rnp_ffi_set_log_fd(ffi, 100));
-#endif
     int file_fd = rnp_open("tests.txt", O_RDWR | O_CREAT | O_TRUNC, 0777);
     assert_true(file_fd > 0);
     assert_rnp_success(rnp_ffi_set_log_fd(ffi, file_fd));


### PR DESCRIPTION
As title says.