### PR TITLE
Require single valid signature for successfull return of  rnp_op_verify_execute() by default.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2921,6 +2921,19 @@ RNP_API rnp_result_t rnp_op_encrypt_set_file_mtime(rnp_op_encrypt_t op, uint32_t
 RNP_API rnp_result_t rnp_op_encrypt_execute(rnp_op_encrypt_t op);
 RNP_API rnp_result_t rnp_op_encrypt_destroy(rnp_op_encrypt_t op);
 
+/**
+ * @brief Decrypt encrypted data in input and write it to the output on success.
+ *        If data is additionally signed then signatures are ignored.
+ *        For more control over the decryption process see functions rnp_op_verify_create() and
+ *        rnp_op_verify_execute(), which allows to verify signatures as well as decrypt data
+ *        and retrieve encryption-related information.
+ *
+ * @param ffi initialized FFI object. Cannot be NULL.
+ * @param input source with encrypted data. Cannot be NULL.
+ * @param output on success decrypted data will be written here. Cannot be NULL.
+ * @return RNP_SUCCESS if data was successfully decrypted and written to the output, or any
+ *         other value on error.
+ */
 RNP_API rnp_result_t rnp_decrypt(rnp_ffi_t ffi, rnp_input_t input, rnp_output_t output);
 
 /** retrieve the raw data for a public key

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -172,6 +172,8 @@ struct rnp_op_verify_st {
     bool           validated{};
     pgp_aead_alg_t aead{};
     pgp_symm_alg_t salg{};
+    bool           ignore_sigs{};
+    bool           require_all_sigs{};
     /* recipient/symenc information */
     rnp_recipient_handle_t recipients{};
     size_t                 recipient_count{};

--- a/src/librepgp/stream-ctx.h
+++ b/src/librepgp/stream-ctx.h
@@ -105,7 +105,6 @@ typedef struct rnp_ctx_t {
     std::list<pgp_key_t *> recipients{};              /* recipients of the encrypted message */
     std::list<rnp_symmetric_pass_info_t> passwords{}; /* passwords to encrypt message */
     std::list<rnp_signer_info_t>         signers{};   /* keys to which sign message */
-    bool                                 discard{};   /* discard the output */
     rnp::SecurityContext *               ctx{};       /* pointer to rnp::RNG */
 
     rnp_ctx_t() = default;

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1071,16 +1071,12 @@ signed_src_finish(pgp_source_t *src)
     }
 
     /* checking the validation results */
-    ret = RNP_SUCCESS;
+    ret = RNP_ERROR_SIGNATURE_INVALID;
     for (auto &sinfo : param->siginfos) {
-        if (sinfo.no_signer && param->handler->ctx->discard) {
-            /* if output is discarded then we interested in verification */
-            ret = RNP_ERROR_SIGNATURE_INVALID;
-            continue;
-        }
-        if (!sinfo.no_signer && (!sinfo.valid || (sinfo.expired))) {
-            /* do not report error if signer not found */
-            ret = RNP_ERROR_SIGNATURE_INVALID;
+        if (sinfo.valid) {
+            /* If we have at least one valid signature then data is safe to process */
+            ret = RNP_SUCCESS;
+            break;
         }
     }
 

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -3741,7 +3741,7 @@ TEST_F(rnp_tests, test_ffi_op_verify_sig_count)
       rnp_input_from_path(&input, "data/test_messages/message.txt.signed.unknown"));
     assert_rnp_success(rnp_output_to_null(&output));
     assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
-    assert_rnp_success(rnp_op_verify_execute(verify));
+    assert_int_equal(rnp_op_verify_execute(verify), RNP_ERROR_SIGNATURE_INVALID);
     assert_rnp_success(rnp_op_verify_get_signature_count(verify, &sigcount));
     assert_int_equal(sigcount, 1);
     assert_true(check_signature(verify, 0, RNP_ERROR_KEY_NOT_FOUND));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1298,7 +1298,7 @@ TEST_F(rnp_tests, test_y2k38)
     /* verify */
     rnpcfg.set_str(CFG_INFILE, "data/test_messages/future.pgp");
     rnpcfg.set_bool(CFG_OVERWRITE, true);
-    assert_true(cli_rnp_process_file(&rnp));
+    assert_false(cli_rnp_process_file(&rnp));
 
     /* clean up and flush the file */
     rnp.end();


### PR DESCRIPTION
This PR changes previous a bit inconsistent behaviour of the `rnp_op_verify_execute()`.
Now by default it will succeed if there is at least one valid signature (if data is signed).

However, as CLI is stick to another rules, function `rnp_op_verify_set_flags()` was added to be able to handle following scenarios:
- decrypt data even if there are no valid signatures
- require all signatures to be valid for successfull processing.
