### PR TITLE
CLI: support for adding more subkeys. Closes #1784.

### DIFF
--- a/src/lib/defaults.h
+++ b/src/lib/defaults.h
@@ -61,6 +61,11 @@
 /* Default RSA key length */
 #define DEFAULT_RSA_NUMBITS 2048
 
+/* Default ElGamal key length */
+#define DEFAULT_ELGAMAL_NUMBITS 2048
+#define ELGAMAL_MIN_P_BITLEN 1024
+#define ELGAMAL_MAX_P_BITLEN 4096
+
 /* Default, min and max DSA key length */
 #define DSA_MIN_P_BITLEN 1024
 #define DSA_MAX_P_BITLEN 3072

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -108,6 +108,8 @@ class cli_rnp_t {
 
     bool fix_cv25519_subkey(const std::string &key, bool checkonly = false);
 
+    bool add_new_subkey(const std::string &key);
+
     bool edit_key(const std::string &key);
 };
 
@@ -163,7 +165,7 @@ rnp_output_t cli_rnp_output_to_specifier(cli_rnp_t &        rnp,
 bool cli_rnp_save_keyrings(cli_rnp_t *rnp);
 void cli_rnp_print_key_info(
   FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);
-bool cli_rnp_set_generate_params(rnp_cfg &cfg);
+bool cli_rnp_set_generate_params(rnp_cfg &cfg, bool subkey = false);
 bool cli_rnp_generate_key(cli_rnp_t *rnp, const char *username);
 /**
  * @brief Find key(s) matching set of flags and search string.

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -88,6 +88,7 @@
 #define CFG_NOTTY "notty" /* disable tty usage and do input/output via stdin/stdout */
 #define CFG_FIX_25519_BITS "fix-25519-bits"   /* fix Cv25519 secret key via --edit-key */
 #define CFG_CHK_25519_BITS "check-25519-bits" /* check Cv25519 secret key bits */
+#define CFG_ADD_SUBKEY "add-subkey"           /* add subkey to existing primary */
 #define CFG_SOURCE "source"                   /* source for the detached signature */
 #define CFG_NOWRAP "no-wrap"            /* do not wrap the output in a literal data packet */
 #define CFG_CURTIME "curtime"           /* date or timestamp to override the system's time */

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -233,6 +233,10 @@ Edit or update information, associated with a key. Should be accompanied with ed
 +
 Currently the following options are available: +
 +
+*--add-subkey*:::
+Generate and add a new subkey to the existing primary key. All additional options for the
+*--generate-key* command apply for subkey generation as well, except *--userid*.
+
 *--check-cv25519-bits*:::
 Check whether least significant/most significant bits of Curve25519 ECDH subkey are correctly set.
 RNP internally sets those bits to required values (3 least significant bits and most significant bit must be zero) during decryption,

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -68,6 +68,7 @@ const char *usage =
   "  --revoke-key           Revoke a key specified.\n"
   "  --remove-key           Remove a key specified.\n"
   "  --edit-key             Edit key properties.\n"
+  "    --add-subkey         Add new subkey.\n"
   "    --check-cv25519-bits Check whether Cv25519 subkey bits are correct.\n"
   "    --fix-cv25519-bits   Fix Cv25519 subkey bits.\n"
   "\n"
@@ -133,6 +134,7 @@ struct option options[] = {
   {"notty", no_argument, NULL, OPT_NOTTY},
   {"fix-cv25519-bits", no_argument, NULL, OPT_FIX_25519_BITS},
   {"check-cv25519-bits", no_argument, NULL, OPT_CHK_25519_BITS},
+  {"add-subkey", no_argument, NULL, OPT_ADD_SUBKEY},
   {"current-time", required_argument, NULL, OPT_CURTIME},
   {NULL, 0, NULL, 0},
 };
@@ -572,6 +574,9 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         return true;
     case OPT_CURTIME:
         cfg.set_str(CFG_CURTIME, arg);
+        return true;
+    case OPT_ADD_SUBKEY:
+        cfg.set_bool(CFG_ADD_SUBKEY, true);
         return true;
     default:
         *cmd = CMD_HELP;

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -54,6 +54,7 @@ typedef enum {
     OPT_FIX_25519_BITS,
     OPT_CHK_25519_BITS,
     OPT_CURTIME,
+    OPT_ADD_SUBKEY,
 
     /* debug */
     OPT_DEBUG

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1739,6 +1739,13 @@ class Keystore(unittest.TestCase):
         self.assertEqual(ret, 1)
         self.assertRegex(out, r'(?s)Too many attempts. Aborting.')
         self.assertRegex(err, r'(?s)Subkey generation setup failed')
+        # Attempt to generate ECDSA subkey with invalid curve
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--password', PASSWORD, '--edit-key', '--add-subkey', 
+                                      'primary_for_many_subs@rnp', '--expert'], 
+                                      '19\n-10\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n')
+        self.assertEqual(ret, 1)
+        self.assertRegex(out, r'(?s)Too many attempts. Aborting.')
+        self.assertRegex(err, r'(?s)Subkey generation setup failed')
         # Pass invalid numbits
         ret, _, err = run_proc(RNPK, ['--numbits', 'wrong', '--homedir', RNPDIR, '--password', PASSWORD,
                                       '--userid', 'wrong', '--edit-key', '--add-subkey', 'primary_for_many_subs@rnp'])
@@ -1749,6 +1756,11 @@ class Keystore(unittest.TestCase):
                                       '--userid', '768', '--edit-key', '--add-subkey', 'primary_for_many_subs@rnp'])
         self.assertNotEqual(ret, 0)
         self.assertRegex(err, r'(?s)^.*wrong bits value: 768.*')
+        # ElGamal too large and wrong numbits
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--password', 'wrong', '--edit-key', '--add-subkey', 'primary_for_many_subs@rnp',
+                                        '--expert'], '16\n2048zzz\n99999999999999999999999999\n2048\n')
+        self.assertRegex(err, r'(?s)Unexpected end of line.*Number out of range.*')
+        self.assertEqual(ret, 1)
         # Wrong hash algorithm
         ret, _, err = run_proc(RNPK, ['--hash', 'BAD_HASH', '--homedir', RNPDIR, '--password', PASSWORD,
                                       '--userid', 'bad_hash', '--edit-key', '--add-subkey', 'primary_for_many_subs@rnp'])


### PR DESCRIPTION
Implements new feature in `rnpkeys`, now more subkeys can be generated and added to existing primary keys using `--edit-key` `--add-subkey` options.