### PR TITLE
Improve wording in help message

### DIFF
--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -53,7 +53,7 @@
 #include "logging.h"
 
 static const char *usage =
-  "Sign, verify, encrypt, decrypt, investigate OpenPGP data.\n"
+  "Sign, verify, encrypt, decrypt, inspect OpenPGP data.\n"
   "Usage: rnp --command [options] [files]\n"
   "Commands:\n"
   "  -h, --help           This help message.\n"


### PR DESCRIPTION
>  "Sign, verify, encrypt, decrypt, investigate OpenPGP data.\n"

investigate -> inspect
 
Just feels a more proper choice of a word here.