### PR TITLE
[#1498] Fix tmpdir cleanup

### DIFF
--- a/ci/env-common.inc.sh
+++ b/ci/env-common.inc.sh
@@ -26,3 +26,6 @@ fi
 BOTAN_MODULES=$(<ci/botan-modules tr '\n' ',')
 
 export BOTAN_MODULES
+
+# Don't clean up tempdirs when in CI runners to save time. Unset to disable.
+export RNP_KEEP_TEMP=1

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4344,6 +4344,8 @@ if __name__ == '__main__':
     if LEAVE_WORKING_DIRECTORY:
         # -w must be removed as unittest doesn't expect it
         sys.argv.remove('-w')
+    else:
+        LEAVE_WORKING_DIRECTORY = os.getenv('RNP_KEEP_TEMP') is not None
 
     LVL = logging.INFO
     if "-d" in sys.argv:
@@ -4358,7 +4360,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     setup(LVL)
-    main()
+    res = main(exit=False)
 
     if not LEAVE_WORKING_DIRECTORY:
         try:
@@ -4369,3 +4371,5 @@ if __name__ == '__main__':
                 shutil.rmtree(GPGDIR)
         except Exception:
             pass
+
+    sys.exit(not res.result.wasSuccessful())

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -529,6 +529,7 @@ TEST_F(rnp_tests, test_ffi_save_keys)
     rnp_ffi_destroy(ffi);
 
     // final cleanup
+    clean_temp_dir(temp_dir);
     free(temp_dir);
 }
 
@@ -616,6 +617,7 @@ TEST_F(rnp_tests, test_ffi_load_save_keys_to_utf8_path)
     rnp_ffi_destroy(ffi);
 
     // final cleanup
+    clean_temp_dir(temp_dir);
     free(temp_dir);
 }
 

--- a/src/tests/issues/1030.cpp
+++ b/src/tests/issues/1030.cpp
@@ -66,6 +66,7 @@ test_issue_1030(const char *keystore)
         close(pipefd[0]);
     }
     rnp.end();
+    clean_temp_dir(home);
     free(home);
 }
 

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -74,6 +74,7 @@ rnp_tests::rnp_tests() : m_dir(make_temp_dir())
 
 rnp_tests::~rnp_tests()
 {
+    clean_temp_dir(m_dir);
     free(m_dir);
 }
 

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -352,6 +352,14 @@ make_temp_dir()
 #error Unsupported platform
 #endif
 
+void
+clean_temp_dir(const char *path)
+{
+    if (!getenv("RNP_KEEP_TEMP")) {
+        delete_recursively(path);
+    }
+}
+
 bool
 bin_eq_hex(const uint8_t *data, size_t len, const char *val)
 {

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -246,7 +246,7 @@ delete_recursively(const char *path)
 
 #ifdef WINSHELLAPI
     SHFILEOPSTRUCTA fileOp = {};
-    fileOp.fFlags = FOF_NOCONFIRMATION;
+    fileOp.fFlags = FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI;
     assert_true(fullpath.size() < MAX_PATH);
     char newFrom[MAX_PATH + 1];
     strcpy_s(newFrom, fullpath.c_str());
@@ -257,7 +257,7 @@ delete_recursively(const char *path)
     fileOp.hNameMappings = NULL;
     fileOp.hwnd = NULL;
     fileOp.lpszProgressTitle = NULL;
-    assert_int_equal(0, SHFileOperationA(&fileOp));
+    SHFileOperationA(&fileOp);
 #else
     nftw(path, remove_cb, 64, FTW_DEPTH | FTW_PHYS);
 #endif

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -120,6 +120,8 @@ void copy_recursively(const char *src, const char *dst);
  */
 char *make_temp_dir(void);
 
+void clean_temp_dir(const char *path);
+
 /* check whether bin value is equals hex string */
 bool bin_eq_hex(const uint8_t *data, size_t len, const char *val);
 


### PR DESCRIPTION
A lot of temporary directories are always left around after the tests even when all they all pass. There are a few sources of that, and this patchset addresses them all.

Bug: https://github.com/rnpgp/rnp/issues/1498