### PR TITLE
Fix build with GoogleTest 1.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ endif(MSVC)
 
 # set a few other things at the top level to prevent incompatibilities
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 add_definitions(-D_GNU_SOURCE)


### PR DESCRIPTION
GoogleTest 1.14.0 requires C++14

Fixes: 
````
[   26s] /usr/include/gtest/internal/gtest-port.h:279:2: error: #error C++ versions less than C++14 are not supported.
[   26s]   279 | #error C++ versions less than C++14 are not supported.
[   26s]       |  ^~~~~
````