### PR TITLE
CLI: export all keys when no filter is specified.

### DIFF
--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1949,7 +1949,7 @@ cli_rnp_keys_matching_string(cli_rnp_t *                    rnp,
         if (rnp_locate_key(rnp->ffi, "fingerprint", fp, &handle) || !handle) {
             goto done;
         }
-        if (!key_matches_flags(handle, flags) || !key_matches_string(handle, str.c_str())) {
+        if (!key_matches_flags(handle, flags) || !key_matches_string(handle, str)) {
             rnp_key_handle_destroy(handle);
             continue;
         }
@@ -2206,7 +2206,7 @@ cli_rnp_export_keys(cli_rnp_t *rnp, const char *filter)
     int                           flags = secret ? CLI_SEARCH_SECRET : 0;
     std::vector<rnp_key_handle_t> keys;
 
-    if (!cli_rnp_keys_matching_string(rnp, keys, filter, flags)) {
+    if (!cli_rnp_keys_matching_string(rnp, keys, filter ? filter : std::string(), flags)) {
         ERR_MSG("Key(s) matching '%s' not found.", filter);
         return false;
     }

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -405,10 +405,6 @@ rnp_cmd(cli_rnp_t *rnp, optdefs_t cmd, const char *f)
             fs = rnp->cfg().get_str(CFG_USERID, 0);
             f = fs.c_str();
         }
-        if (!f) {
-            ERR_MSG("No key specified.");
-            return 0;
-        }
         return cli_rnp_export_keys(rnp, f);
     }
     case CMD_IMPORT:

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1495,10 +1495,10 @@ class Keystore(unittest.TestCase):
         # Import Alice's public key
         ret, _, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--import', data_path(KEY_ALICE_SUB_PUB)])
         self.assertEqual(ret, 0)
-        # Attempt to export no key
-        ret, _, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export-key'])
-        self.assertNotEqual(ret, 0)
-        self.assertRegex(err, r'(?s)^.*No key specified\.$')
+        # Export all keys (no search pattern)
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export-key'])
+        self.assertEqual(ret, 0)
+        self.assertRegex(out, PUB_KEY)
         # Attempt to export wrong key
         ret, _, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export-key', 'boris'])
         self.assertNotEqual(ret, 0)


### PR DESCRIPTION
Closes #1606

`rnpkeys --export-key` will export all keys when no filter/search pattern is specified, instead of "No key specified" error message.