### PR TITLE
Add missing "fingerprint" identifier

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2979,7 +2979,7 @@ RNP_API rnp_result_t rnp_key_to_json(rnp_key_handle_t handle, uint32_t flags, ch
  *
  *  @param ffi
  *  @param it pointer that will be set to the created iterator
- *  @param identifier_type the type of identifier ("userid", "keyid", "grip")
+ *  @param identifier_type the type of identifier ("userid", "keyid", "grip", "fingerprint")
  *  @return RNP_SUCCESS on success, or any other value on error
  */
 RNP_API rnp_result_t rnp_identifier_iterator_create(rnp_ffi_t                  ffi,

--- a/src/tests/ffi-key.cpp
+++ b/src/tests/ffi-key.cpp
@@ -2308,38 +2308,6 @@ TEST_F(rnp_tests, test_ffi_key_iter)
         assert_rnp_success(rnp_identifier_iterator_destroy(it));
     }
 
-    // test with both rings empty
-    // keyid
-    {
-        rnp_identifier_iterator_t it = NULL;
-        assert_rnp_success(rnp_identifier_iterator_create(ffi, &it, "keyid"));
-        assert_non_null(it);
-        const char *ident = NULL;
-        assert_rnp_success(rnp_identifier_iterator_next(it, &ident));
-        assert_null(ident);
-        assert_rnp_success(rnp_identifier_iterator_destroy(it));
-    }
-    // grip
-    {
-        rnp_identifier_iterator_t it = NULL;
-        assert_rnp_success(rnp_identifier_iterator_create(ffi, &it, "grip"));
-        assert_non_null(it);
-        const char *ident = NULL;
-        assert_rnp_success(rnp_identifier_iterator_next(it, &ident));
-        assert_null(ident);
-        assert_rnp_success(rnp_identifier_iterator_destroy(it));
-    }
-    // userid
-    {
-        rnp_identifier_iterator_t it = NULL;
-        assert_rnp_success(rnp_identifier_iterator_create(ffi, &it, "userid"));
-        assert_non_null(it);
-        const char *ident = NULL;
-        assert_rnp_success(rnp_identifier_iterator_next(it, &ident));
-        assert_null(ident);
-        assert_rnp_success(rnp_identifier_iterator_destroy(it));
-    }
-
     // load our keyrings
     assert_true(load_keys_gpg(ffi, pub_path, sec_path));
     // free formats+paths

--- a/src/tests/ffi-key.cpp
+++ b/src/tests/ffi-key.cpp
@@ -2307,6 +2307,16 @@ TEST_F(rnp_tests, test_ffi_key_iter)
         assert_null(ident);
         assert_rnp_success(rnp_identifier_iterator_destroy(it));
     }
+    // fingerprint
+    {
+        rnp_identifier_iterator_t it = NULL;
+        assert_rnp_success(rnp_identifier_iterator_create(ffi, &it, "fingerprint"));
+        assert_non_null(it);
+        const char *ident = NULL;
+        assert_rnp_success(rnp_identifier_iterator_next(it, &ident));
+        assert_null(ident);
+        assert_rnp_success(rnp_identifier_iterator_destroy(it));
+    }
 
     // load our keyrings
     assert_true(load_keys_gpg(ffi, pub_path, sec_path));
@@ -2386,6 +2396,34 @@ TEST_F(rnp_tests, test_ffi_key_iter)
               "key0-uid0", "key0-uid1", "key0-uid2", "key1-uid0", "key1-uid2", "key1-uid1"};
             size_t      i = 0;
             const char *ident = NULL;
+            do {
+                ident = NULL;
+                assert_rnp_success(rnp_identifier_iterator_next(it, &ident));
+                if (ident) {
+                    assert_true(rnp::str_case_eq(expected[i], ident));
+                    i++;
+                }
+            } while (ident);
+            assert_int_equal(i, ARRAY_SIZE(expected));
+        }
+        assert_rnp_success(rnp_identifier_iterator_destroy(it));
+    }
+
+    // fingerprint
+    {
+        rnp_identifier_iterator_t it = NULL;
+        assert_rnp_success(rnp_identifier_iterator_create(ffi, &it, "fingerprint"));
+        assert_non_null(it);
+        {
+            static const char *expected[] = {"E95A3CBF583AA80A2CCC53AA7BC6709B15C23A4A",
+                                             "E332B27CAF4742A11BAA677F1ED63EE56FADC34D",
+                                             "C5B15209940A7816A7AF3FB51D7E8A5393C997A8",
+                                             "5CD46D2A0BD0B8CFE0B130AE8A05B89FAD5ADED1",
+                                             "BE1C4AB951F4C2F6B604C7F82FCADF05FFA501BB",
+                                             "A3E94DE61A8CB229413D348E54505A936A4A970E",
+                                             "57F8ED6E5C197DB63C60FFAF326EF111425D14A5"};
+            size_t             i = 0;
+            const char *       ident = NULL;
             do {
                 ident = NULL;
                 assert_rnp_success(rnp_identifier_iterator_next(it, &ident));


### PR DESCRIPTION
Fixes #1909, adds "fingerprint" to documentation and tests. 

Also seemingly duplicated code is removed from `test_ffi_key_iter`. Code blocks marked by comments "// test with both rings empty" and "// test empty rings" are bit confusing, the same actions are repeated and nothing is changed in testing state between them.