### PR TITLE
Refactor rnp_op_verify_st to use C++ types instead of raw pointers.

### DIFF
--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -54,17 +54,25 @@ struct rnp_signature_handle_st {
 
 struct rnp_recipient_handle_st {
     rnp_ffi_t        ffi;
-    uint8_t          keyid[PGP_KEY_ID_SIZE];
+    pgp_key_id_t     keyid;
     pgp_pubkey_alg_t palg;
+
+    rnp_recipient_handle_st() : ffi(NULL), palg(PGP_PKA_NOTHING)
+    {
+    }
 };
 
 struct rnp_symenc_handle_st {
     rnp_ffi_t           ffi;
-    pgp_symm_alg_t      alg;
-    pgp_hash_alg_t      halg;
-    pgp_s2k_specifier_t s2k_type;
+    pgp_symm_alg_t      alg{};
+    pgp_hash_alg_t      halg{};
+    pgp_s2k_specifier_t s2k_type{};
     uint32_t            iterations;
-    pgp_aead_alg_t      aalg;
+    pgp_aead_alg_t      aalg{};
+
+    rnp_symenc_handle_st() : ffi(NULL), iterations(0)
+    {
+    }
 };
 
 struct rnp_ffi_st {
@@ -176,13 +184,11 @@ struct rnp_op_verify_st {
     bool           require_all_sigs{};
     bool           allow_hidden{};
     /* recipient/symenc information */
-    rnp_recipient_handle_t recipients{};
-    size_t                 recipient_count{};
-    rnp_recipient_handle_t used_recipient{};
-    rnp_symenc_handle_t    symencs{};
-    size_t                 symenc_count{};
-    rnp_symenc_handle_t    used_symenc{};
-    size_t                 encrypted_layers{};
+    std::vector<rnp_recipient_handle_st> recipients;
+    rnp_recipient_handle_t               used_recipient{};
+    std::vector<rnp_symenc_handle_st>    symencs;
+    rnp_symenc_handle_t                  used_symenc{};
+    size_t                               encrypted_layers{};
 
     ~rnp_op_verify_st();
 };

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -170,10 +170,9 @@ struct rnp_op_verify_st {
     rnp_output_t output{};
     rnp_ctx_t    rnpctx{};
     /* these fields are filled after operation execution */
-    rnp_op_verify_signature_t signatures{};
-    size_t                    signature_count{};
-    std::string               filename;
-    uint32_t                  file_mtime{};
+    std::vector<rnp_op_verify_signature_st> signatures_;
+    std::string                             filename;
+    uint32_t                                file_mtime{};
     /* encryption information */
     bool           encrypted{};
     bool           mdc{};

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -172,7 +172,7 @@ struct rnp_op_verify_st {
     /* these fields are filled after operation execution */
     rnp_op_verify_signature_t signatures{};
     size_t                    signature_count{};
-    char *                    filename{};
+    std::string               filename;
     uint32_t                  file_mtime{};
     /* encryption information */
     bool           encrypted{};

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3086,26 +3086,25 @@ rnp_verify_dest_provider(pgp_parse_handler_t *handler,
 }
 
 static void
-recipient_handle_from_pk_sesskey(rnp_recipient_handle_t  handle,
-                                 const pgp_pk_sesskey_t &sesskey)
+recipient_handle_from_pk_sesskey(rnp_recipient_handle_st &handle,
+                                 const pgp_pk_sesskey_t & sesskey)
 {
-    static_assert(sizeof(handle->keyid) == PGP_KEY_ID_SIZE, "Keyid size mismatch");
-    memcpy(handle->keyid, sesskey.key_id.data(), PGP_KEY_ID_SIZE);
-    handle->palg = sesskey.alg;
+    handle.keyid = sesskey.key_id;
+    handle.palg = sesskey.alg;
 }
 
 static void
-symenc_handle_from_sk_sesskey(rnp_symenc_handle_t handle, const pgp_sk_sesskey_t &sesskey)
+symenc_handle_from_sk_sesskey(rnp_symenc_handle_st &handle, const pgp_sk_sesskey_t &sesskey)
 {
-    handle->alg = sesskey.alg;
-    handle->halg = sesskey.s2k.hash_alg;
-    handle->s2k_type = sesskey.s2k.specifier;
+    handle.alg = sesskey.alg;
+    handle.halg = sesskey.s2k.hash_alg;
+    handle.s2k_type = sesskey.s2k.specifier;
     if (sesskey.s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
-        handle->iterations = pgp_s2k_decode_iterations(sesskey.s2k.iterations);
+        handle.iterations = pgp_s2k_decode_iterations(sesskey.s2k.iterations);
     } else {
-        handle->iterations = 1;
+        handle.iterations = 1;
     }
-    handle->aalg = sesskey.aalg;
+    handle.aalg = sesskey.aalg;
 }
 
 static void
@@ -3119,28 +3118,17 @@ rnp_verify_on_recipients(const std::vector<pgp_pk_sesskey_t> &recipients,
         return;
     }
     if (!recipients.empty()) {
-        op->recipients =
-          (rnp_recipient_handle_t) calloc(recipients.size(), sizeof(*op->recipients));
-        if (!op->recipients) {
-            FFI_LOG(op->ffi, "allocation failed");
-            return;
-        }
+        op->recipients.resize(recipients.size());
         for (size_t i = 0; i < recipients.size(); i++) {
-            recipient_handle_from_pk_sesskey(&op->recipients[i], recipients[i]);
+            recipient_handle_from_pk_sesskey(op->recipients[i], recipients[i]);
         }
     }
-    op->recipient_count = recipients.size();
     if (!passwords.empty()) {
-        op->symencs = (rnp_symenc_handle_t) calloc(passwords.size(), sizeof(*op->symencs));
-        if (!op->symencs) {
-            FFI_LOG(op->ffi, "allocation failed");
-            return;
-        }
+        op->symencs.resize(passwords.size());
         for (size_t i = 0; i < passwords.size(); i++) {
-            symenc_handle_from_sk_sesskey(&op->symencs[i], passwords[i]);
+            symenc_handle_from_sk_sesskey(op->symencs[i], passwords[i]);
         }
     }
-    op->symenc_count = passwords.size();
 }
 
 static void
@@ -3152,21 +3140,19 @@ rnp_verify_on_decryption_start(pgp_pk_sesskey_t *pubenc, pgp_sk_sesskey_t *symen
         return;
     }
     if (pubenc) {
-        op->used_recipient = (rnp_recipient_handle_t) calloc(1, sizeof(*op->used_recipient));
+        op->used_recipient = new (std::nothrow) rnp_recipient_handle_st();
         if (!op->used_recipient) {
-            FFI_LOG(op->ffi, "allocation failed");
             return;
         }
-        recipient_handle_from_pk_sesskey(op->used_recipient, *pubenc);
+        recipient_handle_from_pk_sesskey(*op->used_recipient, *pubenc);
         return;
     }
     if (symenc) {
-        op->used_symenc = (rnp_symenc_handle_t) calloc(1, sizeof(*op->used_symenc));
+        op->used_symenc = new (std::nothrow) rnp_symenc_handle_st();
         if (!op->used_symenc) {
-            FFI_LOG(op->ffi, "allocation failed");
             return;
         }
-        symenc_handle_from_sk_sesskey(op->used_symenc, *symenc);
+        symenc_handle_from_sk_sesskey(*op->used_symenc, *symenc);
         return;
     }
     FFI_LOG(op->ffi, "Warning! Both pubenc and symenc are NULL.");
@@ -3440,7 +3426,7 @@ try {
     if (!op || !count) {
         return RNP_ERROR_NULL_POINTER;
     }
-    *count = op->recipient_count;
+    *count = op->recipients.size();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -3464,7 +3450,7 @@ try {
     if (!op || !recipient) {
         return RNP_ERROR_NULL_POINTER;
     }
-    if (idx >= op->recipient_count) {
+    if (idx >= op->recipients.size()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     *recipient = &op->recipients[idx];
@@ -3478,9 +3464,7 @@ try {
     if (!recipient || !keyid) {
         return RNP_ERROR_NULL_POINTER;
     }
-    static_assert(sizeof(recipient->keyid) == PGP_KEY_ID_SIZE,
-                  "rnp_recipient_handle_t.keyid size mismatch");
-    return hex_encode_value(recipient->keyid, PGP_KEY_ID_SIZE, keyid);
+    return ret_keyid(recipient->keyid, keyid);
 }
 FFI_GUARD
 
@@ -3500,7 +3484,7 @@ try {
     if (!op || !count) {
         return RNP_ERROR_NULL_POINTER;
     }
-    *count = op->symenc_count;
+    *count = op->symencs.size();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -3522,7 +3506,7 @@ try {
     if (!op || !symenc) {
         return RNP_ERROR_NULL_POINTER;
     }
-    if (idx >= op->symenc_count) {
+    if (idx >= op->symencs.size()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     *symenc = &op->symencs[idx];
@@ -3593,10 +3577,8 @@ rnp_op_verify_st::~rnp_op_verify_st()
 {
     delete[] signatures;
     free(filename);
-    free(recipients);
-    free(used_recipient);
-    free(symencs);
-    free(used_symenc);
+    delete used_recipient;
+    delete used_symenc;
 }
 
 rnp_result_t

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3021,35 +3021,28 @@ rnp_op_verify_on_signatures(const std::vector<pgp_signature_info_t> &sigs, void 
 
     try {
         /* in case we have multiple signed layers */
-        delete[] op->signatures;
-        op->signatures = new rnp_op_verify_signature_st[sigs.size()];
+        op->signatures_.resize(sigs.size());
+
+        size_t i = 0;
+        for (const auto &sinfo : sigs) {
+            auto &res = op->signatures_[i++];
+            /* sinfo.sig may be NULL */
+            if (sinfo.sig) {
+                res.sig_pkt = *sinfo.sig;
+            }
+
+            if (sinfo.unknown) {
+                res.verify_status = RNP_ERROR_SIGNATURE_UNKNOWN;
+            } else if (sinfo.valid) {
+                res.verify_status = sinfo.expired ? RNP_ERROR_SIGNATURE_EXPIRED : RNP_SUCCESS;
+            } else {
+                res.verify_status =
+                  sinfo.no_signer ? RNP_ERROR_KEY_NOT_FOUND : RNP_ERROR_SIGNATURE_INVALID;
+            }
+            res.ffi = op->ffi;
+        }
     } catch (const std::exception &e) {
         FFI_LOG(op->ffi, "%s", e.what());
-        return;
-    }
-    op->signature_count = sigs.size();
-
-    size_t i = 0;
-    for (const auto &sinfo : sigs) {
-        rnp_op_verify_signature_t res = &op->signatures[i++];
-        /* sinfo.sig may be NULL */
-        if (sinfo.sig) {
-            try {
-                res->sig_pkt = *sinfo.sig;
-            } catch (const std::exception &e) {
-                FFI_LOG(op->ffi, "%s", e.what());
-            }
-        }
-
-        if (sinfo.unknown) {
-            res->verify_status = RNP_ERROR_SIGNATURE_UNKNOWN;
-        } else if (sinfo.valid) {
-            res->verify_status = sinfo.expired ? RNP_ERROR_SIGNATURE_EXPIRED : RNP_SUCCESS;
-        } else {
-            res->verify_status =
-              sinfo.no_signer ? RNP_ERROR_KEY_NOT_FOUND : RNP_ERROR_SIGNATURE_INVALID;
-        }
-        res->ffi = op->ffi;
     }
 }
 
@@ -3301,8 +3294,8 @@ try {
     }
     /* Allow to require all signatures be valid */
     if (op->require_all_sigs && !ret) {
-        for (size_t i = 0; i < op->signature_count; i++) {
-            if (op->signatures[i].verify_status) {
+        for (auto &sig : op->signatures_) {
+            if (sig.verify_status) {
                 ret = RNP_ERROR_SIGNATURE_INVALID;
                 break;
             }
@@ -3323,7 +3316,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    *count = op->signature_count;
+    *count = op->signatures_.size();
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -3334,11 +3327,11 @@ try {
     if (!op || !sig) {
         return RNP_ERROR_NULL_POINTER;
     }
-    if (idx >= op->signature_count) {
+    if (idx >= op->signatures_.size()) {
         FFI_LOG(op->ffi, "Invalid signature index: %zu", idx);
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    *sig = &op->signatures[idx];
+    *sig = &op->signatures_[idx];
     return RNP_SUCCESS;
 }
 FFI_GUARD
@@ -3568,7 +3561,6 @@ FFI_GUARD
 
 rnp_op_verify_st::~rnp_op_verify_st()
 {
-    delete[] signatures;
     delete used_recipient;
     delete used_symenc;
 }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3080,7 +3080,7 @@ rnp_verify_dest_provider(pgp_parse_handler_t *handler,
     }
     *dst = &(op->output->dst);
     *closedst = false;
-    op->filename = filename ? strdup(filename) : NULL;
+    op->filename = filename ? std::string(filename) : "";
     op->file_mtime = mtime;
     return true;
 }
@@ -3352,14 +3352,7 @@ try {
     if (mtime) {
         *mtime = op->file_mtime;
     }
-    if (filename) {
-        if (op->filename) {
-            *filename = strdup(op->filename);
-        } else {
-            *filename = NULL;
-        }
-    }
-    return RNP_SUCCESS;
+    return filename ? ret_str_value(op->filename.c_str(), filename) : RNP_SUCCESS;
 }
 FFI_GUARD
 
@@ -3576,7 +3569,6 @@ FFI_GUARD
 rnp_op_verify_st::~rnp_op_verify_st()
 {
     delete[] signatures;
-    free(filename);
     delete used_recipient;
     delete used_symenc;
 }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -514,6 +514,24 @@ ret_str_value(const char *str, char **res)
     return RNP_SUCCESS;
 }
 
+static rnp_result_t
+ret_fingerprint(const pgp_fingerprint_t &fp, char **res)
+{
+    return hex_encode_value(fp.fingerprint, fp.length, res);
+}
+
+static rnp_result_t
+ret_keyid(const pgp_key_id_t &keyid, char **res)
+{
+    return hex_encode_value(keyid.data(), keyid.size(), res);
+}
+
+static rnp_result_t
+ret_grip(const pgp_key_grip_t &grip, char **res)
+{
+    return hex_encode_value(grip.data(), grip.size(), res);
+}
+
 static uint32_t
 ffi_exception(FILE *fp, const char *func, const char *msg, uint32_t ret = RNP_ERROR_GENERIC)
 {
@@ -6173,8 +6191,7 @@ try {
         *result = NULL;
         return RNP_SUCCESS;
     }
-    pgp_key_id_t keyid = handle->sig->sig.keyid();
-    return hex_encode_value(keyid.data(), keyid.size(), result);
+    return ret_keyid(handle->sig->sig.keyid(), result);
 }
 FFI_GUARD
 
@@ -6191,8 +6208,7 @@ try {
         *result = NULL;
         return RNP_SUCCESS;
     }
-    pgp_fingerprint_t keyfp = handle->sig->sig.keyfp();
-    return hex_encode_value(keyfp.fingerprint, keyfp.length, result);
+    return ret_fingerprint(handle->sig->sig.keyfp(), result);
 }
 FFI_GUARD
 
@@ -6566,9 +6582,7 @@ try {
     if (!handle || !fprint) {
         return RNP_ERROR_NULL_POINTER;
     }
-
-    const pgp_fingerprint_t &fp = get_key_prefer_public(handle)->fp();
-    return hex_encode_value(fp.fingerprint, fp.length, fprint);
+    return ret_fingerprint(get_key_prefer_public(handle)->fp(), fprint);
 }
 FFI_GUARD
 
@@ -6578,9 +6592,7 @@ try {
     if (!handle || !keyid) {
         return RNP_ERROR_NULL_POINTER;
     }
-
-    pgp_key_t *key = get_key_prefer_public(handle);
-    return hex_encode_value(key->keyid().data(), key->keyid().size(), keyid);
+    return ret_keyid(get_key_prefer_public(handle)->keyid(), keyid);
 }
 FFI_GUARD
 
@@ -6591,8 +6603,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    const pgp_key_grip_t &kgrip = get_key_prefer_public(handle)->grip();
-    return hex_encode_value(kgrip.data(), kgrip.size(), grip);
+    return ret_grip(get_key_prefer_public(handle)->grip(), grip);
 }
 FFI_GUARD
 
@@ -6629,7 +6640,7 @@ try {
         *grip = NULL;
         return RNP_SUCCESS;
     }
-    return hex_encode_value(pgrip->data(), pgrip->size(), grip);
+    return ret_grip(*pgrip, grip);
 }
 FFI_GUARD
 
@@ -6648,8 +6659,7 @@ try {
         *fprint = NULL;
         return RNP_SUCCESS;
     }
-    const pgp_fingerprint_t &fp = key->primary_fp();
-    return hex_encode_value(fp.fingerprint, fp.length, fprint);
+    return ret_fingerprint(key->primary_fp(), fprint);
 }
 FFI_GUARD
 


### PR DESCRIPTION
Fixes #2128 as well.