### PR TITLE
Remove CFG_USERINPUTFD and use stdin replacement in affected tests.

### DIFF
--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -60,7 +60,6 @@
 #define CFG_PASSFD "pass-fd"      /* password file descriptor */
 #define CFG_PASSWD "password"     /* password as command-line constant */
 #define CFG_PASSWORDC "passwordc" /* number of passwords for symmetric encryption */
-#define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
 #define CFG_EXPIRATION "expiration"     /* signature expiration time */
 #define CFG_CREATION "creation"         /* signature validity start */

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -54,30 +54,30 @@
 #define CFG_V3_PKESK_ONLY "v3-pkesk-only"     /* disable v6 PKESK */
 #define CFG_ENABLE_V6_SKESK "enable-v6-skesk" /* disable v6 SKESK */
 #endif
-#define CFG_SIGNERS "signers"     /* list of signers */
-#define CFG_HOMEDIR "homedir"     /* home directory - folder with keyrings and so on */
-#define CFG_KEYFILE "keyfile"     /* path to the file with key(s), used instead of keyring */
-#define CFG_PASSFD "pass-fd"      /* password file descriptor */
-#define CFG_PASSWD "password"     /* password as command-line constant */
-#define CFG_PASSWORDC "passwordc" /* number of passwords for symmetric encryption */
-#define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
-#define CFG_EXPIRATION "expiration"     /* signature expiration time */
-#define CFG_CREATION "creation"         /* signature validity start */
-#define CFG_CIPHER "cipher"             /* symmetric encryption algorithm as string */
-#define CFG_HASH "hash"                 /* hash algorithm used, string like 'SHA1'*/
-#define CFG_WEAK_HASH "weak-hash"       /* allow weak algorithms */
-#define CFG_ALLOW_SHA1 "allow-sha1"     /* allow SHA-1 key signatures */
-#define CFG_S2K_ITER "s2k-iter"         /* number of S2K hash iterations to perform */
-#define CFG_S2K_MSEC "s2k-msec"         /* number of milliseconds S2K should target */
-#define CFG_ENCRYPT_PK "encrypt_pk"     /* public key should be used during encryption */
-#define CFG_ENCRYPT_SK "encrypt_sk"     /* password encryption should be used */
-#define CFG_IO_RESS "ress"              /* results stream */
-#define CFG_NUMBITS "numbits"           /* number of bits in generated key */
-#define CFG_EXPERT "expert"             /* expert key generation mode */
-#define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
-#define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
-#define CFG_AEAD "aead"                 /* if nonzero then AEAD encryption mode, int */
-#define CFG_AEAD_CHUNK "aead_chunk"     /* AEAD chunk size bits, int from 0 to 56 */
+#define CFG_SIGNERS "signers"       /* list of signers */
+#define CFG_HOMEDIR "homedir"       /* home directory - folder with keyrings and so on */
+#define CFG_KEYFILE "keyfile"       /* path to the file with key(s), used instead of keyring */
+#define CFG_PASSFD "pass-fd"        /* password file descriptor */
+#define CFG_PASSWD "password"       /* password as command-line constant */
+#define CFG_PASSWORDC "passwordc"   /* number of passwords for symmetric encryption */
+#define CFG_NUMTRIES "numtries"     /* number of password request tries, or 'unlimited' */
+#define CFG_EXPIRATION "expiration" /* signature expiration time */
+#define CFG_CREATION "creation"     /* signature validity start */
+#define CFG_CIPHER "cipher"         /* symmetric encryption algorithm as string */
+#define CFG_HASH "hash"             /* hash algorithm used, string like 'SHA1'*/
+#define CFG_WEAK_HASH "weak-hash"   /* allow weak algorithms */
+#define CFG_ALLOW_SHA1 "allow-sha1" /* allow SHA-1 key signatures */
+#define CFG_S2K_ITER "s2k-iter"     /* number of S2K hash iterations to perform */
+#define CFG_S2K_MSEC "s2k-msec"     /* number of milliseconds S2K should target */
+#define CFG_ENCRYPT_PK "encrypt_pk" /* public key should be used during encryption */
+#define CFG_ENCRYPT_SK "encrypt_sk" /* password encryption should be used */
+#define CFG_IO_RESS "ress"          /* results stream */
+#define CFG_NUMBITS "numbits"       /* number of bits in generated key */
+#define CFG_EXPERT "expert"         /* expert key generation mode */
+#define CFG_ZLEVEL "zlevel"         /* compression level: 0..9 (0 for no compression) */
+#define CFG_ZALG "zalg"             /* compression algorithm: zip, zlib or bzip2 */
+#define CFG_AEAD "aead"             /* if nonzero then AEAD encryption mode, int */
+#define CFG_AEAD_CHUNK "aead_chunk" /* AEAD chunk size bits, int from 0 to 56 */
 #define CFG_KEYSTORE_DISABLED \
     "disable_keystore"              /* indicates whether keystore must be initialized */
 #define CFG_FORCE "force"           /* force command to succeed operation */

