### PR TITLE
fix ecdsa padding strings for sha3

### DIFF
--- a/src/lib/crypto/ecdsa.cpp
+++ b/src/lib/crypto/ecdsa.cpp
@@ -132,9 +132,9 @@ ecdsa_padding_str_for(pgp_hash_alg_t hash_alg)
     case PGP_HASH_SHA224:
         return "Raw(SHA-224)";
     case PGP_HASH_SHA3_256:
-        return "Raw(SHA3(256))";
+        return "Raw(SHA-3(256))";
     case PGP_HASH_SHA3_512:
-        return "Raw(SHA3(512))";
+        return "Raw(SHA-3(512))";
 
     case PGP_HASH_SM3:
         return "Raw(SM3)";


### PR DESCRIPTION
The botan strings in `ecdsa_padding_str_for()` were wrong for SHA3-256/512 (see https://github.com/randombit/botan/blob/master/src/lib/hash/sha3/sha3.cpp#L118)

Note: In `botan_alg_map` in hash.cpp the strings are correctly written. T `ecdsa_padding_str_for` could also make use of the mapping if it's made non-static.