### PR TITLE
CLI: check for conflicting commands.

### DIFF
--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -353,6 +353,11 @@ setcmd(rnp_cfg &cfg, int cmd, const char *arg)
         break;
     }
 
+    if (cfg.has(CFG_COMMAND) && cfg.get_int(CFG_COMMAND) != newcmd) {
+        ERR_MSG("Conflicting commands!");
+        return false;
+    }
+
     cfg.set_int(CFG_COMMAND, newcmd);
     return true;
 }

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -73,23 +73,24 @@ rnpkeys_main(int argc, char **argv)
 #endif
 
     while ((ch = getopt_long(argc, argv, "Vglh", options, &optindex)) != -1) {
+        optdefs_t newcmd = cmd;
+
         if (ch >= CMD_LIST_KEYS) {
             /* getopt_long returns 0 for long options */
-            if (!setoption(cfg, &cmd, options[optindex].val, optarg)) {
+            if (!setoption(cfg, &newcmd, options[optindex].val, optarg)) {
                 ERR_MSG("Failed to process argument --%s", options[optindex].name);
                 goto end;
             }
         } else {
             switch (ch) {
             case 'V':
-                cli_rnp_print_praise();
-                ret = EXIT_SUCCESS;
-                goto end;
+                newcmd = CMD_VERSION;
+                break;
             case 'g':
-                cmd = CMD_GENERATE_KEY;
+                newcmd = CMD_GENERATE_KEY;
                 break;
             case 'l':
-                cmd = CMD_LIST_KEYS;
+                newcmd = CMD_LIST_KEYS;
                 break;
             case '?':
                 print_usage(usage);
@@ -98,10 +99,16 @@ rnpkeys_main(int argc, char **argv)
             case 'h':
                 [[fallthrough]];
             default:
-                cmd = CMD_HELP;
+                newcmd = CMD_HELP;
                 break;
             }
         }
+
+        if (cmd && newcmd != cmd) {
+            ERR_MSG("Conflicting commands!");
+            goto end;
+        }
+        cmd = newcmd;
     }
 
     ret = EXIT_SUCCESS;

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -3780,6 +3780,20 @@ class Misc(unittest.TestCase):
         remove_files(sig)
         clear_workfiles()
 
+    def test_conflicting_commands(self):
+        ret, _, err = run_proc(RNPK, ['--homedir', RNPDIR, '--generate-key', '--import', '--revoke-key', '--list-keys'])
+        self.assertNotEqual(ret, 0)
+        self.assertRegex(err, r'(?s)^.*Conflicting commands!*')
+        ret, _, err = run_proc(RNPK, ['--homedir', RNPDIR, '-g', '-l'])
+        self.assertNotEqual(ret, 0)
+        self.assertRegex(err, r'(?s)^.*Conflicting commands!*')
+        ret, _, err = run_proc(RNP, ['--homedir', RNPDIR, '--sign', '--verify', '--decrypt', '--list-packets'])
+        self.assertNotEqual(ret, 0)
+        self.assertRegex(err, r'(?s)^.*Conflicting commands!*')
+        ret, _, err = run_proc(RNP, ['--homedir', RNPDIR, '-s', '-v'])
+        self.assertNotEqual(ret, 0)
+        self.assertRegex(err, r'(?s)^.*Conflicting commands!*')
+
     def test_hidden_recipient(self):
         seckey = data_path(SECRING_1)
         msg1 = data_path('test_messages/message.txt.enc-hidden-1')


### PR DESCRIPTION
This PR adds new error message to `rnp` and `rnpkeys` when multiple conflicting commands are passed on a command line.

Closes #1982