### PR TITLE
CI: Do not install botan with OpenSSL backend runners.

### DIFF
--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -312,7 +312,10 @@ install_static_cacheable_build_dependencies() {
 
   mkdir -p "$LOCAL_BUILDS"
 
-  local default=(botan jsonc gpg)
+  local default=(jsonc gpg)
+  if [ "${CRYPTO_BACKEND:-}" != "openssl" ]; then
+    default=(botan "${default[@]}")
+  fi
   local items=("${@:-${default[@]}}")
   for item in "${items[@]}"; do
     install_"$item"


### PR DESCRIPTION
Fixes #1904 

Still leaves behind BOTAN_INSTALL and some other traces which pollute logs.