### PR TITLE
Custom Docker images to speed up CI

### DIFF
--- a/.github/workflows/fedora35-lean.yml
+++ b/.github/workflows/fedora35-lean.yml
@@ -1,0 +1,72 @@
+name: fedora35-lean
+
+on:
+  push:
+    branches:
+      - master
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/fedora35-lean.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - '/vcpkg.txt'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+
+env:
+  CORES: 2
+  CODECOV_TOKEN: dbecf176-ea3f-4832-b743-295fd71d0fad
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
+  LC_LANG: C.UTF-8
+  USE_STATIC_DEPENDENCIES: no
+  DOWNLOAD_RUBYRNP: Off
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    container:
+      image: andreyutkin/rnp-ci-fedora:35
+    timeout-minutes: 70
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - BUILD_MODE: normal
+            CC: gcc
+            CXX: g++
+            CRYPTO_BACKEND: openssl
+          - BUILD_MODE: sanitize
+            CC: clang
+            CXX: clang++
+            CRYPTO_BACKEND: botan
+    env: ${{ matrix.env }}
+    name: fedora35 [${{ CRYPTO_BACKEND }} mode ${{ matrix.env.BUILD_MODE }}; CC ${{ matrix.env.CC }}]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: tests
+        run: |
+          set -x
+          chown -R rnpuser:rnpuser .
+          exec su rnpuser -c ci/run.sh

--- a/ci/docker/Makefile
+++ b/ci/docker/Makefile
@@ -1,0 +1,11 @@
+all: fedora35.pushed
+clean:
+	rm *.built *.pushed
+.PHONY: all clean
+
+fedora35.built:
+	cd ../.. && docker build --squash -t andreyutkin/rnp-ci-fedora:35 -f ci/docker/fedora35.Dockerfile .
+	touch $@
+fedora35.pushed: fedora35.built
+	docker push andreyutkin/rnp-ci-fedora:35
+	touch $@

--- a/ci/docker/fedora35.Dockerfile
+++ b/ci/docker/fedora35.Dockerfile
@@ -1,0 +1,53 @@
+FROM fedora:35
+RUN dnf makecache
+RUN dnf -y install \
+autoconf \
+automake \
+bison \
+botan2 \
+botan2-devel \
+byacc \
+bzip2 \
+bzip2-devel \
+clang \
+cmake \
+gcc \
+gcc-c++ \
+gettext-devel \
+git \
+gtest \
+gtest-devel \
+gzip \
+json-c \
+json-c-devel \
+libtool \
+make \
+ncurses-devel \
+openssl \
+openssl-devel \
+openssl-libs \
+python3 \
+ruby-devel \
+rubygem-asciidoctor \
+rubygem-bundler \
+sudo \
+wget \
+zlib-devel \
+;
+RUN dnf clean all
+
+RUN useradd rnpuser
+RUN echo -e "rnpuser\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/rnpuser
+RUN echo -e "rnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf
+
+# Everything below wouldn't be needed if packaged gpg didn't fail with "Unknown elliptic curve"
+# on these tests from cli_tests.Misc:
+# test_aead_last_chunk_zero_length
+# test_clearsign_long_lines
+# test_eddsa_sig_lead_zero
+# test_text_sig_crcr
+
+COPY ci ci
+RUN export USE_STATIC_DEPENDENCIES=yes && su rnpuser -c ci/install_noncacheable_dependencies.sh
+RUN export USE_STATIC_DEPENDENCIES=yes && su rnpuser -c ci/install_cacheable_dependencies.sh
+RUN rm -rf /home/rnpuser/local-builds

--- a/ci/docker/fedora35.test-locally
+++ b/ci/docker/fedora35.test-locally
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+rm -rf /tmp/rnp*
+
+cat > run-this <<EOF
+#!/bin/bash
+set -e
+set -x
+
+export USE_STATIC_DEPENDENCIES=no DOWNLOAD_RUBYRNP=Off
+
+export BUILD_MODE=normal CC=gcc CXX=g++ CRYPTO_BACKEND=openssl
+#export BUILD_MODE=sanitize CC=clang CXX=clang++ CRYPTO_BACKEND=botan
+
+cp -a /rnp /rnp.container
+cd /rnp.container
+chown -R rnpuser:rnpuser .
+su rnpuser -c ci/run.sh || bash -i
+EOF
+chmod a+x run-this
+
+docker run -v $PWD:/rnp -it andreyutkin/rnp-ci-fedora:35 /rnp/run-this


### PR DESCRIPTION
This changeset introduces the first custom Docker container intended for RNP's CI.
This Fedora 35 CI config intends to replace the existing config fedora35-ossl.yml (which is currently broken due to riboseinc repo signature issue).
There seems to be no way to trigger GHA to run this CI configuration before it is merged to master.
There is also a script ci/docker/fedora35.test-locally which shows how to use this container for local testing.