### PR TITLE
Removed tests against gpg 2.3.0 beta

### DIFF
--- a/.github/workflows/centos-and-fedora.yml
+++ b/.github/workflows/centos-and-fedora.yml
@@ -73,7 +73,6 @@ jobs:
           - { name: 'CentOS 8',  container: 'tgagor/centos:stream8',         gpg_ver: lts,    backend: Botan,   sm2: On,           locale: C.UTF-8     }
           - { name: 'CentOS 8',  container: 'tgagor/centos:stream8',         gpg_ver: stable, backend: Botan,   sm2: Off,          locale: C.UTF-8     }
           - { name: 'CentOS 8',  container: 'tgagor/centos:stream8',         gpg_ver: lts,    backend: OpenSSL,                    locale: C.UTF-8     }
-          - { name: 'CentOS 8',  container: 'tgagor/centos:stream8',         gpg_ver: beta,   backend: Botan,   sm2: On,           locale: C.UTF-8     }
           - { name: 'CentOS 8',  container: 'tgagor/centos:stream8',         gpg_ver: 2.3.1,  backend: Botan,   sm2: On,           locale: C.UTF-8     }
           - { name: 'CentOS 9',  container: 'quay.io/centos/centos:stream9', gpg_ver: stable, backend: OpenSSL, idea: On,          locale: C.UTF-8     }
           - { name: 'CentOS 9',  container: 'quay.io/centos/centos:stream9', gpg_ver: stable, backend: OpenSSL, idea: Off,         locale: C.UTF-8     }

--- a/ci/lib/cacheable_install_functions.inc.sh
+++ b/ci/lib/cacheable_install_functions.inc.sh
@@ -230,11 +230,11 @@ install_gpg() {
         #                              npth libgpg-error libgcrypt libassuan libksba pinentry gnupg
         _install_gpg component-version 1.6  1.46         1.8.10    2.5.5     1.6.3   1.2.1    2.2.41
         ;;
-      beta)
+      # beta)
         #                              npth    libgpg-error libgcrypt libassuan libksba pinentry gnupg
-        _install_gpg component-git-ref 2501a48 f73605e      d9c4183   909133b   3df0cd3 0e2e53c  c6702d7
+        # _install_gpg component-git-ref 2501a48 f73605e      d9c4183   909133b   3df0cd3 0e2e53c  c6702d7
         # _install_gpg component-git-ref 7e45b50 c66594d      cf88dca   57cf9d6   4243085 6e8ad31  d4e5979
-        ;;
+        # ;;
       "2.3.1")
         #                              npth libgpg-error libgcrypt libassuan libksba pinentry gnupg
         _install_gpg component-version 1.6  1.42         1.9.3     2.5.5     1.6.0   1.1.1    2.3.1


### PR DESCRIPTION
One of gnupg tags used for testing pints to 2.3.0 beta version of 2021. 
I do not think there is any value to test against it -- 2.3 line is at 2.3.8 know.