### PR TITLE
Fix armored stream detection and refactor pgp_source_t.

### DIFF
--- a/src/fuzzing/keyring_g10.cpp
+++ b/src/fuzzing/keyring_g10.cpp
@@ -46,7 +46,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     init_mem_src(&memsrc, data, size, false);
     ks.load_g10(memsrc);
-    src_close(&memsrc);
+    memsrc.close();
 
     return 0;
 }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2152,8 +2152,8 @@ try {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     src->param = obj;
-    src->read = input_reader_bounce;
-    src->close = input_closer_bounce;
+    src->raw_read = input_reader_bounce;
+    src->raw_close = input_closer_bounce;
     src->type = PGP_STREAM_MEMORY;
     *input = obj;
     return RNP_SUCCESS;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1640,7 +1640,7 @@ rnp_input_dearmor_if_needed(rnp_input_t input, bool noheaders = false)
         return RNP_ERROR_EOF;
     }
     /* check whether input is armored only if base64 is not forced */
-    if (!noheaders && !is_armored_source(&input->src)) {
+    if (!noheaders && !input->src.is_armored()) {
         return require_armor ? RNP_ERROR_BAD_FORMAT : RNP_SUCCESS;
     }
 
@@ -1713,7 +1713,7 @@ try {
     rnp::KeyStore tmp_store(PGP_KEY_STORE_GPG, "", ffi->context);
 
     /* check whether input is base64 */
-    if (base64 && is_base64_source(input->src)) {
+    if (base64 && input->src.is_base64()) {
         ret = rnp_input_dearmor_if_needed(input, true);
         if (ret) {
             return ret;
@@ -8409,9 +8409,9 @@ try {
     }
 
     pgp_armored_msg_t msgtype = PGP_ARMORED_UNKNOWN;
-    if (is_cleartext_source(&input->src)) {
+    if (input->src.is_cleartext()) {
         msgtype = PGP_ARMORED_CLEARTEXT;
-    } else if (is_armored_source(&input->src)) {
+    } else if (input->src.is_armored()) {
         msgtype = rnp_armored_get_type(&input->src);
     } else {
         msgtype = rnp_armor_guess_type(&input->src);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -8409,7 +8409,9 @@ try {
     }
 
     pgp_armored_msg_t msgtype = PGP_ARMORED_UNKNOWN;
-    if (is_armored_source(&input->src)) {
+    if (is_cleartext_source(&input->src)) {
+        msgtype = PGP_ARMORED_CLEARTEXT;
+    } else if (is_armored_source(&input->src)) {
         msgtype = rnp_armored_get_type(&input->src);
     } else {
         msgtype = rnp_armor_guess_type(&input->src);

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -83,7 +83,7 @@ KeyStore::load(const KeyProvider *key_provider)
             if (!load_g10(src, key_provider)) {
                 RNP_LOG("Can't parse file: %s", apath.c_str()); // TODO: %S ?
             }
-            src_close(&src);
+            src.close();
         }
         rnp_closedir(dir);
         return true;
@@ -96,7 +96,7 @@ KeyStore::load(const KeyProvider *key_provider)
     }
 
     bool rc = load(src, key_provider);
-    src_close(&src);
+    src.close();
     return rc;
 }
 

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -808,8 +808,8 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc, bool noheaders)
     param->readsrc = readsrc;
     param->noheaders = noheaders;
     src->param = param;
-    src->read = armored_src_read;
-    src->close = armored_src_close;
+    src->raw_read = armored_src_read;
+    src->raw_close = armored_src_close;
     src->type = PGP_STREAM_ARMORED;
 
     /* base64 data only */

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -565,9 +565,6 @@ armor_str_to_data_type(const char *str, size_t len)
     if (str_equals(str, len, "BEGIN PGP SIGNATURE")) {
         return PGP_ARMORED_SIGNATURE;
     }
-    if (str_equals(str, len, "BEGIN PGP SIGNED MESSAGE")) {
-        return PGP_ARMORED_CLEARTEXT;
-    }
     return PGP_ARMORED_UNKNOWN;
 }
 

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -1159,6 +1159,9 @@ is_armored_source(pgp_source_t *src)
         return false;
     }
     buf[read - 1] = 0;
+    if (!!strstr((char *) buf, ST_CLEAR_BEGIN)) {
+        return false;
+    }
     return !!strstr((char *) buf, ST_ARMOR_BEGIN);
 }
 

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -841,15 +841,12 @@ finish:
 }
 
 /** @brief Write message header to the dst. */
-static bool
+static void
 armor_write_message_header(pgp_dest_armored_param_t *param, bool finish)
 {
     const char *str = finish ? ST_ARMOR_END : ST_ARMOR_BEGIN;
     dst_write(param->writedst, str, strlen(str));
     switch (param->type) {
-    case PGP_ARMORED_MESSAGE:
-        str = "MESSAGE";
-        break;
     case PGP_ARMORED_PUBLIC_KEY:
         str = "PUBLIC KEY BLOCK";
         break;
@@ -859,15 +856,13 @@ armor_write_message_header(pgp_dest_armored_param_t *param, bool finish)
     case PGP_ARMORED_SIGNATURE:
         str = "SIGNATURE";
         break;
-    case PGP_ARMORED_CLEARTEXT:
-        str = "SIGNED MESSAGE";
-        break;
+    case PGP_ARMORED_MESSAGE:
     default:
-        return false;
+        str = "MESSAGE";
+        break;
     }
     dst_write(param->writedst, str, strlen(str));
     dst_write(param->writedst, ST_DASHES, strlen(ST_DASHES));
-    return true;
 }
 
 static void
@@ -1057,9 +1052,7 @@ armored_dst_finish(pgp_dest_t *dst)
     armor_write_eol(param);
 
     /* writing armor header */
-    if (!armor_write_message_header(param, true)) {
-        return RNP_ERROR_BAD_PARAMETERS;
-    }
+    armor_write_message_header(param, true);
     armor_write_eol(param);
     return param->writedst->werr;
 }
