### PR TITLE
FIx some PQC issues.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1176,6 +1176,7 @@ RNP_API rnp_result_t rnp_op_generate_clear_pref_ciphers(rnp_op_generate_t op);
 RNP_API rnp_result_t rnp_op_generate_set_pref_keyserver(rnp_op_generate_t op,
                                                         const char *      keyserver);
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
 /** Set the generated key version to v6.
  *  NOTE: This is an experimantal feature and this function can be replaced (or removed) at any
  *        time.
@@ -1184,7 +1185,9 @@ RNP_API rnp_result_t rnp_op_generate_set_pref_keyserver(rnp_op_generate_t op,
  * @return RNP_SUCCESS or error code if failed.
  */
 RNP_API rnp_result_t rnp_op_generate_set_v6_key(rnp_op_generate_t op);
+#endif
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_PQC)
 /** Set the SPHINCS+ parameter set
  *  NOTE: This is an experimantal feature and this function can be replaced (or removed) at any
  *        time.
@@ -1200,6 +1203,7 @@ RNP_API rnp_result_t rnp_op_generate_set_v6_key(rnp_op_generate_t op);
  */
 RNP_API rnp_result_t rnp_op_generate_set_sphincsplus_param(rnp_op_generate_t op,
                                                            const char *      param);
+#endif
 
 /** Execute the prepared key or subkey generation operation.
  *  Note: if you set protection algorithm, then you need to specify ffi password provider to
@@ -3005,6 +3009,7 @@ RNP_API rnp_result_t rnp_op_encrypt_create(rnp_op_encrypt_t *op,
  */
 RNP_API rnp_result_t rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_handle_t key);
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
 /**
  * @brief Enables the creation of PKESK v6 (instead of v3) which results in the use of SEIPDv2.
  *        The actually created version depends on the capabilities of the list of recipients.
@@ -3015,6 +3020,7 @@ RNP_API rnp_result_t rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_h
  * @return RNP_SUCCESS or errorcode if failed.
  */
 RNP_API rnp_result_t rnp_op_encrypt_enable_pkesk_v6(rnp_op_encrypt_t op);