--- a/src/rnpkeys/tui.cpp
+++ b/src/rnpkeys/tui.cpp
@@ -562,18 +562,6 @@ cli_rnp_set_generate_params(rnp_cfg &cfg, bool subkey)
         cfg.set_int(CFG_KG_SUBKEY_BITS, cfg.get_int(CFG_NUMBITS));
     } else {
         FILE *input = stdin;
-        if (cfg.has(CFG_USERINPUTFD)) {
-            int inputfd = dup(cfg.get_int(CFG_USERINPUTFD));
-            if (inputfd != -1) {
-                input = rnp_fdopen(inputfd, "r");
-                if (!input) {
-                    close(inputfd);
-                }
-            }
-        }
-        if (!input) {
-            return false;
-        }
         if (subkey) {
             res = rnpkeys_ask_generate_params_subkey(cfg, input);
         } else {

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -642,10 +642,13 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg &ops, const char *rsp)
     if (!ret) {
         goto end;
     }
+#ifndef _WIN32
+    /* fcntl(), F_SETFD and FD_CLOEXEC are not available on Windows */
     if (fcntl(STDIN_FILENO, F_SETFD, FD_CLOEXEC) == -1) {
         ret = false;
         goto end;
     }
+#endif
     ops.copy(ctx->cfg());
     ret = true;
 end:

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -602,6 +602,7 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg &ops, const char *rsp)
     bool   ret = false;
     int    pipefd[2] = {-1, -1};
     int    user_input_pipefd[2] = {-1, -1};
+    int    saved_stdin = -1;
     size_t rsp_len;
 
     if (pipe(pipefd) == -1) {
@@ -625,10 +626,23 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg &ops, const char *rsp)
     }
     close(user_input_pipefd[1]);
 
-    /* Mock user-input*/
-    ctx->cfg().set_int(CFG_USERINPUTFD, user_input_pipefd[0]);
+    /* Replace stdin with our pipe */
+    saved_stdin = dup(STDIN_FILENO);
+    if (dup2(user_input_pipefd[0], STDIN_FILENO) == -1) {
+        ret = false;
+        goto end;
+    }
 
-    if (!rnp_cmd(ctx, CMD_GENERATE_KEY, NULL)) {
+    ret = rnp_cmd(ctx, CMD_GENERATE_KEY, NULL);
+    /* always restore the original stdin */
+    if (dup2(saved_stdin, STDIN_FILENO) == -1) {
+        ret = false;
+        goto end;
+    }
+    if (!ret) {
+        goto end;
+    }
+    if (fcntl(STDIN_FILENO, F_SETFD, FD_CLOEXEC) == -1) {
         ret = false;
         goto end;
     }
@@ -639,6 +653,7 @@ end:
     if (user_input_pipefd[0]) {
         close(user_input_pipefd[0]);
     }
+    close(saved_stdin);
     return ret;
 }
 

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -647,7 +647,12 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg &ops, const char *rsp)
         goto end;
     }
 #ifndef _WIN32
-    /* fcntl(), F_SETFD and FD_CLOEXEC are not available on Windows */
+    /* fcntl(), F_SETFD and FD_CLOEXEC are not available on Windows.
+     * Restore close-on-exec on STDIN_FILENO: dup() (used to snapshot the original
+     * stdin into saved_stdin) drops the CLOEXEC flag, and dup2() inherits the
+     * flag state from the source descriptor, so without this restoration any
+     * child process spawned by later tests would inherit a non-close-on-exec
+     * stdin. */
     if (fcntl(STDIN_FILENO, F_SETFD, FD_CLOEXEC) == -1) {
         ret = false;
         goto end;
@@ -660,7 +665,9 @@ end:
     if (user_input_pipefd[0]) {
         close(user_input_pipefd[0]);
     }
-    close(saved_stdin);
+    if (saved_stdin != -1) {
+        close(saved_stdin);
+    }
     return ret;
 }
 

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -632,6 +632,10 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg &ops, const char *rsp)
         ret = false;
         goto end;
     }
+    /* Reset the EOF/error flags: a previous call may have set stdin's EOF flag
+       (e.g. an expected-failure run which reads past the provided input), and
+       stdio would then refuse to read from the new pipe. */
+    clearerr(stdin);
 
     ret = rnp_cmd(ctx, CMD_GENERATE_KEY, NULL);
     /* always restore the original stdin */

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -60,6 +60,8 @@
 
 #ifdef _WIN32
 #define pipe(fds) _pipe(fds, 256, O_BINARY)
+#define dup(fd) _dup(fd)
+#define dup2(fd1, fd2) _dup2(fd1, fd2)
 int setenv(const char *name, const char *value, int overwrite);
 int unsetenv(const char *name);
 #endif


### PR DESCRIPTION
Closes #1609 and closes #1857

Affected tests now use stdin temporarily replaced with a pipe read end.