### PR TITLE
RIPEMD160 is now available by default since OpenSSL 3.0.7.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
-      - uses: cachix/install-nix-action@v15
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix build .?submodules=1

--- a/src/lib/crypto/backend_version.cpp
+++ b/src/lib/crypto/backend_version.cpp
@@ -109,7 +109,7 @@ backend_version()
 #if defined(CRYPTO_BACKEND_OPENSSL3)
 
 #if defined(ENABLE_IDEA) || defined(ENABLE_CAST5) || defined(ENABLE_BLOWFISH) || \
-  defined(ENABLE_RIPEMD160)
+  (defined(ENABLE_RIPEMD160) && OPENSSL_VERSION_NUMBER < 0x30000070L)
 #define OPENSSL_LOAD_LEGACY
 #endif
 


### PR DESCRIPTION
Closes #1980 