### PR TITLE
Fix possible memory leak during ElGamal key generation with OpenSSL 3.0 backend.

### DIFF
--- a/src/lib/crypto/elgamal_ossl.cpp
+++ b/src/lib/crypto/elgamal_ossl.cpp
@@ -394,6 +394,10 @@ start:
             goto done;
         }
         if (y.bytes() != BITS_TO_BYTES(keybits)) {
+            EVP_PKEY_CTX_free(ctx);
+            ctx = NULL;
+            EVP_PKEY_free(pkey);
+            pkey = NULL;
             goto start;
         }
 


### PR DESCRIPTION
Noticed via https://github.com/rnpgp/rnp/pull/2087