### PR TITLE
AEAD: fix incorrect behaviour in case of different algos used for CEK/KEK

### DIFF
--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1594,11 +1594,10 @@ encrypted_try_password(pgp_source_encrypted_param_t *param, const char *password
             continue;
 #else
             /* v5 AEAD-encrypted session key */
-            size_t  taglen = pgp_cipher_aead_tag_len(skey.aalg);
-            uint8_t nonce[PGP_AEAD_MAX_NONCE_LEN];
-            size_t  noncelen;
-
-            if (!taglen || (keysize != skey.enckeylen - taglen)) {
+            size_t taglen = pgp_cipher_aead_tag_len(skey.aalg);
+            size_t ceklen = pgp_key_size(param->aead_hdr.ealg);
+            if (!taglen || !ceklen || (ceklen + taglen != skey.enckeylen)) {
+                RNP_LOG("CEK len/alg mismatch");
                 continue;
             }
             alg = skey.alg;
@@ -1615,17 +1614,17 @@ encrypted_try_password(pgp_source_encrypted_param_t *param, const char *password
             }
 
             /* calculate nonce */
-            noncelen = pgp_cipher_aead_nonce(skey.aalg, skey.iv, nonce, 0);
+            uint8_t nonce[PGP_AEAD_MAX_NONCE_LEN];
+            size_t  noncelen = pgp_cipher_aead_nonce(skey.aalg, skey.iv, nonce, 0);
 
             /* start cipher, decrypt key and verify tag */
-            keyavail = pgp_cipher_aead_start(&crypt, nonce, noncelen);
-            bool decres = keyavail && pgp_cipher_aead_finish(
-                                        &crypt, keybuf.data(), skey.enckey, skey.enckeylen);
-
+            keyavail =
+              pgp_cipher_aead_start(&crypt, nonce, noncelen) &&
+              pgp_cipher_aead_finish(&crypt, keybuf.data(), skey.enckey, skey.enckeylen);
             pgp_cipher_aead_destroy(&crypt);
 
             /* we have decrypted key so let's start decryption */
-            if (!keyavail || !decres) {
+            if (!keyavail) {
                 continue;
             }
 #endif


### PR DESCRIPTION
There were two problems:
- AEAD always used the same algorithm for both CEK and KEK (which is not common but still acceptable)
- because of this it was not able to decrypt data in case of different CEK/KEK algorithms

This applies to the symmetric (password-based) encryption only.

Fixes #1939 