### PR TITLE
Check return value of malloc/calloc in tests.

### DIFF
--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -56,6 +56,10 @@ call_rnp(const char *cmd, ...)
     char ** argv = (char **) calloc(32, sizeof(char *));
     va_list args;
 
+    if (!argv) {
+        return -1;
+    }
+
     va_start(args, cmd);
     while (cmd) {
         argv[argc++] = (char *) cmd;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1088,6 +1088,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         pgp_userid_pkt_t uid;
         uid.tag = PGP_PKT_USER_ID;
         uid.uid = (uint8_t *) malloc(4);
+        assert_non_null(uid.uid);
         uid.uid_len = 4;
         memcpy(uid.uid, "fake", 4);
 


### PR DESCRIPTION
Addresses #1277 

Fixes two places where `malloc()/calloc()` return values were not checked for NULL.