### PR TITLE
CLI tests: drop a strange behaviour of file_text() utility function

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1955,6 +1955,12 @@ class Misc(unittest.TestCase):
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--export', 'Alice'])
         self.assertEqual(ret, 0, 'key export failed')
         pubpath = os.path.join(RNPDIR, 'Alice-export-test.asc')
+
+        # print out `out` in hex
+        print(':'.join(hex(ord(x))[2:] for x in out))
+        # search for \r\r and fail if found
+        self.assertFalse("\r\r" in out)
+
         with open(pubpath, 'w+') as f:
             f.write(out)
         # List exported key packets


### PR DESCRIPTION
file_text() is a function in src/tests/cli_common.py which reads the
whole file (in binary mode, so it doesn't transform newlines in
OS-dependent way) and returns it as a Python string, making a two-liner
task a single function call.

But it also does `.replace('\r\r', '\r')` on the resulting string, which
is questionable for a function which has a very general-purpose name,
doesn't have this behaviour documented, and is used in 36 places across
the test suite. It's unclear what was the original intent, and whether
this was a series of typos or not (`\r\n -> \n`?).

Dropping this transformation altogether doesn't affect any of existing
tests.