### PR TITLE
Add CLI option --force-weak for weak hashes.

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -2818,6 +2818,36 @@ cli_rnp_setup(cli_rnp_t *rnp)
 }
 
 bool
+cli_rnp_check_weak_hash(cli_rnp_t *rnp)
+{
+    if (rnp->cfg().has(CFG_WEAK_HASH)) {
+        return true;
+    }
+
+    uint32_t security_level = 0;
+
+    if (rnp_get_security_rule(rnp->ffi,
+                              RNP_FEATURE_HASH_ALG,
+                              rnp->cfg().get_hashalg().c_str(),
+                              rnp->cfg().time(),
+                              NULL,
+                              NULL,
+                              &security_level)) {
+        ERR_MSG("Failed to get security rules for hash algorithm \'%s\'!",
+                rnp->cfg().get_hashalg().c_str());
+        return false;
+    }
+
+    if (security_level < RNP_SECURITY_DEFAULT) {
+        ERR_MSG("Hash algorithm \'%s\' is cryptographically weak!",
+                rnp->cfg().get_hashalg().c_str());
+        return false;
+    }
+    /* TODO: check other weak algorithms and key sizes */
+    return true;
+}
+
+bool
 cli_rnp_protect_file(cli_rnp_t *rnp)
 {
     rnp_input_t  input = NULL;

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -213,6 +213,7 @@ bool        cli_rnp_add_key(cli_rnp_t *rnp);
 bool        cli_rnp_dump_file(cli_rnp_t *rnp);
 bool        cli_rnp_armor_file(cli_rnp_t *rnp);
 bool        cli_rnp_dearmor_file(cli_rnp_t *rnp);
+bool        cli_rnp_check_weak_hash(cli_rnp_t *rnp);
 bool        cli_rnp_setup(cli_rnp_t *rnp);
 bool        cli_rnp_protect_file(cli_rnp_t *rnp);
 bool        cli_rnp_process_file(cli_rnp_t *rnp);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -62,6 +62,7 @@
 #define CFG_CREATION "creation"         /* signature validity start */
 #define CFG_CIPHER "cipher"             /* symmetric encryption algorithm as string */
 #define CFG_HASH "hash"                 /* hash algorithm used, string like 'SHA1'*/
+#define CFG_WEAK_HASH "weak-hash"       /* allow weak algorithms */
 #define CFG_S2K_ITER "s2k-iter"         /* number of S2K hash iterations to perform */
 #define CFG_S2K_MSEC "s2k-msec"         /* number of milliseconds S2K should target */
 #define CFG_ENCRYPT_PK "encrypt_pk"     /* public key should be used during encryption */

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -53,6 +53,7 @@ const char *usage =
   "    --expiration         Set key and subkey expiration time.\n"
   "    --cipher             Set cipher used to encrypt a secret key.\n"
   "    --hash               Set hash which is used for key derivation.\n"
+  "    --allow-weak-hash    Allow usage of a weak hash algorithm.\n"
   "  -l, --list-keys        List keys in the keyrings.\n"
   "    --secret             List secret keys instead of public ones.\n"
   "    --with-sigs          List signatures as well.\n"
@@ -138,6 +139,7 @@ struct option options[] = {
   {"add-subkey", no_argument, NULL, OPT_ADD_SUBKEY},
   {"set-expire", required_argument, NULL, OPT_SET_EXPIRE},
   {"current-time", required_argument, NULL, OPT_CURTIME},
+  {"allow-weak-hash", no_argument, NULL, OPT_ALLOW_WEAK_HASH},
   {NULL, 0, NULL, 0},
 };
 
@@ -488,6 +490,9 @@ setoption(rnp_cfg &cfg, optdefs_t *cmd, int val, const char *arg)
         cfg.set_int(CFG_NUMBITS, bits);
         return true;
     }
+    case OPT_ALLOW_WEAK_HASH:
+        cfg.set_bool(CFG_WEAK_HASH, true);
+        return true;
     case OPT_HASH_ALG:
         return cli_rnp_set_hash(cfg, arg);
     case OPT_S2K_ITER: {
@@ -605,6 +610,11 @@ rnpkeys_init(cli_rnp_t *rnp, const rnp_cfg &cfg)
     }
     if (!rnp->init(rnpcfg)) {
         ERR_MSG("fatal: failed to initialize rnpkeys");
+        goto end;
+    }
+    if (!cli_rnp_check_weak_hash(rnp)) {
+        ERR_MSG("Weak hash algorithm detected. Pass --allow-weak-hash option if you really "
+                "want to use it.");
         goto end;
     }
     /* TODO: at some point we should check for error here */

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -32,6 +32,7 @@ typedef enum {
     OPT_USERID,
     OPT_HOMEDIR,
     OPT_NUMBITS,
+    OPT_ALLOW_WEAK_HASH,
     OPT_HASH_ALG,
     OPT_COREDUMPS,
     OPT_PASSWDFD,

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -923,6 +923,7 @@ TEST_F(rnp_tests, generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjus
 
     ops.set_bool(CFG_EXPERT, true);
     ops.set_str(CFG_HASH, "SHA1");
+    ops.set_bool(CFG_WEAK_HASH, true);
     ops.set_int(CFG_S2K_ITER, 1);
     ops.add_str(CFG_USERID, "expert_small_digest");
     assert_true(ask_expert_details(&rnp, ops, "19\n2\n"));


### PR DESCRIPTION
Introduces new CLI option `--force-weak`. From now, using cryptographically weak hashes for key and data signatures is prohibited unless `--force-weak` is present.

This PR reimplements CLI related part of #1524 using `rnp_get_security_rule()`.


Closes #1524 