### PR TITLE
Update README.adoc for openSUSE

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,10 +32,7 @@ Currently supported platforms:
 * MacOS
 * Windows
 * Debian
-
-Upcoming supported platforms:
-
-* OpenSUSE Leap
+* openSUSE Leap, openSUSE Tumbleweed
 * SLES
 
 == link:docs/installation.adoc[Installation]


### PR DESCRIPTION
README.adoc: note support for openSUSE.

rnp / sexp are now packaged for openSUSE and SLE.

* https://build.opensuse.org/package/show/openSUSE:Factory/rnp 
* https://build.opensuse.org/package/show/security:privacy/rnp