### PR TITLE
CLI: add command --set-filename and do not store env/stdin filename in message

### DIFF
--- a/ci/lib/install_functions.inc.sh
+++ b/ci/lib/install_functions.inc.sh
@@ -647,7 +647,6 @@ msys_install() {
                clang64/mingw-w64-clang-x86_64-openmp
                clang64/mingw-w64-clang-x86_64-libc++
                clang64/mingw-w64-clang-x86_64-libbotan
-               clang64/mingw-w64-clang-x86_64-libssp
                clang64/mingw-w64-clang-x86_64-json-c
                clang64/mingw-w64-clang-x86_64-libsystre
     )

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -326,6 +326,12 @@ By default RNP uses system's time in all signature/key checks, however in some s
 +
 *TIME* may be specified in the same way as *--creation*.
 
+*--set-filename* _FNAME_::
+Override or set a file name, stored inside of OpenPGP message. +
++
+By default RNP will store input filename (or empty string for *stdin*/*env* input) in the resulting OpenPGP message during encryption or embedded signing.
+This option allows to override this. Special value *_CONSOLE* may be used for "for your eyes only"-message. Refer OpenPGP documentation for the details.
+
 == EXIT STATUS
 
 _0_::

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -93,6 +93,7 @@ static const char *usage =
   "  --pass-fd num        Read password(s) from the file descriptor.\n"
   "  --notty              Do not output anything to the TTY.\n"
   "  --current-time       Override system's time.\n"
+  "  --set-filename       Override file name, stored inside of OpenPGP message.\n"
   "\n"
   "See man page for a detailed listing and explanation.\n"
   "\n";
@@ -150,6 +151,7 @@ enum optdefs {
     OPT_SOURCE,
     OPT_NOWRAP,
     OPT_CURTIME,
+    OPT_SETFNAME,
 
     /* debug */
     OPT_DEBUG
@@ -213,6 +215,7 @@ static struct option options[] = {
   {"source", required_argument, NULL, OPT_SOURCE},
   {"no-wrap", no_argument, NULL, OPT_NOWRAP},
   {"current-time", required_argument, NULL, OPT_CURTIME},
+  {"set-filename", required_argument, NULL, OPT_SETFNAME},
 
   {NULL, 0, NULL, 0},
 };
@@ -484,6 +487,9 @@ setoption(rnp_cfg &cfg, int val, const char *arg)
         return true;
     case OPT_CURTIME:
         cfg.set_str(CFG_CURTIME, arg);
+        return true;
+    case OPT_SETFNAME:
+        cfg.set_str(CFG_SETFNAME, arg);
         return true;
     case OPT_DEBUG:
         ERR_MSG("Option --debug is deprecated, ignoring.");

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -43,6 +43,7 @@
 #define CFG_OUTFILE "outfile"            /* name/path of the output file */
 #define CFG_NO_OUTPUT "no_output"        /* do not output any data - just verify or process */
 #define CFG_INFILE "infile"              /* name/path of the input file */
+#define CFG_SETFNAME "setfname"          /* file name to embed into the literal data packet */
 #define CFG_RESULTS "results"            /* name/path for results, not used right now */
 #define CFG_KEYSTOREFMT "keystorefmt"    /* keyring format : GPG, G10, KBX */
 #define CFG_COREDUMPS "coredumps"        /* enable/disable core dumps. 1 or 0. */


### PR DESCRIPTION
- fixes #1843 
- adds `--set-filename` command to override file name in the literal data packet.