+#endif
 
 /**
  * @brief Add signature to encrypting context, so data will be encrypted and signed.
@@ -3416,8 +3422,11 @@ RNP_API const char *rnp_backend_version();
 #define RNP_ALGNAME_ECDH "ECDH"
 #define RNP_ALGNAME_ECDSA "ECDSA"
 #define RNP_ALGNAME_EDDSA "EDDSA"
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
 #define RNP_ALGNAME_ED25519 "ED25519"
 #define RNP_ALGNAME_X25519 "X25519"
+#endif
+#if defined(RNP_EXPERIMENTAL_PQC)
 #define RNP_ALGNAME_KYBER768_X25519 "KYBER768_X25519"
 #define RNP_ALGNAME_KYBER1024_X448 "KYBER1024_X448"
 #define RNP_ALGNAME_KYBER768_P256 "KYBER768_P256"
@@ -3432,6 +3441,7 @@ RNP_API const char *rnp_backend_version();
 #define RNP_ALGNAME_DILITHIUM5_BP384 "DILITHIUM5_BP384"
 #define RNP_ALGNAME_SPHINCSPLUS_SHA2 "SPHINCSPLUS_SHA2"
 #define RNP_ALGNAME_SPHINCSPLUS_SHAKE "SPHINCSPLUS_SHAKE"
+#endif
 #define RNP_ALGNAME_IDEA "IDEA"
 #define RNP_ALGNAME_TRIPLEDES "TRIPLEDES"
 #define RNP_ALGNAME_CAST5 "CAST5"

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1177,8 +1177,8 @@ RNP_API rnp_result_t rnp_op_generate_set_pref_keyserver(rnp_op_generate_t op,
                                                         const char *      keyserver);
 
 /** Set the generated key version to v6.
- * NOTE: This is an experimantal feature and this function can be replaced (or removed) at any
- * time.
+ *  NOTE: This is an experimantal feature and this function can be replaced (or removed) at any
+ *        time.
  *
  * @param op pointer to opaque key generation context.
  * @return RNP_SUCCESS or error code if failed.
@@ -1186,8 +1186,8 @@ RNP_API rnp_result_t rnp_op_generate_set_pref_keyserver(rnp_op_generate_t op,
 RNP_API rnp_result_t rnp_op_generate_set_v6_key(rnp_op_generate_t op);
 
 /** Set the SPHINCS+ parameter set
- * NOTE: This is an experimantal feature and this function can be replaced (or removed) at any
- * time.
+ *  NOTE: This is an experimantal feature and this function can be replaced (or removed) at any
+ *        time.
  *
  * @param op pointer to opaque key generation context.
  * @param param string, representing the SHPINCS+ parameter set.
@@ -3007,9 +3007,9 @@ RNP_API rnp_result_t rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_h
 
 /**
  * @brief Enables the creation of PKESK v6 (instead of v3) which results in the use of SEIPDv2.
- * The actually created version depends on the capabilities of the list of recipients.
- * NOTE: This is an experimental feature and this function can be replaced (or removed) at any
- * time.
+ *        The actually created version depends on the capabilities of the list of recipients.
+ *        NOTE: This is an experimental feature and this function can be replaced (or removed)
+ *        at any time.
  *
  * @param op opaque encrypting context. Must be allocated and initialized.
  * @return RNP_SUCCESS or errorcode if failed.
@@ -3030,7 +3030,8 @@ RNP_API rnp_result_t rnp_op_encrypt_add_signature(rnp_op_encrypt_t         op,
 
 /**
  * @brief Set hash function used for signature calculation. Makes sense if encrypt-and-sign is
- * used. To set hash function for each signature separately use rnp_op_sign_signature_set_hash.
+ *        used. To set hash function for each signature separately use
+ *        rnp_op_sign_signature_set_hash.
  *
  * @param op opaque encrypting context. Must be allocated and initialized.
  * @param hash hash algorithm to be used as NULL-terminated string. Following values are
@@ -3157,7 +3158,8 @@ RNP_API rnp_result_t rnp_op_encrypt_set_flags(rnp_op_encrypt_t op, uint32_t flag
  *
  * @param op opaque encrypted context. Must be allocated and initialized
  * @param filename file name as NULL-terminated string. May be empty string. Value "_CONSOLE"
- * may have specific processing (see RFC 4880 for the details), depending on implementation.
+ *                 may have specific processing (see RFC 4880 for the details), depending on
+ *                 implementation.
  * @return RNP_SUCCESS on success, or any other value on error
  */
 RNP_API rnp_result_t rnp_op_encrypt_set_file_name(rnp_op_encrypt_t op, const char *filename);
@@ -3191,7 +3193,8 @@ RNP_API rnp_result_t rnp_op_encrypt_destroy(rnp_op_encrypt_t op);
  */
 RNP_API rnp_result_t rnp_decrypt(rnp_ffi_t ffi, rnp_input_t input, rnp_output_t output);
 
