### PR TITLE
OpenSSL backend: replace functions, deprecated in OpenSSL 3.0

### DIFF
--- a/cmake/Modules/findopensslfeatures.c
+++ b/cmake/Modules/findopensslfeatures.c
@@ -65,15 +65,37 @@ list_ciphers()
     return 0;
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+static void
+print_km_name(const char *name, void *param)
+{
+    /* Do not print OIDs for better clarity */
+    if (!name || ((name[0] <= '9') && (name[0] >= '0'))) {
+        return;
+    }
+    printf("%s\n", name);
+}
+
+static void
+print_km(EVP_KEYMGMT *km, void *param)
+{
+    EVP_KEYMGMT_names_do_all(km, print_km_name, NULL);
+}
+#endif
+
 int
 list_publickey()
 {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     for (size_t i = 0; i < EVP_PKEY_meth_get_count(); i++) {
         const EVP_PKEY_METHOD *pmeth = EVP_PKEY_meth_get0(i);
         int                    id = 0;
         EVP_PKEY_meth_get0_info(&id, NULL, pmeth);
         printf("%s\n", OBJ_nid2ln(id));
     }
+#else
+    EVP_KEYMGMT_do_all_provided(NULL, print_km, NULL);
+#endif
     return 0;
 }
 

--- a/src/lib/crypto/bn.h
+++ b/src/lib/crypto/bn.h
@@ -61,4 +61,82 @@ bool bn2mpi(const bignum_t *bn, pgp_mpi_t *val);
 
 size_t bn_num_bytes(const bignum_t &a);
 
+#if defined(CRYPTO_BACKEND_OPENSSL)
+namespace rnp {
+class bn {
+    BIGNUM *_bn;
+
+  public:
+    bn(BIGNUM *val = NULL) : _bn(val)
+    {
+    }
+
+    bn(const pgp_mpi_t &val) : _bn(mpi2bn(&val))
+    {
+    }
+
+    ~bn()
+    {
+        BN_free(_bn);
+    }
+
+    void
+    set(BIGNUM *val = NULL) noexcept
+    {
+        BN_free(_bn);
+        _bn = val;
+    }
+
+    void
+    set(const pgp_mpi_t &val) noexcept
+    {
+        BN_free(_bn);
+        _bn = mpi2bn(&val);
+    }
+
+    BIGNUM **
+    ptr() noexcept
+    {
+        set();
+        return &_bn;
+    }
+
+    BIGNUM *
+    get() noexcept
+    {
+        return _bn;
+    }
+
+    BIGNUM *
+    own() noexcept
+    {
+        auto res = _bn;
+        _bn = NULL;
+        return res;
+    }
+
+    size_t
+    bytes() const noexcept
+    {
+        return BN_num_bytes(_bn);
+    }
+
+    bool
+    bin(uint8_t *b) const noexcept
+    {
+        if (!b) {
+            return false;
+        }
+        return BN_bn2bin(_bn, b) >= 0;
+    }
+
+    bool
+    mpi(pgp_mpi_t &mpi) const noexcept
+    {
+        return bn2mpi(_bn, &mpi);
+    }
+};
+}; // namespace rnp
+#endif
+
 #endif

--- a/src/lib/crypto/ecdh_ossl.cpp
+++ b/src/lib/crypto/ecdh_ossl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2021-2023, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
And do some refactoring for less gotos.