### PR TITLE
add INSTALL_STATIC_LIBS buid option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option(ENABLE_COVERAGE "Enable code coverage testing.")
 option(ENABLE_SANITIZERS "Enable ASan and other sanitizers.")
 option(ENABLE_FUZZERS "Enable fuzz targets.")
 option(DOWNLOAD_GTEST "Download Googletest" On)
+option(INSTALL_STATIC_LIBS "Install the static library" On)
 # crypto components
 function(tristate_feature_auto NAME DESCRIPTION)
   set(${NAME} Auto CACHE STRING ${DESCRIPTION})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -422,7 +422,7 @@ endif()
 
 if (BUILD_SHARED_LIBS)
 # both static and shared libraries
-install(TARGETS librnp
+  install(TARGETS librnp
     EXPORT rnp-targets
     LIBRARY
       DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
@@ -432,21 +432,22 @@ install(TARGETS librnp
       DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
       COMPONENT development
   )
-
-  install(TARGETS librnp-static sexp
+  if (INSTALL_STATIC_LIBS)
+    install(TARGETS librnp-static sexp
+      EXPORT rnp-targets
+      ARCHIVE
+        DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
+        COMPONENT development
+    )
+  endif(INSTALL_STATIC_LIBS)
+else(BUILD_SHARED_LIBS)
+# static libraries only
+  install(TARGETS librnp sexp
     EXPORT rnp-targets
     ARCHIVE
       DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
       COMPONENT development
   )
-else(BUILD_SHARED_LIBS)
-# static libraries only
-install(TARGETS librnp sexp
-    EXPORT rnp-targets
-    ARCHIVE
-      DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
-      COMPONENT development
-)
 endif(BUILD_SHARED_LIBS)
 
 # install dll only for windows


### PR DESCRIPTION
to allow to not install the static library

As RPM packaging Guidelines disallow static libraries
See https://docs.fedoraproject.org/en-US/packaging-guidelines/#packaging-static-libraries

> Packages including libraries SHOULD exclude static libs as far as possible (e.g., by configuring with --disable-static). Applications linking against libraries SHOULD link against shared libraries not static versions.