### PR TITLE
Update CI to use clang-format 11.0.0.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 1
       - uses: DoozyX/clang-format-lint-action@v0.15
         with:
-          clangFormatVersion: 11
+          clangFormatVersion: 11.0.0
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11.0]
+        os: [macos-11, macos-12]
         env:
           - CC: gcc
             CXX: g++

--- a/src/lib/crypto/backend_version.cpp
+++ b/src/lib/crypto/backend_version.cpp
@@ -72,7 +72,7 @@ backend_version()
     if (version[0]) {
         return version;
     }
-    const char *   reg = "OpenSSL (([0-9]\\.[0-9]\\.[0-9])[a-z]*(-beta[0-9])*(-dev)*) ";
+    const char *reg = "OpenSSL (([0-9]\\.[0-9]\\.[0-9])[a-z]*(-beta[0-9])*(-dev)*) ";
 #ifndef RNP_USE_STD_REGEX
     static regex_t r;
     regmatch_t     matches[5];

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -358,9 +358,9 @@ rnp_cfg::get_expiration(const std::string &key, uint32_t &seconds) const
     if (!std::regex_search(val, result, re)) {
         return false;
     }
-    std::string       delta_stdstr = result[1].str();
-    const char *      delta_str = delta_stdstr.c_str();
-    char              mult = result[2].str()[0];
+    std::string delta_stdstr = result[1].str();
+    const char *delta_str = delta_stdstr.c_str();
+    char        mult = result[2].str()[0];
 #endif
     errno = 0;
     delta = strtoul(delta_str, NULL, 10);


### PR DESCRIPTION
Commit 793e5b38 updates lint.yml for clang-format action, which started to use version 11.1.0 instead 11.0.0 by default, so this PR reverts this back to 11.0.0.
Also it updates macOS version runners.

@maxirmx  Was this done by intension, i.e. are there any benefits of switching to 11.1.0? I'm not against it but just want to get aligned/update work setup.

Fixes #1975 
Fixes #1976 