@@ -1113,11 +1106,7 @@ init_armored_dst(pgp_dest_t *dst, pgp_dest_t *writedst, pgp_armored_msg_t msgtyp
     param->eol[1] = CH_LF;
     param->llen = 76; /* must be multiple of 4 */
     /* armor header */
-    if (!armor_write_message_header(param, false)) {
-        RNP_LOG("unknown data type");
-        armored_dst_close(dst, true);
-        return RNP_ERROR_BAD_PARAMETERS;
-    }
+    armor_write_message_header(param, false);
     armor_write_eol(param);
     /* empty line */
     armor_write_eol(param);

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2023, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -105,12 +105,12 @@ static const uint8_t B64DEC[256] = {
   0xff};
 
 static bool
-armor_read_padding(pgp_source_armored_param_t *param, size_t *read)
+armor_read_padding(pgp_source_t &src, size_t *read)
 {
     char   st[64];
     size_t stlen = 0;
 
-    if (!src_peek_line(param->readsrc, st, 64, &stlen)) {
+    if (!src.peek_line(st, 64, &stlen)) {
         return false;
     }
 
@@ -120,8 +120,8 @@ armor_read_padding(pgp_source_armored_param_t *param, size_t *read)
         }
 
         *read = stlen;
-        src_skip(param->readsrc, stlen);
-        return src_skip_eol(param->readsrc);
+        src.skip(stlen);
+        return src.skip_eol();
     } else if (stlen == 5) {
         *read = 0;
         return true;
@@ -134,13 +134,13 @@ armor_read_padding(pgp_source_armored_param_t *param, size_t *read)
 }
 
 static bool
-base64_read_padding(pgp_source_armored_param_t *param, size_t *read)
+base64_read_padding(pgp_source_t &src, size_t *read)
 {
     char   pad[16];
     size_t padlen = sizeof(pad);
 
     /* we would allow arbitrary number of whitespaces/eols after the padding */
-    if (!src_read(param->readsrc, pad, padlen, &padlen)) {
+    if (!src.read(pad, padlen, &padlen)) {
         return false;
     }
     /* strip trailing whitespaces */
@@ -158,7 +158,7 @@ base64_read_padding(pgp_source_armored_param_t *param, size_t *read)
         RNP_LOG("wrong base64 padding length %zu.", padlen);
         return false;
     }
-    if (!src_eof(param->readsrc)) {
+    if (!src.eof()) {
         RNP_LOG("warning: extra data after the base64 stream.");
     }
     *read = padlen;
@@ -166,14 +166,13 @@ base64_read_padding(pgp_source_armored_param_t *param, size_t *read)
 }
 
 static bool
-armor_read_crc(pgp_source_t *src)
+armor_read_crc(pgp_source_armored_param_t *param)
 {
-    uint8_t                     dec[4] = {0};
-    char                        crc[8] = {0};
-    size_t                      clen = 0;
-    pgp_source_armored_param_t *param = (pgp_source_armored_param_t *) src->param;
+    uint8_t dec[4] = {0};
+    char    crc[8] = {0};
+    size_t  clen = 0;
 
-    if (!src_peek_line(param->readsrc, crc, sizeof(crc), &clen)) {
+    if (!param->readsrc->peek_line(crc, sizeof(crc), &clen)) {
         return false;
     }
 
@@ -193,19 +192,19 @@ armor_read_crc(pgp_source_t *src)
 
     param->has_crc = true;
 
-    src_skip(param->readsrc, 5);
-    return src_skip_eol(param->readsrc);
+    param->readsrc->skip(5);
+    return param->readsrc->skip_eol();
 }
 
 static bool
-armor_skip_chars(pgp_source_t *src, const char *chars)
+armor_skip_chars(pgp_source_t &src, const char *chars)
 {
     uint8_t ch;
     size_t  read;
 
     do {
         bool found = false;
-        if (!src_peek(src, &ch, 1, &read)) {
+        if (!src.peek(&ch, 1, &read)) {
             return false;
         }
         if (!read) {
@@ -214,7 +213,7 @@ armor_skip_chars(pgp_source_t *src, const char *chars)
         }
         for (const char *chptr = chars; *chptr; chptr++) {
             if (ch == *chptr) {
-                src_skip(src, 1);
+                src.skip(1);
                 found = true;
                 break;
             }
@@ -228,14 +227,13 @@ armor_skip_chars(pgp_source_t *src, const char *chars)
 }
 
 static bool
-armor_read_trailer(pgp_source_t *src)
+armor_read_trailer(pgp_source_armored_param_t *param)
 {
-    char                        st[64];
-    char                        str[64];
-    size_t                      stlen;
-    pgp_source_armored_param_t *param = (pgp_source_armored_param_t *) src->param;
+    char   st[64];
+    char   str[64];
+    size_t stlen;
 
-    if (!armor_skip_chars(param->readsrc, "\r\n")) {
+    if (!armor_skip_chars(*param->readsrc, "\r\n")) {
         return false;
     }
 
@@ -249,12 +247,12 @@ armor_read_trailer(pgp_source_t *src)
         RNP_LOG("Internal error");
         return false;
     }
-    if (!src_peek_eq(param->readsrc, str, stlen) || strncmp(str, st, stlen)) {
+    if (!param->readsrc->peek_eq(str, stlen) || strncmp(str, st, stlen)) {
         return false;
     }
-    src_skip(param->readsrc, stlen);
-    (void) armor_skip_chars(param->readsrc, "\t ");
-    (void) src_skip_eol(param->readsrc);
+    param->readsrc->skip(stlen);
+    (void) armor_skip_chars(*param->readsrc, "\t ");
+    (void) param->readsrc->skip_eol();
     return true;
 }
 
@@ -333,7 +331,7 @@ armored_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
     dend = decbuf + param->brestlen;
 
     do {
-        if (!src_peek(param->readsrc, b64buf, sizeof(b64buf), &read)) {
+        if (!param->readsrc->peek(b64buf, sizeof(b64buf), &read)) {
             return false;
         }
         if (!read) {
@@ -394,37 +392,37 @@ armored_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
         /* skip already processed data */
         if (!param->eofb64) {
             /* all input is base64 data or eol/spaces, so skipping it */
-            src_skip(param->readsrc, read);
+            param->readsrc->skip(read);
             /* check for eof for base64-encoded data without headers */
-            if (param->noheaders && src_eof(param->readsrc)) {
-                src_skip(param->readsrc, read);
+            if (param->noheaders && param->readsrc->eof()) {
+                param->readsrc->skip(read);
                 param->eofb64 = true;
             } else {
                 continue;
             }
         } else {
             /* '=' reached, bptr points on it */
-            src_skip(param->readsrc, bptr - b64buf - 1);
+            param->readsrc->skip(bptr - b64buf - 1);
         }
 
         /* end of base64 data */
         if (param->noheaders) {
-            if (!base64_read_padding(param, &eqcount)) {
+            if (!base64_read_padding(*param->readsrc, &eqcount)) {
                 return false;
             }
             break;
         }
         /* reading b64 padding if any */
-        if (!armor_read_padding(param, &eqcount)) {
+        if (!armor_read_padding(*param->readsrc, &eqcount)) {
             RNP_LOG("wrong padding");
             return false;
         }
         /* reading crc */
-        if (!armor_read_crc(src)) {
+        if (!armor_read_crc(param)) {
             RNP_LOG("Warning: missing or malformed CRC line");
         }
         /* reading armor trailing line */
-        if (!armor_read_trailer(src)) {
+        if (!armor_read_trailer(param)) {
             RNP_LOG("wrong armor trailer");
             return false;
         }
@@ -578,7 +576,7 @@ rnp_armor_guess_type(pgp_source_t *src)
 {
     uint8_t ptag;
 
-    if (!src_peek_eq(src, &ptag, 1)) {
+    if (!src->peek_eq(&ptag, 1)) {
         return PGP_ARMORED_UNKNOWN;
     }
 
@@ -616,7 +614,7 @@ rnp_armored_guess_type_by_readahead(pgp_source_t *src)
     pgp_source_t memsrc = {0};
     size_t       read;
     // peek as much as the cache can take
-    bool cache_res = src_peek(src, NULL, sizeof(src->cache->buf), &read);
+    bool cache_res = src->peek(NULL, sizeof(src->cache->buf), &read);
     if (!cache_res || !read ||
         init_mem_src(&memsrc,
                      src->cache->buf + src->cache->pos,
@@ -626,13 +624,13 @@ rnp_armored_guess_type_by_readahead(pgp_source_t *src)
     }
     rnp_result_t res = init_armored_src(&armorsrc, &memsrc);
     if (res) {
-        src_close(&memsrc);
+        memsrc.close();
         RNP_LOG("failed to parse armored data");
         return PGP_ARMORED_UNKNOWN;
     }
     pgp_armored_msg_t guessed = rnp_armor_guess_type(&armorsrc);
-    src_close(&armorsrc);
-    src_close(&memsrc);
+    armorsrc.close();
+    memsrc.close();
     return guessed;
 }
 
@@ -649,7 +647,7 @@ rnp_armored_get_type(pgp_source_t *src)
     size_t      armhdrlen;
     size_t      read;
 
-    if (!src_peek(src, hdr, sizeof(hdr), &read) || (read < 20)) {
+    if (!src->peek(hdr, sizeof(hdr), &read) || (read < 20)) {
         return PGP_ARMORED_UNKNOWN;
     }
     if (!(armhdr = find_armor_header(hdr, read, &armhdrlen))) {
@@ -660,15 +658,14 @@ rnp_armored_get_type(pgp_source_t *src)
 }
 
 static bool
-armor_parse_header(pgp_source_t *src)
+armor_parse_header(pgp_source_armored_param_t *param)
 {
-    char                        hdr[ARMORED_PEEK_BUF_SIZE];
-    const char *                armhdr;
-    size_t                      armhdrlen;
-    size_t                      read;
-    pgp_source_armored_param_t *param = (pgp_source_armored_param_t *) src->param;
+    char        hdr[ARMORED_PEEK_BUF_SIZE];
+    const char *armhdr;
+    size_t      armhdrlen;
+    size_t      read;
 
-    if (!src_peek(param->readsrc, hdr, sizeof(hdr), &read) || (read < 20)) {
+    if (!param->readsrc->peek(hdr, sizeof(hdr), &read) || (read < 20)) {
         return false;
     }
 
@@ -698,20 +695,20 @@ armor_parse_header(pgp_source_t *src)
 
     memcpy(param->armorhdr, armhdr + 5, armhdrlen - 10);
     param->armorhdr[armhdrlen - 10] = '\0';
-    src_skip(param->readsrc, armhdr - hdr + armhdrlen);
-    armor_skip_chars(param->readsrc, "\t ");
+    param->readsrc->skip(armhdr - hdr + armhdrlen);
+    armor_skip_chars(*param->readsrc, "\t ");
     return true;
 }
 
 static bool
-armor_skip_line(pgp_source_t *src)
+armor_skip_line(pgp_source_t &src)
 {
     char header[ARMORED_PEEK_BUF_SIZE] = {0};
     do {
         size_t hdrlen = 0;
-        bool   res = src_peek_line(src, header, sizeof(header), &hdrlen);
+        bool   res = src.peek_line(header, sizeof(header), &hdrlen);
         if (hdrlen) {
-            src_skip(src, hdrlen);
+            src.skip(hdrlen);
         }
         if (res || (hdrlen < sizeof(header) - 1)) {
             return res;
@@ -730,17 +727,16 @@ is_base64_line(const char *line, size_t len)
 }
 
 static bool
-armor_parse_headers(pgp_source_t *src)
+armor_parse_headers(pgp_source_armored_param_t *param)
 {
-    pgp_source_armored_param_t *param = (pgp_source_armored_param_t *) src->param;
-    char                        header[ARMORED_PEEK_BUF_SIZE] = {0};
+    char header[ARMORED_PEEK_BUF_SIZE] = {0};
 
     do {
         size_t hdrlen = 0;
-        if (!src_peek_line(param->readsrc, header, sizeof(header), &hdrlen)) {
+        if (!param->readsrc->peek_line(header, sizeof(header), &hdrlen)) {
             /* if line is too long let's cut it to the reasonable size */
-            src_skip(param->readsrc, hdrlen);
-            if ((hdrlen != sizeof(header) - 1) || !armor_skip_line(param->readsrc)) {
+            param->readsrc->skip(hdrlen);
+            if ((hdrlen != sizeof(header) - 1) || !armor_skip_line(*param->readsrc)) {
                 RNP_LOG("failed to peek line: unexpected end of data");
                 return false;
             }
@@ -751,13 +747,13 @@ armor_parse_headers(pgp_source_t *src)
                 RNP_LOG("Warning: no empty line after the base64 headers");
                 return true;
             }
-            src_skip(param->readsrc, hdrlen);
+            param->readsrc->skip(hdrlen);
             if (rnp::is_blank_line(header, hdrlen)) {
-                return src_skip_eol(param->readsrc);
+                return param->readsrc->skip_eol();
             }
         } else {
             /* empty line - end of the headers */
-            return src_skip_eol(param->readsrc);
+            return param->readsrc->skip_eol();
         }
 
         char *hdrval = (char *) malloc(hdrlen + 1);
@@ -787,7 +783,7 @@ armor_parse_headers(pgp_source_t *src)
             free(hdrval);
         }
 
-        if (!src_skip_eol(param->readsrc)) {
+        if (!param->readsrc->skip_eol()) {
             return false;
         }
     } while (1);
@@ -821,18 +817,18 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc, bool noheaders)
     param->crc_ctx = rnp::CRC24::create();
     /* parsing armored header */
     rnp_result_t errcode = RNP_ERROR_GENERIC;
-    if (!armor_parse_header(src)) {
+    if (!armor_parse_header(param)) {
         errcode = RNP_ERROR_BAD_FORMAT;
         goto finish;
     }
     /* eol */
-    if (!src_skip_eol(param->readsrc)) {
+    if (!param->readsrc->skip_eol()) {
         RNP_LOG("no eol after the armor header");
         errcode = RNP_ERROR_BAD_FORMAT;
         goto finish;
     }
     /* parsing headers */
-    if (!armor_parse_headers(src)) {
+    if (!armor_parse_headers(param)) {
         RNP_LOG("failed to parse headers");
         errcode = RNP_ERROR_BAD_FORMAT;
         goto finish;
@@ -842,7 +838,7 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc, bool noheaders)
     errcode = RNP_SUCCESS;
 finish:
     if (errcode) {
-        src_close(src);
+        src->close();
     }
     return errcode;
 }
@@ -1155,7 +1151,7 @@ pgp_source_t::is_armored()
     char   buf[ARMORED_PEEK_BUF_SIZE] = {0};
     size_t read = 0;
 
-    if (!src_peek(this, buf, sizeof(buf), &read) || (read < strlen(ST_ARMOR_BEGIN) + 1)) {
+    if (!peek(buf, sizeof(buf), &read) || (read < strlen(ST_ARMOR_BEGIN) + 1)) {
         return false;
     }
     buf[read - 1] = 0;
@@ -1171,7 +1167,7 @@ pgp_source_t::is_cleartext()
     char   buf[ARMORED_PEEK_BUF_SIZE] = {0};
     size_t read = 0;
 
-    if (!src_peek(this, buf, sizeof(buf), &read) || (read < strlen(ST_CLEAR_BEGIN))) {
+    if (!peek(buf, sizeof(buf), &read) || (read < strlen(ST_CLEAR_BEGIN))) {
         return false;
     }
     buf[read - 1] = 0;
@@ -1184,7 +1180,7 @@ pgp_source_t::is_base64()
     char   buf[128] = {0};
     size_t read = 0;
 
-    if (!src_peek(this, buf, sizeof(buf), &read) || (read < 4)) {
+    if (!peek(buf, sizeof(buf), &read) || (read < 4)) {
         return false;
     }
     return is_base64_line(buf, read);
@@ -1207,7 +1203,7 @@ rnp_dearmor_source(pgp_source_t *src, pgp_dest_t *dst)
         RNP_LOG("dearmoring failed");
     }
 
-    src_close(&armorsrc);
+    armorsrc.close();
     return res;
 }
 
@@ -1272,10 +1268,10 @@ ArmoredSource::ArmoredSource(pgp_source_t &readsrc, uint32_t flags)
 void
 ArmoredSource::restart()
 {
-    if (!armored_ || src_eof(&readsrc_) || src_error(&readsrc_)) {
+    if (!armored_ || readsrc_.eof() || readsrc_.error()) {
         return;
     }
-    src_close(&src_);
+    src_.close();
     auto res = init_armored_src(&src_, &readsrc_);
     if (res) {
         throw rnp::rnp_exception(res);

--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -1150,41 +1150,41 @@ armored_dst_set_line_length(pgp_dest_t *dst, size_t llen)
 }
 
 bool
-is_armored_source(pgp_source_t *src)
+pgp_source_t::is_armored()
 {
-    uint8_t buf[ARMORED_PEEK_BUF_SIZE];
-    size_t  read = 0;
-
-    if (!src_peek(src, buf, sizeof(buf), &read) || (read < strlen(ST_ARMOR_BEGIN) + 1)) {
-        return false;
-    }
-    buf[read - 1] = 0;
-    if (!!strstr((char *) buf, ST_CLEAR_BEGIN)) {
-        return false;
-    }
-    return !!strstr((char *) buf, ST_ARMOR_BEGIN);
-}
-
-bool
-is_cleartext_source(pgp_source_t *src)
-{
-    uint8_t buf[ARMORED_PEEK_BUF_SIZE];
-    size_t  read = 0;
-
-    if (!src_peek(src, buf, sizeof(buf), &read) || (read < strlen(ST_CLEAR_BEGIN))) {
-        return false;
-    }
-    buf[read - 1] = 0;
-    return !!strstr((char *) buf, ST_CLEAR_BEGIN);
-}
-
-bool
-is_base64_source(pgp_source_t &src)
-{
-    char   buf[128];
+    char   buf[ARMORED_PEEK_BUF_SIZE] = {0};
     size_t read = 0;
 
-    if (!src_peek(&src, buf, sizeof(buf), &read) || (read < 4)) {
+    if (!src_peek(this, buf, sizeof(buf), &read) || (read < strlen(ST_ARMOR_BEGIN) + 1)) {
+        return false;
+    }
+    buf[read - 1] = 0;
+    if (!!strstr(buf, ST_CLEAR_BEGIN)) {
+        return false;
+    }
+    return !!strstr(buf, ST_ARMOR_BEGIN);
+}
+
+bool
+pgp_source_t::is_cleartext()
+{
+    char   buf[ARMORED_PEEK_BUF_SIZE] = {0};
+    size_t read = 0;
+
+    if (!src_peek(this, buf, sizeof(buf), &read) || (read < strlen(ST_CLEAR_BEGIN))) {
+        return false;
+    }
+    buf[read - 1] = 0;
+    return !!strstr(buf, ST_CLEAR_BEGIN);
+}
+
+bool
+pgp_source_t::is_base64()
+{
+    char   buf[128] = {0};
+    size_t read = 0;
+
+    if (!src_peek(this, buf, sizeof(buf), &read) || (read < 4)) {
         return false;
     }
     return is_base64_line(buf, read);
@@ -1241,7 +1241,7 @@ ArmoredSource::ArmoredSource(pgp_source_t &readsrc, uint32_t flags)
     /* Do not dearmor already armored stream */
     bool already = readsrc_.type == PGP_STREAM_ARMORED;
     /* Check for base64 source: no multiple streams allowed */
-    if (!already && (flags & AllowBase64) && (is_base64_source(readsrc))) {
+    if (!already && (flags & AllowBase64) && (readsrc.is_base64())) {
         auto res = init_armored_src(&src_, &readsrc_, true);
         if (res) {
             RNP_LOG("Failed to parse base64 data.");
@@ -1251,7 +1251,7 @@ ArmoredSource::ArmoredSource(pgp_source_t &readsrc, uint32_t flags)
         return;
     }
     /* Check for armored source */
-    if (!already && is_armored_source(&readsrc)) {
+    if (!already && readsrc.is_armored()) {
         auto res = init_armored_src(&src_, &readsrc_);
         if (res) {
             RNP_LOG("Failed to parse armored data.");

--- a/src/librepgp/stream-armor.h
+++ b/src/librepgp/stream-armor.h
@@ -85,29 +85,11 @@ pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src);
  **/
 pgp_armored_msg_t rnp_armored_get_type(pgp_source_t *src);
 
-/* @brief Check whether source could be an armored source
- * @param src initialized source with some data
- * @return true if source could be an armored data or false otherwise
- **/
-bool is_armored_source(pgp_source_t *src);
-
 /* @brief Check whether destination is armored
  * @param dest initialized destination
  * @return true if destination is armored or false otherwise
  **/
 bool is_armored_dest(pgp_dest_t *dst);
-
-/* @brief Check whether source is cleartext signed
- * @param src initialized source with some data
- * @return true if source could be a cleartext signed data or false otherwise
- **/
-bool is_cleartext_source(pgp_source_t *src);
-
-/** @brief Check whether source is base64-encoded
- *  @param src initialized source with some data
- *  @return true if source could be a base64-encoded data or false otherwise
- **/
-bool is_base64_source(pgp_source_t &src);
 
 /** Set line length for armoring
  *

--- a/src/librepgp/stream-common.cpp
+++ b/src/librepgp/stream-common.cpp
@@ -137,22 +137,10 @@ finish:
 }
 
 bool
-src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
-{
-    return src->read(buf, len, readres);
-}
-
-bool
 pgp_source_t::read_eq(void *buf, size_t len)
 {
     size_t res = 0;
     return read(buf, len, &res) && (res == len);
-}
-
-bool
-src_read_eq(pgp_source_t *src, void *buf, size_t len)
-{
-    return src->read_eq(buf, len);
 }
 
 bool
@@ -220,22 +208,10 @@ pgp_source_t::peek(void *buf, size_t len, size_t *peeked)
 }
 
 bool
-src_peek(pgp_source_t *src, void *buf, size_t len, size_t *peeked)
-{
-    return src->peek(buf, len, peeked);
-}
-
-bool
 pgp_source_t::peek_eq(void *buf, size_t len)
 {
     size_t res = 0;
     return peek(buf, len, &res) && (res == len);
-}
-
-bool
-src_peek_eq(pgp_source_t *src, void *buf, size_t len)
-{
-    return src->peek_eq(buf, len);
 }
 
 void
@@ -272,34 +248,16 @@ pgp_source_t::skip(size_t len)
     free(buf);
 }
 
-void
-src_skip(pgp_source_t *src, size_t len)
-{
-    src->skip(len);
-}
-
 rnp_result_t
 pgp_source_t::finish()
 {
     return raw_finish ? raw_finish(this) : RNP_SUCCESS;
 }
 
-rnp_result_t
-src_finish(pgp_source_t *src)
-{
-    return src->finish();
-}
-
 bool
 pgp_source_t::error() const
 {
     return error_;
-}
-
-bool
-src_error(const pgp_source_t *src)
-{
-    return src->error();
 }
 
 bool
@@ -314,12 +272,6 @@ pgp_source_t::eof()
     return peek(&check, 1, &read) && (read == 0);
 }
 
-bool
-src_eof(pgp_source_t *src)
-{
-    return src->eof();
-}
-
 void
 pgp_source_t::close()
 {
@@ -331,12 +283,6 @@ pgp_source_t::close()
         free(cache);
         cache = NULL;
     }
-}
-
-void
-src_close(pgp_source_t *src)
-{
-    src->close();
 }
 
 bool
@@ -357,12 +303,6 @@ pgp_source_t::skip_eol()
         return true;
     }
     return false;
-}
-
-bool
-src_skip_eol(pgp_source_t *src)
-{
-    return src->skip_eol();
 }
 
 bool
@@ -398,12 +338,6 @@ pgp_source_t::peek_line(char *buf, size_t len, size_t *readres)
         }
     } while (scan_pos < len);
     return false;
-}
-
-bool
-src_peek_line(pgp_source_t *src, char *buf, size_t len, size_t *readres)
-{
-    return src->peek_line(buf, len, readres);
 }
 
 bool

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -73,9 +73,10 @@ typedef struct pgp_source_cache_t {
 } pgp_source_cache_t;
 
 typedef struct pgp_source_t {
-    pgp_source_read_func_t *  read;
-    pgp_source_finish_func_t *finish;
-    pgp_source_close_func_t * close;
+    pgp_source_read_func_t *raw_read; /* Raw read/finish/close function. To be later refactored
+                                         to virtual rnp::Source::raw_read()/finish()/close() */
+    pgp_source_finish_func_t *raw_finish;
+    pgp_source_close_func_t * raw_close;
     pgp_stream_type_t         type;
 
     uint64_t size;  /* size of the data if available, see knownsize */

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2017-2020,2023 [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -85,23 +85,103 @@ typedef struct pgp_source_t {
     pgp_source_cache_t *cache; /* cache if used */
     void *              param; /* source-specific additional data */
 
-    unsigned eof : 1;       /* end of data as reported by read and empty cache */
-    unsigned knownsize : 1; /* whether size of the data is known */
-    unsigned error : 1;     /* there were reading error */
+    bool eof_;      /* end of data as reported by read and empty cache */
+    bool knownsize; /* whether size of the data is known */
+    bool error_;    /* there were reading error */
+
+    /** @brief read up to len bytes from the source
+     *  While this function tries to read as much bytes as possible however it may return
+     *  less then len bytes. Then src->eof can be checked if it's end of data.
+     *
+     *  @param buf preallocated buffer which can store up to len bytes
+     *  @param len number of bytes to read
+     *  @param read number of read bytes will be stored here. Cannot be NULL.
+     *  @return true on success or false otherwise
+     */
+    bool read(void *buf, size_t len, size_t *read);
+
+    /** @brief shortcut to read exactly len bytes from source. See read() for parameters.
+     *  @return true if len bytes were read or false otherwise (i.e. less then len were read or
+     *          read error occurred)
+     */
+    bool read_eq(void *buf, size_t len);
+
+    /** @brief read up to len bytes and keep them in the cache/do not process
+     *         Works only for streams with cache
+     *  @param buf preallocated buffer which can store up to len bytes, or NULL if data should
+     *             be discarded, just making sure that needed input is available in source
+     *  @param len number of bytes to read. Must be less then PGP_INPUT_CACHE_SIZE.
+     *  @param read number of bytes read will be stored here. Cannot be NULL.
+     *  @return true on success or false otherwise
+     */
+    bool peek(void *buf, size_t len, size_t *read);
+
+    /** @brief shortcut to read exactly len bytes and keep them in the cache/do not process
+     *         Works only for streams with cache
+     *  @return true if len bytes were read or false otherwise (i.e. less then len were read or
+     *          read error occurred)
+     */
+    bool peek_eq(void *buf, size_t len);
+
+    /** @brief skip up to len bytes.
+     *         Note: use read() if you want to check error condition/get number of bytes
+     * skipped.
+     *  @param len number of bytes to skip
+     */
+    void skip(size_t len);
+
+    /** @brief notify source that all reading is done, so final data processing may be started,
+     *         i.e. signature reading and verification and so on. Do not misuse with close().
+     *  @return RNP_SUCCESS or error code. If source doesn't have finish handler then also
+     *          RNP_SUCCESS is returned
+     */
+    rnp_result_t finish();
+
+    /** @brief check whether there were reading error on source
+     *  @return true if there were reading error or false otherwise
+     */
+    bool error() const;
+
+    /** @brief check whether there is no more input on source
+     *  @return true if there is no more input or false otherwise.
+     *          On read error false will be returned.
+     */
+    bool eof();
+
+    /** @brief close the source and deallocate all internal resources if any
+     */
+    void close();
+
+    /** @brief skip end of line on the source (\r\n or \n, depending on input)
+     *  @return true if eol was found and skipped or false otherwise
+     */
+    bool skip_eol();
+
+    /** @brief peek the line on the source
+     *  @param buf preallocated buffer to store the result. Result include NULL character and
+     *             doesn't include the end of line sequence.
+     *  @param len maximum length of data to store in buf, including terminating NULL
+     *  @param read on success here will be stored number of bytes in the string, without the
+     *              NULL character.
+     *  @return true on success
+     *          false is returned if there were eof, read error or eol was not found within the
+     *          len. Supported eol sequences are \r\n and \n
+     */
+    bool peek_line(char *buf, size_t len, size_t *read);
 
     /** @brief Check whether source could be an armored source
      *  @return true if source could be an armored data or false otherwise
-     **/
+     */
     bool is_armored();
 
     /** @brief Check whether source is cleartext signed
      *  @return true if source could be a cleartext signed data or false otherwise
-     **/
+     */
     bool is_cleartext();
 
     /** @brief Check whether source is base64-encoded
      *  @return true if source could be a base64-encoded data or false otherwise
-     **/
+     */
     bool is_base64();
 } pgp_source_t;
 
@@ -113,90 +193,37 @@ typedef struct pgp_source_t {
  **/
 bool init_src_common(pgp_source_t *src, size_t paramsize);
 
-/** @brief read up to len bytes from the source
- *  While this function tries to read as much bytes as possible however it may return
- *  less then len bytes. Then src->eof can be checked if it's end of data.
- *
- *  @param src source structure
- *  @param buf preallocated buffer which can store up to len bytes
- *  @param len number of bytes to read
- *  @param read number of read bytes will be stored here. Cannot be NULL.
- *  @return true on success or false otherwise
- **/
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_read(pgp_source_t *src, void *buf, size_t len, size_t *read);
 
-/** @brief shortcut to read exactly len bytes from source. See src_read for parameters.
- *  @return true if len bytes were read or false otherwise (i.e. less then len were read or
- *          read error occurred) */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_read_eq(pgp_source_t *src, void *buf, size_t len);
 
-/** @brief read up to len bytes and keep them in the cache/do not process
- *  Works only for streams with cache
- *  @param src source structure
- *  @param buf preallocated buffer which can store up to len bytes, or NULL if data should be
- *             discarded, just making sure that needed input is available in source
- *  @param len number of bytes to read. Must be less then PGP_INPUT_CACHE_SIZE.
- *  @param read number of bytes read will be stored here. Cannot be NULL.
- *  @return true on success or false otherwise
- **/
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_peek(pgp_source_t *src, void *buf, size_t len, size_t *read);
 
-/** @brief shortcut to read exactly len bytes and keep them in the cache/do not process
- *         Works only for streams with cache
- *  @return true if len bytes were read or false otherwise (i.e. less then len were read or
- *          read error occurred) */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_peek_eq(pgp_source_t *src, void *buf, size_t len);
 
-/** @brief skip up to len bytes.
- *         Note: use src_read() if you want to check error condition/get number of bytes
- *skipped.
- *  @param src source structure
- *  @param len number of bytes to skip
- **/
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 void src_skip(pgp_source_t *src, size_t len);
 
-/** @brief notify source that all reading is done, so final data processing may be started,
- * i.e. signature reading and verification and so on. Do not misuse with src_close.
- *  @param src allocated and initialized source structure
- *  @return RNP_SUCCESS or error code. If source doesn't have finish handler then also
- * RNP_SUCCESS is returned
- */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 rnp_result_t src_finish(pgp_source_t *src);
 
-/** @brief check whether there were reading error on source
- *  @param allocated and initialized source structure
- *  @return true if there were reading error or false otherwise
- */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_error(const pgp_source_t *src);
 
-/** @brief check whether there is no more input on source
- *  @param src allocated and initialized source structure
- *  @return true if there is no more input or false otherwise.
- *          On read error false will be returned.
- */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_eof(pgp_source_t *src);
 
-/** @brief close the source and deallocate all internal resources if any
- */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 void src_close(pgp_source_t *src);
 
-/** @brief skip end of line on the source (\r\n or \n, depending on input)
- *  @param src allocated and initialized source
- *  @return true if eol was found and skipped or false otherwise
- */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_skip_eol(pgp_source_t *src);
 
-/** @brief peek the line on the source
- *  @param src allocated and initialized source with data
- *  @param buf preallocated buffer to store the result. Result include NULL character and
- *             doesn't include the end of line sequence.
- *  @param len maximum length of data to store in buf, including terminating NULL
- *  @param read on success here will be stored number of bytes in the string, without the NULL
- * character.
- *  @return true on success
- *          false is returned if there were eof, read error or eol was not found within the
- * len. Supported eol sequences are \r\n and \n
- */
+/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
 bool src_peek_line(pgp_source_t *src, char *buf, size_t len, size_t *read);
 
 /** @brief init file source
@@ -406,7 +433,7 @@ class Source {
 
     virtual ~Source()
     {
-        src_close(&src_);
+        src_.close();
     }
 
     virtual pgp_source_t &
@@ -430,13 +457,13 @@ class Source {
     bool
     eof()
     {
-        return src_eof(&src());
+        return src().eof();
     }
 
     bool
     error()
     {
-        return src_error(&src());
+        return src().error();
     }
 };
 

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -193,39 +193,6 @@ typedef struct pgp_source_t {
  **/
 bool init_src_common(pgp_source_t *src, size_t paramsize);
 
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_read(pgp_source_t *src, void *buf, size_t len, size_t *read);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_read_eq(pgp_source_t *src, void *buf, size_t len);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_peek(pgp_source_t *src, void *buf, size_t len, size_t *read);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_peek_eq(pgp_source_t *src, void *buf, size_t len);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-void src_skip(pgp_source_t *src, size_t len);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-rnp_result_t src_finish(pgp_source_t *src);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_error(const pgp_source_t *src);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_eof(pgp_source_t *src);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-void src_close(pgp_source_t *src);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_skip_eol(pgp_source_t *src);
-
-/** @brief To be removed once codebase is refactored to use pgp_source_t methods. */
-bool src_peek_line(pgp_source_t *src, char *buf, size_t len, size_t *read);
-
 /** @brief init file source
  *  @param src pre-allocated source structure
  *  @param path path to the file

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -87,6 +87,21 @@ typedef struct pgp_source_t {
     unsigned eof : 1;       /* end of data as reported by read and empty cache */
     unsigned knownsize : 1; /* whether size of the data is known */
     unsigned error : 1;     /* there were reading error */
+
+    /** @brief Check whether source could be an armored source
+     *  @return true if source could be an armored data or false otherwise
+     **/
+    bool is_armored();
+
+    /** @brief Check whether source is cleartext signed
+     *  @return true if source could be a cleartext signed data or false otherwise
+     **/
+    bool is_cleartext();
+
+    /** @brief Check whether source is base64-encoded
+     *  @return true if source could be a base64-encoded data or false otherwise
+     **/
+    bool is_base64();
 } pgp_source_t;
 
 /** @brief helper function to allocate memory for source's cache and param

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1558,7 +1558,7 @@ stream_dump_packets(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
     ctx->stream_pkts = 0;
     ctx->failures = 0;
     /* check whether source is cleartext - then skip till the signature */
-    if (is_cleartext_source(src)) {
+    if (src->is_cleartext()) {
         dst_printf(dst, ":cleartext signed data\n");
         if (!stream_skip_cleartext(src)) {
             RNP_LOG("malformed cleartext signed data");
@@ -1572,7 +1572,7 @@ stream_dump_packets(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
     bool         armored = false;
     bool         indent = false;
     rnp_result_t ret = RNP_ERROR_GENERIC;
-    if (is_armored_source(src)) {
+    if (src->is_armored()) {
         if ((ret = init_armored_src(&armorsrc, src))) {
             RNP_LOG("failed to parse armored data");
             return ret;
@@ -2658,14 +2658,14 @@ stream_dump_packets_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object **j
     ctx->stream_pkts = 0;
     ctx->failures = 0;
     /* check whether source is cleartext - then skip till the signature */
-    if (is_cleartext_source(src)) {
+    if (src->is_cleartext()) {
         if (!stream_skip_cleartext(src)) {
             RNP_LOG("malformed cleartext signed data");
             return RNP_ERROR_BAD_FORMAT;
         }
     }
     /* check whether source is armored */
-    if (is_armored_source(src)) {
+    if (src->is_armored()) {
         if ((ret = init_armored_src(&armorsrc, src))) {
             RNP_LOG("failed to parse armored data");
             return ret;

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -276,7 +276,7 @@ size_t get_partial_pkt_len(uint8_t blen);
  *  @param pktlen packet length will be stored here on success. Cannot be NULL.
  *  @return true on success or false if there is read error or packet length is ill-formed
  **/
-bool stream_read_pkt_len(pgp_source_t *src, size_t *pktlen);
+bool stream_read_pkt_len(pgp_source_t &src, size_t *pktlen);
 
 /** @brief Read partial packet chunk length.
  *

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -2555,7 +2555,7 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
     }
     src->param = param;
 
-    cleartext = is_cleartext_source(readsrc);
+    cleartext = readsrc->is_cleartext();
     param->readsrc = readsrc;
     param->handler = handler;
     param->cleartext = cleartext;
@@ -2854,10 +2854,10 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t &src)
         res = init_packet_sequence(ctx, src);
     } else {
         /* Trying armored or cleartext data */
-        if (is_cleartext_source(&src)) {
+        if (src.is_cleartext()) {
             /* Initializing cleartext message */
             res = init_cleartext_sequence(ctx, src);
-        } else if (is_armored_source(&src)) {
+        } else if (src.is_armored()) {
             /* Initializing armored message */
             res = init_armored_sequence(ctx, src);
         } else {

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -307,8 +307,8 @@ init_partial_pkt_src(pgp_source_t *src, pgp_source_t *readsrc, pgp_packet_hdr_t 
     param->last = false;
     param->readsrc = readsrc;
 
-    src->read = partial_pkt_src_read;
-    src->close = partial_pkt_src_close;
+    src->raw_read = partial_pkt_src_read;
+    src->raw_close = partial_pkt_src_close;
     src->type = PGP_STREAM_PARLEN_PACKET;
 
     if (param->psize < PGP_PARTIAL_PKT_FIRST_PART_MIN_SIZE) {
@@ -1931,8 +1931,8 @@ init_literal_src(pgp_source_t *src, pgp_source_t *readsrc)
 
     param = (pgp_source_literal_param_t *) src->param;
     param->pkt.readsrc = readsrc;
-    src->read = literal_src_read;
-    src->close = literal_src_close;
+    src->raw_read = literal_src_read;
+    src->raw_close = literal_src_close;
     src->type = PGP_STREAM_LITERAL;
 
     /* Reading packet length/checking whether it is partial */
@@ -2028,8 +2028,8 @@ init_compressed_src(pgp_source_t *src, pgp_source_t *readsrc)
 
     param = (pgp_source_compressed_param_t *) src->param;
     param->pkt.readsrc = readsrc;
-    src->read = compressed_src_read;
-    src->close = compressed_src_close;
+    src->raw_read = compressed_src_read;
+    src->raw_close = compressed_src_close;
     src->type = PGP_STREAM_COMPRESSED;
 
     /* Reading packet length/checking whether it is partial */
@@ -2349,8 +2349,8 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
     param->pkt.readsrc = readsrc;
     param->handler = handler;
 
-    src->close = encrypted_src_close;
-    src->finish = encrypted_src_finish;
+    src->raw_close = encrypted_src_close;
+    src->raw_finish = encrypted_src_finish;
     src->type = PGP_STREAM_ENCRYPTED;
 
     /* Read the packet-related information */
@@ -2359,13 +2359,13 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
         goto finish;
     }
 
-    src->read = (!param->use_cfb()
+    src->raw_read = (!param->use_cfb()
 #ifdef ENABLE_CRYPTO_REFRESH
-                 || param->is_v2_seipd()
+                     || param->is_v2_seipd()
 #endif
-                   ) ?
-                  encrypted_src_read_aead :
-                  encrypted_src_read_cfb;
+                       ) ?
+                      encrypted_src_read_aead :
+                      encrypted_src_read_cfb;
 
     /* Obtaining the symmetric key */
     if (!handler->password_provider) {
@@ -2560,9 +2560,9 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
     param->handler = handler;
     param->cleartext = cleartext;
     param->stripped_crs = 0;
-    src->read = cleartext ? cleartext_src_read : signed_src_read;
-    src->close = signed_src_close;
-    src->finish = signed_src_finish;
+    src->raw_read = cleartext ? cleartext_src_read : signed_src_read;
+    src->raw_close = signed_src_close;
+    src->raw_finish = signed_src_finish;
     src->type = cleartext ? PGP_STREAM_CLEARTEXT : PGP_STREAM_SIGNED;
 
     /* we need key provider to validate signatures */

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -228,7 +228,7 @@ is_pgp_source(pgp_source_t &src)
 static bool
 partial_pkt_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
-    if (src->eof) {
+    if (src->eof_) {
         *readres = 0;
         return true;
     }
@@ -354,7 +354,7 @@ compressed_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
         return false;
     }
 
-    if (src->eof || param->zend) {
+    if (src->eof_ || param->zend) {
         *readres = 0;
         return true;
     }
@@ -709,7 +709,7 @@ encrypted_src_read_cfb(pgp_source_t *src, void *buf, size_t len, size_t *readres
         return false;
     }
 
-    if (src->eof) {
+    if (src->eof_) {
         *readres = 0;
         return true;
     }
@@ -2890,7 +2890,7 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t &src)
             goto finish;
         }
 
-        while (!datasrc.eof) {
+        while (!datasrc.eof_) {
             size_t read = 0;
             if (!src_read(&datasrc, readbuf, PGP_INPUT_CACHE_SIZE, &read)) {
                 res = RNP_ERROR_GENERIC;
@@ -2925,7 +2925,7 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t &src)
         }
 
         /* reading the input */
-        while (!decsrc->eof) {
+        while (!decsrc->eof_) {
             size_t read = 0;
             if (!src_read(decsrc, readbuf, PGP_INPUT_CACHE_SIZE, &read)) {
                 res = RNP_ERROR_GENERIC;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1151,7 +1151,7 @@ pgp_signature_t::set_embedded_sig(const pgp_signature_t &esig)
     pgp_rawpacket_t   esigpkt(esig);
     rnp::MemorySource mem(esigpkt.raw);
     size_t            len = 0;
-    stream_read_pkt_len(&mem.src(), &len);
+    stream_read_pkt_len(mem.src(), &len);
     if (!len || (len > 0xffff) || (len >= esigpkt.raw.size())) {
         RNP_LOG("wrong pkt len");
         throw rnp::rnp_exception(RNP_ERROR_BAD_STATE);

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1924,7 +1924,7 @@ process_stream_sequence(pgp_source_t *src,
     /* processing source stream */
     while (!src->eof_) {
         size_t read = 0;
-        if (!src_read(src, readbuf.get(), PGP_INPUT_CACHE_SIZE, &read)) {
+        if (!src->read(readbuf.get(), PGP_INPUT_CACHE_SIZE, &read)) {
             RNP_LOG("failed to read from source");
             return RNP_ERROR_READ;
         } else if (!read) {

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1922,7 +1922,7 @@ process_stream_sequence(pgp_source_t *src,
     }
 
     /* processing source stream */
-    while (!src->eof) {
+    while (!src->eof_) {
         size_t read = 0;
         if (!src_read(src, readbuf.get(), PGP_INPUT_CACHE_SIZE, &read)) {
             RNP_LOG("failed to read from source");

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -794,7 +794,7 @@ read_key_pkt(pgp_key_pkt_t *key, const char *path)
         return false;
     }
     bool res = !key->parse(src);
-    src_close(&src);
+    src.close();
     return res;
 }
 

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -773,7 +773,7 @@ TEST_F(rnp_tests, test_cli_rnpkeys_genkey)
     assert_rnp_success(init_file_src(&src, GENKEYS "/pubring.gpg"));
     assert_true(keystore->load(src));
     assert_int_equal(keystore->key_count(), 34);
-    src_close(&src);
+    src.close();
     assert_int_equal(key_expiration_check(keystore, "expiration_max_32bit@rnp", 4294967295),
                      1);
     assert_int_equal(key_expiration_check(keystore, "expiration_max_32bit_h@rnp", 4294965600),

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2224,6 +2224,18 @@ class Misc(unittest.TestCase):
         remove_files(dec)
         self.assertEqual(ret, 0)
         self.assertRegex(err, R_CRC)
+        # 1-byte message
+        ret, out, _ = run_proc(RNP, ['--enarmor'], '1')
+        self.assertEqual(ret, 0)
+        self.assertRegex(out, r'(?s)^.*BEGIN PGP MESSAGE.*MQ==.*=LrpI.*')
+        ret, out, _ = run_proc(RNP, ['--dearmor'], out)
+        self.assertEqual(ret, 0)
+        self.assertRegex(out, r'(?s)^.*1.*')
+        # Charset and other headers
+        ret, _, err = run_proc(RNP, ['--dearmor', data_path('test_stream_armor/misc_headers.asc'), '--output', dec], out)
+        self.assertEqual(ret, 0)
+        self.assertRegex(err, r'(?s)^.*unknown header \'Unknown: Unknown\'.*')
+        remove_files(dec)
 
     def test_rnpkeys_lists(self):
         KEYRING_1 = data_path(KEYRING_DIR_1)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4023,6 +4023,17 @@ class Misc(unittest.TestCase):
         clear_workfiles()
         shutil.rmtree(RNP2, ignore_errors=True)
 
+    def test_armored_detection_on_cleartext(self):
+        ret, out, err = run_proc(RNP, ['--keyfile', data_path(SECRING_1), '--password', PASSWORD, '--clearsign'], 'Hello\n')
+        self.assertEqual(ret, 0)
+        self.assertRegex(out, r'(?s)^.*BEGIN PGP SIGNED MESSAGE.*$')
+        self.assertRegex(out, r'(?s)^.*BEGIN PGP SIGNATURE.*$')
+        ret, _, err = run_proc(RNP, ['--keyfile', data_path(PUBRING_1), '--verify', '-'], out)
+        self.assertEqual(ret, 0)
+        self.assertRegex(err, r'(?s)^.*Good signature made.*$')
+        self.assertNotRegex(err, r'(?s)^.*Warning: missing or malformed CRC line.*$')
+        self.assertNotRegex(err, r'(?s)^.*wrong armor trailer.*$')
+
 class Encryption(unittest.TestCase):
     '''
         Things to try later:

--- a/src/tests/data/test_key_validity/case5/generate.cpp
+++ b/src/tests/data/test_key_validity/case5/generate.cpp
@@ -37,7 +37,7 @@ load_transferable_key(pgp_transferable_key_t *key, const char *fname)
 {
     pgp_source_t src = {};
     bool         res = !init_file_src(&src, fname) && !process_pgp_key(src, key, false);
-    src_close(&src);
+    src.close();
     return res;
 }
 

--- a/src/tests/data/test_stream_armor/misc_headers.asc
+++ b/src/tests/data/test_stream_armor/misc_headers.asc
@@ -1,0 +1,19 @@
+-----BEGIN PGP MESSAGE-----
+Charset: UTF-8
+Charset: UTF-16
+Version: Unknown
+Version: Known
+Comment: 
+Comment: Large comment
+Unknown: Unknown
+Hash: SHA1, SHA256
+Charset: Something
+Version: 1.0
+
+
+yLIBAAMA/P/IsgEADQDy/wADAPz/yLIBAA0A8v+CcKAcAAAFAPr/gnCgHAAABQD6/wAFAPr/ABQA
+6/+CcKAcAAAFAPr/AAUA+v8AFADr/0KIIcQAABQA6/9CiCHEAAAUAOv/QoghxAAAFADr/0KIIcQA
+ABQA6/9CiCHEAAAAAP//AAAA//8ACgD1/0KIIcQAAAAA//8AAAD//wAKAPX/ArPALEAAAAD//wKz
+wCxAAAAA//8A
+=ZXuW
+-----END PGP MESSAGE-----

--- a/src/tests/ffi-key-sig.cpp
+++ b/src/tests/ffi-key-sig.cpp
@@ -575,7 +575,7 @@ TEST_F(rnp_tests, test_ffi_export_revocation)
     assert_rnp_success(init_file_src(&src, "alice-revocation.pgp"));
     pgp_signature_t sig = {};
     assert_rnp_success(sig.parse(src));
-    src_close(&src);
+    src.close();
     assert_int_equal(sig.type(), PGP_SIG_REV_KEY);
     assert_true(sig.has_subpkt(PGP_SIG_SUBPKT_REVOCATION_REASON));
     assert_true(sig.has_keyfp());

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -760,7 +760,7 @@ file_equals(const char *filename, const void *data, size_t len)
     }
 
     res = (msrc.size == len) && !memcmp(mem_src_get_memory(&msrc), data, len);
-    src_close(&msrc);
+    msrc.close();
     return res;
 }
 
@@ -911,8 +911,8 @@ test_ffi_check_recovered()
     res = (msrc1.size == msrc2.size) &&
           !memcmp(mem_src_get_memory(&msrc1), mem_src_get_memory(&msrc2), msrc1.size);
 finish:
-    src_close(&msrc1);
-    src_close(&msrc2);
+    msrc1.close();
+    msrc2.close();
     return res;
 }
 

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -3393,6 +3393,20 @@ TEST_F(rnp_tests, test_ffi_rnp_guess_contents)
     assert_string_equal(msgt, "unknown");
     rnp_buffer_destroy(msgt);
     rnp_input_destroy(input);
+
+    const char *msg1 = "-----BEGIN PGP PGP";
+    assert_rnp_success(rnp_input_from_memory(&input, (uint8_t *) msg1, strlen(msg1), false));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_string_equal(msgt, "unknown");
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
+
+    const char *msg2 = "-----BEGIN PGP PGP PGP PGP PGP PGP PGP";
+    assert_rnp_success(rnp_input_from_memory(&input, (uint8_t *) msg2, strlen(msg2), false));
+    assert_rnp_success(rnp_guess_contents(input, &msgt));
+    assert_string_equal(msgt, "unknown");
+    rnp_buffer_destroy(msgt);
+    rnp_input_destroy(input);
 }
 
 TEST_F(rnp_tests, test_ffi_literal_filename)

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -48,7 +48,7 @@ TEST_F(rnp_tests, test_key_add_userid)
 
     assert_rnp_success(init_file_src(&src, "data/keyrings/1/secring.gpg"));
     assert_rnp_success(ks->load_pgp(src));
-    src_close(&src);
+    src.close();
 
     // locate our key
     assert_non_null(key = rnp_tests_get_key_by_id(ks, keyids[0]));
@@ -161,7 +161,7 @@ TEST_F(rnp_tests, test_key_add_userid)
     // read from the saved packets
     assert_rnp_success(init_mem_src(&src, mem_dest_get_memory(&dst), dst.writeb, false));
     assert_rnp_success(ks->load_pgp(src));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
     assert_non_null(key = rnp_tests_get_key_by_id(ks, keyids[0]));
 

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -52,7 +52,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
         assert_rnp_success(init_file_src(&src, "data/keyrings/1/secring.gpg"));
         assert_rnp_success(ks->load_pgp(src));
-        src_close(&src);
+        src.close();
 
         for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
             pgp_key_t *key = NULL;
@@ -129,7 +129,7 @@ TEST_F(rnp_tests, test_key_protect_load_pgp)
 
         assert_rnp_success(init_mem_src(&memsrc, pkt.raw.data(), pkt.raw.size(), false));
         assert_rnp_success(ks->load_pgp(memsrc));
-        src_close(&memsrc);
+        memsrc.close();
 
         // grab the first key
         pgp_key_t *reloaded_key = NULL;
@@ -302,7 +302,7 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_rnp_success(
       init_mem_src(&memsrc, skey.rawpkt().raw.data(), skey.rawpkt().raw.size(), false));
     assert_rnp_success(skeypkt->parse(memsrc));
-    src_close(&memsrc);
+    memsrc.close();
     assert_int_not_equal(memcmp(raw_skey, skeypkt->sec_data, 32), 0);
     assert_int_equal(skeypkt->sec_protection.s2k.specifier, PGP_S2KS_ITERATED_AND_SALTED);
     delete skeypkt;
@@ -310,7 +310,7 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_rnp_success(
       init_mem_src(&memsrc, ssub.rawpkt().raw.data(), ssub.rawpkt().raw.size(), false));
     assert_rnp_success(ssubpkt->parse(memsrc));
-    src_close(&memsrc);
+    memsrc.close();
     assert_int_not_equal(memcmp(raw_ssub, ssubpkt->sec_data, 32), 0);
     assert_int_equal(ssubpkt->sec_protection.s2k.specifier, PGP_S2KS_ITERATED_AND_SALTED);
     delete ssubpkt;
@@ -342,7 +342,7 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_rnp_success(
       init_mem_src(&memsrc, skey.rawpkt().raw.data(), skey.rawpkt().raw.size(), false));
     assert_rnp_success(skeypkt->parse(memsrc));
-    src_close(&memsrc);
+    memsrc.close();
     assert_int_not_equal(memcmp(raw_skey, skeypkt->sec_data, 32), 0);
     assert_int_equal(skeypkt->sec_protection.s2k.specifier, PGP_S2KS_ITERATED_AND_SALTED);
     delete skeypkt;
@@ -350,7 +350,7 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     assert_rnp_success(
       init_mem_src(&memsrc, ssub.rawpkt().raw.data(), ssub.rawpkt().raw.size(), false));
     assert_rnp_success(ssubpkt->parse(memsrc));
-    src_close(&memsrc);
+    memsrc.close();
     assert_int_not_equal(memcmp(raw_ssub, ssubpkt->sec_data, 32), 0);
     assert_int_equal(ssubpkt->sec_protection.s2k.specifier, PGP_S2KS_ITERATED_AND_SALTED);
     delete ssubpkt;

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -151,7 +151,7 @@ key_store_add(rnp::KeyStore *keyring, const char *keypath)
     assert_rnp_success(init_file_src(&keysrc, keypath));
     assert_rnp_success(process_pgp_key(keysrc, tkey, false));
     assert_true(keyring->add_ts_key(tkey));
-    src_close(&keysrc);
+    keysrc.close();
 }
 
 static bool

--- a/src/tests/large-mpi.cpp
+++ b/src/tests/large-mpi.cpp
@@ -41,7 +41,7 @@ TEST_F(rnp_tests, test_large_mpi_rsa_pub)
     assert_rnp_success(init_file_src(&keysrc, "data/test_large_MPIs/rsa-pub-65535bits.pgp"));
     assert_rnp_failure(process_pgp_keys(keysrc, keyseq, false));
     assert_true(keyseq.keys.empty());
-    src_close(&keysrc);
+    keysrc.close();
 
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
     assert_rnp_success(

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -44,7 +44,7 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
     // load pubring in to the key store
     assert_rnp_success(init_file_src(&src, "data/keyrings/2/pubring.gpg"));
     assert_rnp_success(key_store->load_pgp(src));
-    src_close(&src);
+    src.close();
     assert_int_equal(1, key_store->key_count());
 
     // find the key by keyid
@@ -66,7 +66,7 @@ TEST_F(rnp_tests, test_load_v3_keyring_pgp)
 
     assert_rnp_success(init_file_src(&src, "data/keyrings/4/secring.pgp"));
     assert_rnp_success(key_store->load_pgp(src));
-    src_close(&src);
+    src.close();
     assert_int_equal(1, key_store->key_count());
 
     key = rnp_tests_get_key_by_id(key_store, "7D0BC10E933404C9");
@@ -106,7 +106,7 @@ TEST_F(rnp_tests, test_load_v4_keyring_pgp)
     // load it in to the key store
     assert_rnp_success(init_file_src(&src, "data/keyrings/1/pubring.gpg"));
     assert_rnp_success(key_store->load_pgp(src));
-    src_close(&src);
+    src.close();
     assert_int_equal(7, key_store->key_count());
 
     // find the key by keyid
@@ -133,7 +133,7 @@ check_pgp_keyring_counts(const char *   path,
     // load it in to the key store
     assert_rnp_success(init_file_src(&src, path));
     assert_rnp_success(key_store->load_pgp(src));
-    src_close(&src);
+    src.close();
 
     // count primary keys first
     unsigned total_primary_count = 0;
@@ -420,7 +420,7 @@ load_transferable_key(pgp_transferable_key_t *key, const char *fname)
 {
     pgp_source_t src = {};
     bool         res = !init_file_src(&src, fname) && !process_pgp_key(src, *key, false);
-    src_close(&src);
+    src.close();
     return res;
 }
 
@@ -429,7 +429,7 @@ load_transferable_subkey(pgp_transferable_subkey_t *key, const char *fname)
 {
     pgp_source_t src = {};
     bool         res = !init_file_src(&src, fname) && !process_pgp_subkey(src, *key, false);
-    src_close(&src);
+    src.close();
     return res;
 }
 
@@ -438,7 +438,7 @@ load_keystore(rnp::KeyStore *keystore, const char *fname)
 {
     pgp_source_t src = {};
     bool         res = !init_file_src(&src, fname) && !keystore->load_pgp(src);
-    src_close(&src);
+    src.close();
     return res;
 }
 

--- a/src/tests/partial-length.cpp
+++ b/src/tests/partial-length.cpp
@@ -212,7 +212,7 @@ TEST_F(rnp_tests, test_partial_length_first_packet_length)
     assert_rnp_success(body.read(src));
     // checking next packet header (should be partial length literal data)
     uint8_t flags = 0;
-    assert_true(src_read_eq(&src, &flags, 1));
+    assert_true(src.read_eq(&flags, 1));
     assert_int_equal(flags, PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT | PGP_PKT_LITDATA);
     // checking length
     bool last = true; // should be reset by stream_read_partial_chunk_len()
@@ -220,7 +220,7 @@ TEST_F(rnp_tests, test_partial_length_first_packet_length)
     assert_true(len >= PGP_PARTIAL_PKT_FIRST_PART_MIN_SIZE);
     assert_false(last);
     // cleanup
-    src_close(&src);
+    src.close();
     assert_rnp_success(rnp_op_sign_destroy(sign));
     assert_rnp_success(rnp_input_destroy(input));
     assert_rnp_success(rnp_output_destroy(output));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -808,7 +808,7 @@ TEST_F(rnp_tests, test_stream_key_load_errors)
 
     for (size_t i = 0; i < sizeof(key_files) / sizeof(char *); i++) {
         assert_rnp_success(init_file_src(&fsrc, key_files[i]));
-        if (is_armored_source(&fsrc)) {
+        if (fsrc.is_armored()) {
             assert_rnp_success(init_armored_src(&armorsrc, &fsrc));
             assert_rnp_success(read_mem_src(&memsrc, &armorsrc));
             src_close(&armorsrc);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1719,7 +1719,7 @@ TEST_F(rnp_tests, test_stream_cache)
 
     init_src_common(&src, 0);
     int8_t *buf = (int8_t *) src.cache->buf;
-    src.read = src_reader_generator;
+    src.raw_read = src_reader_generator;
     size_t len = sizeof(src.cache->buf);
 
     // empty cache, pos=0

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -54,7 +54,7 @@ stream_hash_file(rnp::Hash &hash, const char *path)
     do {
         uint8_t readbuf[1024];
         size_t  read = 0;
-        if (!src_read(&src, readbuf, sizeof(readbuf), &read)) {
+        if (!src.read(readbuf, sizeof(readbuf), &read)) {
             goto finish;
         } else if (read == 0) {
             break;
@@ -64,7 +64,7 @@ stream_hash_file(rnp::Hash &hash, const char *path)
 
     res = true;
 finish:
-    src_close(&src);
+    src.close();
     return res;
 }
 
@@ -237,17 +237,17 @@ TEST_F(rnp_tests, test_stream_file)
     assert_rnp_success(init_file_src(&src, filename));
     for (int i = 0; i < iterations; i++) {
         size_t read = 0;
-        assert_true(src_read(&src, tmpbuf, filedatalen, &read));
+        assert_true(src.read(tmpbuf, filedatalen, &read));
         assert_int_equal(read, filedatalen);
         assert_int_equal(memcmp(tmpbuf, filedata, filedatalen), 0);
     }
     for (int i = 0; i < 5 * iterations; i++) {
         size_t read = 0;
-        assert_true(src_read(&src, tmpbuf, 3, &read));
+        assert_true(src.read(tmpbuf, 3, &read));
         assert_int_equal(read, 3);
         assert_int_equal(memcmp(tmpbuf, "zzz", 3), 0);
     }
-    src_close(&src);
+    src.close();
 
     /* overwrite and discard - file should be deleted */
     assert_rnp_success(init_file_dest(&dst, filename, true));
@@ -345,7 +345,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     /* load signature */
     assert_rnp_success(init_file_src(&sigsrc, "data/test_stream_signatures/source.txt.sig"));
     assert_rnp_success(sig.parse(sigsrc));
-    src_close(&sigsrc);
+    sigsrc.close();
     /* hash signed file */
     pgp_hash_alg_t halg = sig.halg;
     auto           hash_orig = rnp::Hash::create(halg);
@@ -424,7 +424,7 @@ TEST_F(rnp_tests, test_stream_signatures_revoked_key)
     assert_rnp_success(
       init_file_src(&sigsrc, "data/test_stream_signatures/revoked-key-sig.gpg"));
     assert_rnp_success(sig.parse(sigsrc));
-    src_close(&sigsrc);
+    sigsrc.close();
     /* check revocation */
     assert_int_equal(sig.revocation_code(), PGP_REVOCATION_RETIRED);
     assert_string_equal(sig.revocation_reason().c_str(), "For testing!");
@@ -444,7 +444,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
     assert_true(keyseq.keys.size() > 1);
-    src_close(&keysrc);
+    keysrc.close();
 
     assert_rnp_success(init_file_dest(&keydst, "keyout.gpg", true));
     assert_true(write_transferable_keys(keyseq, &keydst, false));
@@ -452,7 +452,7 @@ TEST_F(rnp_tests, test_stream_key_load)
 
     assert_rnp_success(init_file_src(&keysrc, "keyout.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
 
     assert_rnp_success(init_file_dest(&keydst, "keyout.asc", true));
     assert_true(write_transferable_keys(keyseq, &keydst, true));
@@ -460,13 +460,13 @@ TEST_F(rnp_tests, test_stream_key_load)
 
     assert_rnp_success(init_file_src(&keysrc, "keyout.asc"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* secret keyring */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
     assert_true(keyseq.keys.size() > 1);
-    src_close(&keysrc);
+    keysrc.close();
 
     assert_rnp_success(init_file_dest(&keydst, "keyout-sec.gpg", true));
     assert_true(write_transferable_keys(keyseq, &keydst, false));
@@ -474,7 +474,7 @@ TEST_F(rnp_tests, test_stream_key_load)
 
     assert_rnp_success(init_file_src(&keysrc, "keyout-sec.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
 
     assert_rnp_success(init_file_dest(&keydst, "keyout-sec.asc", true));
     assert_true(write_transferable_keys(keyseq, &keydst, true));
@@ -482,7 +482,7 @@ TEST_F(rnp_tests, test_stream_key_load)
 
     assert_rnp_success(init_file_src(&keysrc, "keyout-sec.asc"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* armored v3 public key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
@@ -492,7 +492,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_rnp_success(pgp_keyid(keyid, key->key));
     assert_true(cmp_keyid(keyid, "7D0BC10E933404C9"));
     assert_false(cmp_keyid(keyid, "1D0BC10E933404C9"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* armored v3 secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-s.asc"));
@@ -501,7 +501,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_keyid(keyid, key->key));
     assert_true(cmp_keyid(keyid, "7D0BC10E933404C9"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* rsa/rsa public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-pub.asc"));
@@ -514,7 +514,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyid(keyid, "2FB9179118898E8B"));
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* rsa/rsa secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-sec.asc"));
@@ -527,7 +527,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyid(keyid, "2FB9179118898E8B"));
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* dsa/el-gamal public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-pub.asc"));
@@ -540,7 +540,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "02A5715C3537717E"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* dsa/el-gamal secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-sec.asc"));
@@ -549,7 +549,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* curve 25519 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-pub.asc"));
@@ -558,7 +558,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(pgp_fingerprint(keyfp, key->key));
     assert_true(cmp_keyfp(keyfp, "21FC68274AAE3B5DE39A4277CC786278981B0728"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* curve 25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-sec.asc"));
@@ -566,7 +566,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_true(key->subkeys.empty());
-    src_close(&keysrc);
+    keysrc.close();
 
     /* eddsa/x25519 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-pub.asc"));
@@ -579,7 +579,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "C711187E594376AF"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* eddsa/x25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-sec.asc"));
@@ -588,7 +588,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-256 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-pub.asc"));
@@ -600,7 +600,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "37E285E9E9851491"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-sec.asc"));
@@ -609,7 +609,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-384 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-pub.asc"));
@@ -621,7 +621,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "E210E3D554A4FAD9"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-sec.asc"));
@@ -630,7 +630,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-521 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-pub.asc"));
@@ -642,7 +642,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "9853DF2F6D297442"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-521 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-sec.asc"));
@@ -651,7 +651,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* Brainpool P256 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp256-pub.asc"));
@@ -663,7 +663,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "2EDABB94D3055F76"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* Brainpool P256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp256-sec.asc"));
@@ -672,7 +672,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* Brainpool P384 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp384-pub.asc"));
@@ -684,7 +684,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "CFF1BB6F16D28191"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* Brainpool P384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp384-sec.asc"));
@@ -693,7 +693,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* Brainpool P512 ecc public key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp512-pub.asc"));
@@ -705,7 +705,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "20CDAA1482BA79CE"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* Brainpool P512 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-bp512-sec.asc"));
@@ -714,7 +714,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 
     /* secp256k1 ecc public key, not supported now */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256k1-pub.asc"));
@@ -726,7 +726,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(skey = &key->subkeys.front());
     assert_rnp_success(pgp_keyid(keyid, skey->subkey));
     assert_true(cmp_keyid(keyid, "7635401F90D3E533"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* secp256k1 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256k1-sec.asc"));
@@ -735,7 +735,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
     assert_non_null(key->subkeys[0].subkey.hashed_data);
-    src_close(&keysrc);
+    keysrc.close();
 }
 
 static void
@@ -755,7 +755,7 @@ buggy_key_load_single(const void *keydata, size_t keylen)
         } else {
             assert_true(keyseq.keys.empty());
         }
-        src_close(&memsrc);
+        memsrc.close();
     }
 
     /* try modified load */
@@ -769,7 +769,7 @@ buggy_key_load_single(const void *keydata, size_t keylen)
         } else {
             assert_true(keyseq.keys.empty());
         }
-        src_close(&memsrc);
+        memsrc.close();
         dataptr[partlen] ^= 0xff;
     }
 }
@@ -811,13 +811,13 @@ TEST_F(rnp_tests, test_stream_key_load_errors)
         if (fsrc.is_armored()) {
             assert_rnp_success(init_armored_src(&armorsrc, &fsrc));
             assert_rnp_success(read_mem_src(&memsrc, &armorsrc));
-            src_close(&armorsrc);
+            armorsrc.close();
         } else {
             assert_rnp_success(read_mem_src(&memsrc, &fsrc));
         }
-        src_close(&fsrc);
+        fsrc.close();
         buggy_key_load_single(mem_src_get_memory(&memsrc), memsrc.size);
-        src_close(&memsrc);
+        memsrc.close();
     }
 }
 
@@ -840,7 +840,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
             assert_rnp_success(decrypt_secret_key(&subkey.subkey, "password"));
         }
     }
-    src_close(&keysrc);
+    keysrc.close();
 
     /* armored v3 secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-s.asc"));
@@ -852,7 +852,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
 #else
     assert_rnp_failure(decrypt_secret_key(&key->key, "password"));
 #endif
-    src_close(&keysrc);
+    keysrc.close();
 
     /* rsa/rsa secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/rsa-rsa-sec.asc"));
@@ -861,7 +861,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* dsa/el-gamal secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/dsa-eg-sec.asc"));
@@ -870,14 +870,14 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* curve 25519 eddsa ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-25519-sec.asc"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
     assert_non_null(key = &keyseq.keys.front());
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* x25519 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-x25519-sec.asc"));
@@ -886,7 +886,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-256 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p256-sec.asc"));
@@ -895,7 +895,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-384 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p384-sec.asc"));
@@ -904,7 +904,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* p-521 ecc secret key */
     assert_rnp_success(init_file_src(&keysrc, "data/test_stream_key_load/ecc-p521-sec.asc"));
@@ -913,7 +913,7 @@ TEST_F(rnp_tests, test_stream_key_decrypt)
     assert_rnp_success(decrypt_secret_key(&key->key, "password"));
     assert_non_null(subkey = &key->subkeys.front());
     assert_rnp_success(decrypt_secret_key(&subkey->subkey, "password"));
-    src_close(&keysrc);
+    keysrc.close();
 }
 
 TEST_F(rnp_tests, test_stream_key_encrypt)
@@ -928,7 +928,7 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
     /* load and decrypt secret keyring, then re-encrypt and reload keys */
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/secring.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
     for (auto &key : keyseq.keys) {
         assert_rnp_success(decrypt_secret_key(&key.key, "password"));
 
@@ -951,7 +951,7 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
         /* load and decrypt changed key */
         assert_rnp_success(init_mem_src(&keysrc, keybuf, keylen, false));
         assert_rnp_success(process_pgp_keys(keysrc, keyseq2, false));
-        src_close(&keysrc);
+        keysrc.close();
         assert_false(keyseq2.keys.empty());
         auto &key2 = keyseq2.keys.front();
         assert_int_equal(key2.key.sec_protection.symm_alg, PGP_SA_CAMELLIA_192);
@@ -976,7 +976,7 @@ TEST_F(rnp_tests, test_stream_key_encrypt)
         /* load non-encrypted key */
         assert_rnp_success(init_mem_src(&keysrc, keybuf, keylen, false));
         assert_rnp_success(process_pgp_keys(keysrc, keyseq2, false));
-        src_close(&keysrc);
+        keysrc.close();
         assert_false(keyseq2.keys.empty());
         auto &key3 = keyseq2.keys.front();
         assert_int_equal(key3.key.sec_protection.s2k.usage, PGP_S2KU_NONE);
@@ -1002,7 +1002,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     assert_true(pubring->load());
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
     assert_int_equal(keyseq.keys.size(), 1);
     auto &key = keyseq.keys.front();
     auto &uid = key.userids.front();
@@ -1032,7 +1032,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     assert_true(pubring->load());
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
-    src_close(&keysrc);
+    keysrc.close();
 
     /* check key signatures */
     for (auto &keyref : keyseq.keys) {
@@ -1241,7 +1241,7 @@ check_dump_file_dst(const char *file, bool mpi, bool grip)
     if (stream_dump_packets(&ctx, &src, &dst)) {
         return false;
     }
-    src_close(&src);
+    src.close();
     dst_close(&dst, false);
     return true;
 }
@@ -1265,7 +1265,7 @@ check_dump_file_json(const char *file, bool mpi, bool grip)
     if (!json_object_is_type(jso, json_type_array)) {
         return false;
     }
-    src_close(&src);
+    src.close();
     json_object_put(jso);
     return true;
 }
@@ -1330,7 +1330,7 @@ TEST_F(rnp_tests, test_stream_dumper_y2k38)
     assert_rnp_success(init_file_src(&src, "data/keyrings/6/pubring.gpg"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     auto   written = (const uint8_t *) mem_dest_get_memory(&dst);
     auto   last = written + dst.writeb;
     time_t timestamp = 2958774690;
@@ -1387,25 +1387,25 @@ TEST_F(rnp_tests, test_stream_dumper)
     assert_rnp_success(init_file_src(&src, "data/test_stream_signatures/source.txt"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_failure(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, false);
 
     assert_rnp_success(init_file_src(&src, "data/test_messages/message.txt.enc-no-mdc"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, false);
 
     assert_rnp_success(init_file_src(&src, "data/test_messages/message.txt.enc-mdc"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, false);
 
     assert_rnp_success(init_file_src(&src, "data/test_messages/message-32k-crlf.txt.gpg"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, false);
 }
 
@@ -1422,37 +1422,37 @@ TEST_F(rnp_tests, test_stream_z)
     assert_rnp_success(init_file_src(&src, "data/test_stream_z/4gb.bzip2"));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 
     assert_rnp_success(init_file_src(&src, "data/test_stream_z/4gb.bzip2.cut"));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 
     assert_rnp_success(init_file_src(&src, "data/test_stream_z/128mb.zlib"));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 
     assert_rnp_success(init_file_src(&src, "data/test_stream_z/128mb.zlib.cut"));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 
     assert_rnp_success(init_file_src(&src, "data/test_stream_z/128mb.zip"));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 
     assert_rnp_success(init_file_src(&src, "data/test_stream_z/128mb.zip.cut"));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 }
 
@@ -1467,7 +1467,7 @@ TEST_F(rnp_tests, test_stream_814_dearmor_double_free)
     assert_rnp_success(init_mem_src(&src, buf, strlen(buf), false));
     assert_rnp_success(init_null_dest(&dst));
     assert_rnp_failure(rnp_dearmor_source(&src, &dst));
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
 }
 
@@ -1480,7 +1480,7 @@ TEST_F(rnp_tests, test_stream_825_dearmor_blank_line)
       init_file_src(&src, "data/test_stream_armor/extra_line_before_trailer.asc"));
     assert_true(keystore->load(src));
     assert_int_equal(keystore->key_count(), 2);
-    src_close(&src);
+    src.close();
     delete keystore;
 }
 
@@ -1502,7 +1502,7 @@ try_dearmor(const char *str, int len)
     }
     res = rnp_dearmor_source(&src, &dst) == RNP_SUCCESS;
 done:
-    src_close(&src);
+    src.close();
     dst_close(&dst, true);
     return res;
 }
@@ -1609,7 +1609,7 @@ add_openpgp_layers(const char *msg, pgp_dest_t &pgpdst, int compr, int encr)
     assert_rnp_success(init_mem_src(&src, msg, strlen(msg), false));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(rnp_wrap_src(src, dst, "message.txt", time(NULL)));
-    src_close(&src);
+    src.close();
     assert_rnp_success(init_mem_src(&src, mem_dest_own_memory(&dst), dst.writeb, true));
     dst_close(&dst, false);
 
@@ -1618,7 +1618,7 @@ add_openpgp_layers(const char *msg, pgp_dest_t &pgpdst, int compr, int encr)
         pgp_compression_type_t alg = (pgp_compression_type_t)((i % 3) + 1);
         assert_rnp_success(init_mem_dest(&dst, NULL, 0));
         assert_rnp_success(rnp_compress_src(src, dst, alg, 9));
-        src_close(&src);
+        src.close();
         assert_rnp_success(init_mem_src(&src, mem_dest_own_memory(&dst), dst.writeb, true));
         dst_close(&dst, false);
     }
@@ -1627,14 +1627,14 @@ add_openpgp_layers(const char *msg, pgp_dest_t &pgpdst, int compr, int encr)
     for (int i = 0; i < encr; i++) {
         assert_rnp_success(init_mem_dest(&dst, NULL, 0));
         assert_rnp_success(rnp_raw_encrypt_src(src, dst, "password", global_ctx));
-        src_close(&src);
+        src.close();
         assert_rnp_success(init_mem_src(&src, mem_dest_own_memory(&dst), dst.writeb, true));
         dst_close(&dst, false);
     }
 
     assert_rnp_success(init_mem_dest(&pgpdst, NULL, 0));
     assert_rnp_success(dst_write_src(&src, &pgpdst));
-    src_close(&src);
+    src.close();
 }
 
 TEST_F(rnp_tests, test_stream_deep_packet_nesting)
@@ -1652,7 +1652,7 @@ TEST_F(rnp_tests, test_stream_deep_packet_nesting)
     assert_rnp_success(init_stdout_dest(&outdst));
     assert_rnp_success(rnp_armor_source(&src, &outdst, PGP_ARMORED_MESSAGE));
     dst_close(&outdst, false);
-    src_close(&src);
+    src.close();
 #endif
     /* decrypt it via FFI for less code */
     rnp_ffi_t ffi = NULL;
@@ -1678,7 +1678,7 @@ TEST_F(rnp_tests, test_stream_deep_packet_nesting)
     assert_rnp_success(init_stdout_dest(&outdst));
     assert_rnp_success(rnp_armor_source(&src, &outdst, PGP_ARMORED_MESSAGE));
     dst_close(&outdst, false);
-    src_close(&src);
+    src.close();
 #endif
     /* decrypt it via FFI for less code */
     assert_rnp_success(rnp_input_from_memory(
@@ -1726,21 +1726,21 @@ TEST_F(rnp_tests, test_stream_cache)
     memset(src.cache->buf, 0xFF, len);
     src.cache->pos = 0;
     src.cache->len = 0;
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
     // empty cache, pos is somewhere in the middle
     memset(src.cache->buf, 0xFF, len);
     src.cache->pos = 100;
     src.cache->len = 100;
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
     // empty cache, pos=max
     memset(src.cache->buf, 0xFF, len);
     src.cache->pos = len;
     src.cache->len = len;
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
     // cache has some data in the middle
@@ -1748,21 +1748,21 @@ TEST_F(rnp_tests, test_stream_cache)
     src.cache->len = 300;
     memset(src.cache->buf, 0xFF, src.cache->pos);
     memset(src.cache->buf + src.cache->len, 0xFF, len - src.cache->len);
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
     // cache has some data starting from pos until the end
     src.cache->pos = 128; // sample boundary
     src.cache->len = len;
     memset(src.cache->buf, 0xFF, src.cache->pos);
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
     // cache is almost full
     src.cache->pos = 0;
     src.cache->len = len - 1;
     src.cache->buf[len - 1] = 0xFF;
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
     // cache is full
@@ -1770,8 +1770,8 @@ TEST_F(rnp_tests, test_stream_cache)
     src.cache->len = len;
     memset(src.cache->buf, 0xFF, src.cache->pos);
     memset(src.cache->buf + src.cache->len, 0xFF, len - src.cache->len);
-    assert_true(src_peek_eq(&src, NULL, len));
+    assert_true(src.peek_eq(NULL, len));
     assert_false(memcmp(buf, sample, samplesize));
 
-    src_close(&src);
+    src.close();
 }


### PR DESCRIPTION
This PR fixes incorrect detection of cleartext-signed stream. In addition it refactors pgp_source_t to be more C++ (still a lot of work left).

Fixes #2154 