### PR TITLE
[#1783] FFI: Add rnp_signature_export()

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1518,6 +1518,18 @@ RNP_API rnp_result_t rnp_signature_packet_to_json(rnp_signature_handle_t sig,
  */
 RNP_API rnp_result_t rnp_signature_remove(rnp_key_handle_t key, rnp_signature_handle_t sig);
 
+/**
+ * @brief Export a signature.
+ *
+ * @param sig signature handle, cannot be NULL.
+ * @param output destination of the data stream.
+ * @param flags must be RNP_KEY_EXPORT_ARMORED or 0.
+ * @return RNP_SUCCESS or error code if failed.
+ */
+RNP_API rnp_result_t rnp_signature_export(rnp_signature_handle_t sig,
+                                          rnp_output_t           output,
+                                          uint32_t               flags);
+
 /** Free signature handle.
  *
  * @param sig signature handle.


### PR DESCRIPTION
This changeset adds an FFI API function to export specifically a signature, in binary or armored form.