-/** retrieve the raw data for a public key
+/**
+ *  @brief retrieve the raw data for a public key
  *
  *  This will always be PGP packets and will never include ASCII armor.
  *
@@ -3204,7 +3207,8 @@ RNP_API rnp_result_t rnp_get_public_key_data(rnp_key_handle_t handle,
                                              uint8_t **       buf,
                                              size_t *         buf_len);
 
-/** retrieve the raw data for a secret key
+/**
+ *  @brief retrieve the raw data for a secret key
  *
  *  If this is a G10 key, this will be the s-expr data. Otherwise, it will
  *  be PGP packets.

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -458,12 +458,24 @@ foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERF
 
 endforeach()
 
+set(EXPERIMENTAL_FEATURES "")
+if (ENABLE_CRYPTO_REFRESH)
+  set(EXPERIMENTAL_FEATURES "${EXPERIMENTAL_FEATURES}\n#define RNP_EXPERIMENTAL_CRYPTO_REFRESH\n")
+endif()
+if(ENABLE_PQC)
+  set(EXPERIMENTAL_FEATURES "${EXPERIMENTAL_FEATURES}\n#define RNP_EXPERIMENTAL_PQC\n")
+endif()
+if(NOT EXPERIMENTAL_FEATURES STREQUAL "")
+  message(WARNING "One or more experimental features are enabled. Use it on your own risk.")
+endif()
+
 generate_export_header(librnp
   BASE_NAME rnp
   EXPORT_MACRO_NAME RNP_API
   EXPORT_FILE_NAME rnp/rnp_export.h
   STATIC_DEFINE RNP_STATIC
   INCLUDE_GUARD_NAME RNP_EXPORT
+  CUSTOM_CONTENT_FROM_VARIABLE EXPERIMENTAL_FEATURES
 )
 
 # This has precedence and can cause some confusion when the binary

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -69,6 +69,13 @@
         RNP_LOG_FD(fp, __VA_ARGS__); \
     } while (0)
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH) != defined(ENABLE_CRYPTO_REFRESH)
+#error "Invalid defines combination."
+#endif
+#if defined(RNP_EXPERIMENTAL_PQC) != defined(ENABLE_PQC)
+#error "Invalid defines combination."
+#endif
+
 static pgp_key_t *get_key_require_public(rnp_key_handle_t handle);
 static pgp_key_t *get_key_prefer_public(rnp_key_handle_t handle);
 static pgp_key_t *get_key_require_secret(rnp_key_handle_t handle);
@@ -2592,21 +2599,19 @@ try {
 }
 FFI_GUARD
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
 rnp_result_t
 rnp_op_encrypt_enable_pkesk_v6(rnp_op_encrypt_t op)
 try {
-#if defined(ENABLE_CRYPTO_REFRESH)
     if (!op) {
         return RNP_ERROR_NULL_POINTER;
     }
 
     op->rnpctx.enable_pkesk_v6 = true;
     return RNP_SUCCESS;
-#else
-    return RNP_ERROR_NOT_IMPLEMENTED;
-#endif
 }
 FFI_GUARD
+#endif
 
 rnp_result_t
 rnp_op_encrypt_add_signature(rnp_op_encrypt_t         op,
@@ -5672,26 +5677,24 @@ try {
 }
 FFI_GUARD
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
 rnp_result_t
 rnp_op_generate_set_v6_key(rnp_op_generate_t op)
 try {
-#if defined(ENABLE_CRYPTO_REFRESH)
     if (!op) {
         return RNP_ERROR_NULL_POINTER;
     }
     op->pgp_version = PGP_V6;
     return RNP_SUCCESS;
-#else
-    return RNP_ERROR_NOT_IMPLEMENTED;
-#endif
 }
 FFI_GUARD
+#endif
 
+#if defined(RNP_EXPERIMENTAL_CRYPTO_PQC)
 rnp_result_t
 rnp_op_generate_set_sphincsplus_param(rnp_op_generate_t op, const char *param_cstr)
 try {
-#if defined(ENABLE_PQC)
-    if (!op) {
+    if (!op || !param_cstr) {
         return RNP_ERROR_NULL_POINTER;
     }
 
@@ -5716,11 +5719,9 @@ try {
 
     op->crypto.sphincsplus.param = param;
     return RNP_SUCCESS;
-#else
-    return RNP_ERROR_NOT_IMPLEMENTED;
-#endif
 }
 FFI_GUARD
+#endif
 
 rnp_result_t
 rnp_op_generate_execute(rnp_op_generate_t op)

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1681,7 +1681,7 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
     if (sesskey->version == PGP_PKSK_V3) {
         /* Check algorithm and key length */
         if (!pgp_is_sa_supported(sesskey->salg)) {
-            RNP_LOG("Unsupported symmetric algorithm %" PRIu8, sesskey->salg);
+            RNP_LOG("Unsupported symmetric algorithm %d", (int) sesskey->salg);
             return false;
         }
 

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1548,8 +1548,8 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
         - The payload following any v6 PKESK or v6 SKESK packet MUST be a v2 SEIPD.
         - implementations MUST NOT precede a v2 SEIPD payload with either v3 PKESK or v4
        SKESK packets. */
-    if ((param->is_v2_seipd() && !(sesskey->version == PGP_PKSK_V6)) ||
-        (param->auth_type == rnp::AuthType::MDC && !(sesskey->version == PGP_PKSK_V3))) {
+    if ((param->is_v2_seipd() && (sesskey->version != PGP_PKSK_V6)) ||
+        (param->auth_type == rnp::AuthType::MDC && (sesskey->version != PGP_PKSK_V3))) {
         RNP_LOG("Attempt to mix SEIPD v1 with PKESK v6 or SEIPD v2 with PKESK v3");
         return false;
     }


### PR DESCRIPTION
Among other minor issues this PR adds RNP_EXPERIMENTAL_* defines to the rnp_export.h header, allowing to cut-off by default yet experimental features. Probably better solution would be to remove those function calls from the header at all, however don't see good solution for that at the moment.