### PR TITLE
CI: Update actions/checkout and actions/cache to v3 where applicable.

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -93,7 +93,7 @@ jobs:
       - run: |
           yum -y install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Add rnpuser
@@ -108,7 +108,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -147,7 +147,7 @@ jobs:
       - run: |
           yum -y install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Test

--- a/.github/workflows/centos8-ossl.yml
+++ b/.github/workflows/centos8-ossl.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Add rnpuser
@@ -81,7 +81,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}

--- a/.github/workflows/centos8.yml
+++ b/.github/workflows/centos8.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Add rnpuser
@@ -126,7 +126,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-sm2-${{ matrix.env.ENABLE_SM2 }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -197,7 +197,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Test

--- a/.github/workflows/centos9-ossl.yml
+++ b/.github/workflows/centos9-ossl.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - run: |
           dnf -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Add rnpuser

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Setup environment
@@ -27,7 +27,7 @@ jobs:
           ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ env.BUILD_MODE }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}

--- a/.github/workflows/disabled/centos9.yml
+++ b/.github/workflows/disabled/centos9.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Add rnpuser
@@ -126,7 +126,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-sm2-${{ matrix.env.ENABLE_SM2 }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -165,7 +165,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Test

--- a/.github/workflows/fedora35-lean.yml
+++ b/.github/workflows/fedora35-lean.yml
@@ -62,7 +62,7 @@ jobs:
     env: ${{ matrix.env }}
     name: fedora35 [${{ CRYPTO_BACKEND }} mode ${{ matrix.env.BUILD_MODE }}; CC ${{ matrix.env.CC }}]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: tests

--- a/.github/workflows/fedora35-ossl.yml
+++ b/.github/workflows/fedora35-ossl.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Add rnpuser
@@ -78,7 +78,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}

--- a/.github/workflows/fedora36-ossl.yml
+++ b/.github/workflows/fedora36-ossl.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Add rnpuser
@@ -104,7 +104,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}

--- a/.github/workflows/fedora36.yml
+++ b/.github/workflows/fedora36.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Add rnpuser
@@ -77,7 +77,7 @@ jobs:
           exec su rnpuser -c ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ matrix.env.GPG_VERSION }}-sm2-${{ matrix.env.ENABLE_SM2 }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -116,7 +116,7 @@ jobs:
     steps:
       - run: |
           yum -y install git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: DoozyX/clang-format-lint-action@v0.11
         with:
           clangFormatVersion: 11
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ludeeus/action-shellcheck@master
         with:
           scandir: './ci'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,7 +52,7 @@ jobs:
     env: ${{ matrix.env }}
     timeout-minutes: 250
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Setup environment
@@ -61,7 +61,7 @@ jobs:
           ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ matrix.os }}-${{ env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,7 +38,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: cachix/install-nix-action@v15

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,7 +54,7 @@ jobs:
     env: ${{ matrix.env }}
     timeout-minutes: 50
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Setup environment
@@ -63,7 +63,7 @@ jobs:
           ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -89,7 +89,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Setup environment
@@ -99,7 +99,7 @@ jobs:
           sudo apt-get -y install googletest
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ env.BUILD_MODE }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -123,7 +123,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 50
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Setup environment
@@ -133,7 +133,7 @@ jobs:
           sudo apt-get -y install googletest
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ env.CACHE_DIR }}
@@ -166,7 +166,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 50
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Setup environment
@@ -175,7 +175,7 @@ jobs:
           ci/install_noncacheable_dependencies.sh
       - name: Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ env.BUILD_MODE }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}
@@ -196,12 +196,12 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
           path: rnp
       - name: Download latest version.cmake
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: rnpgp/cmake-versioning
           fetch-depth: 1

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -48,12 +48,12 @@ jobs:
             vcpkg_dir: 'C:\\vcpkg'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           lfs: true
       - name: Cache vcpkg
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '${{ matrix.vcpkg_dir }}/installed'
           key: vcpkg-${{ matrix.triplet }}-${{ hashFiles('vcpkg.txt') }}

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -74,7 +74,7 @@ jobs:
 # The code below kept here for potential need to build some dependencies locally
 #      - name: Cache
 #        id: cache
-#        uses: actions/cache@v2
+#        uses: actions/cache@v3
 #        with:
 #          path: ${{ env.CACHE_DIR }}
 #          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.BUILD_MODE }}-${{ matrix.env.CC }}-gpg-${{ env.GPG_VERSION }}-${{ hashFiles('ci/**') }}-${{ hashFiles('.github/workflows/**') }}


### PR DESCRIPTION
This PR is partial solution to the issue #1923 
However it cannot be fully resolved due to problems of v2-v3 actions running with the non-host architecture (see https://github.com/actions/checkout/issues/334 and https://github.com/actions/runner/issues/1011).