### PR TITLE
Remove tests, sexpp and certain code lines from the Coverage report.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,5 +22,6 @@
 ignore:
 # Google test sources stored under the build directory
   - "build"
+  - "src/examples"
   - "src/libsexpp"
   - "src/tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,3 +22,5 @@
 ignore:
 # Google test sources stored under the build directory
   - "build"
+  - "src/libsexpp"
+  - "src/tests"

--- a/src/lib/crypto/ecdh_ossl.cpp
+++ b/src/lib/crypto/ecdh_ossl.cpp
@@ -70,8 +70,10 @@ ecdh_derive_kek(uint8_t *                x,
     const size_t hash_len = rnp::Hash::size(key.kdf_hash_alg);
     if (!hash_len) {
         // must not assert here as kdf/hash algs are not checked during key parsing
+        /* LCOV_EXCL_START */
         RNP_LOG("Unsupported key wrap hash algorithm.");
         return RNP_ERROR_NOT_SUPPORTED;
+        /* LCOV_EXCL_END */
     }
     size_t other_len = kdf_other_info_serialize(
       other_info, curve_desc, fingerprint, key.kdf_hash_alg, key.key_wrap_alg);
@@ -83,8 +85,10 @@ ecdh_derive_kek(uint8_t *                x,
     size_t reps = (kek_len + hash_len - 1) / hash_len;
     // As we use AES & SHA2 we should not get more then 2 iterations
     if (reps > 2) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Invalid key wrap/hash alg combination.");
         return RNP_ERROR_NOT_SUPPORTED;
+        /* LCOV_EXCL_END */
     }
     size_t have = 0;
     try {
@@ -100,8 +104,10 @@ ecdh_derive_kek(uint8_t *                x,
         }
         return RNP_SUCCESS;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to derive kek: %s", e.what());
         return RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -115,27 +121,35 @@ ecdh_rfc3394_wrap_ctx(EVP_CIPHER_CTX **ctx,
     const char *cipher_name = NULL;
     ARRAY_LOOKUP_BY_ID(ecdh_wrap_alg_map, alg, name, wrap_alg, cipher_name);
     if (!cipher_name) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Unsupported key wrap algorithm: %d", (int) wrap_alg);
         return RNP_ERROR_NOT_SUPPORTED;
+        /* LCOV_EXCL_END */
     }
     const EVP_CIPHER *cipher = EVP_get_cipherbyname(cipher_name);
     if (!cipher) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Cipher %s is not supported by OpenSSL.", cipher_name);
         return RNP_ERROR_NOT_SUPPORTED;
+        /* LCOV_EXCL_END */
     }
     *ctx = EVP_CIPHER_CTX_new();
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Context allocation failed : %lu", ERR_peek_last_error());
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     EVP_CIPHER_CTX_set_flags(*ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
     int res = decrypt ? EVP_DecryptInit_ex(*ctx, cipher, NULL, key, NULL) :
                         EVP_EncryptInit_ex(*ctx, cipher, NULL, key, NULL);
     if (res <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to initialize cipher : %lu", ERR_peek_last_error());
         EVP_CIPHER_CTX_free(*ctx);
         *ctx = NULL;
         return RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
     return RNP_SUCCESS;
 }
@@ -151,14 +165,16 @@ ecdh_rfc3394_wrap(uint8_t *            out,
     EVP_CIPHER_CTX *ctx = NULL;
     rnp_result_t    ret = ecdh_rfc3394_wrap_ctx(&ctx, wrap_alg, key, false);
     if (ret) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Wrap context initialization failed.");
         return ret;
+        /* LCOV_EXCL_END */
     }
     int intlen = *out_len;
     /* encrypts in one pass, no final is needed */
     int res = EVP_EncryptUpdate(ctx, out, &intlen, in, in_len);
     if (res <= 0) {
-        RNP_LOG("Failed to encrypt data : %lu", ERR_peek_last_error());
+        RNP_LOG("Failed to encrypt data : %lu", ERR_peek_last_error()); // LCOV_EXCL_LINE
     } else {
         *out_len = intlen;
     }
@@ -181,8 +197,10 @@ ecdh_rfc3394_unwrap(uint8_t *            out,
     EVP_CIPHER_CTX *ctx = NULL;
     rnp_result_t    ret = ecdh_rfc3394_wrap_ctx(&ctx, wrap_alg, key, true);
     if (ret) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Unwrap context initialization failed.");
         return ret;
+        /* LCOV_EXCL_END */
     }
     int intlen = *out_len;
     /* decrypts in one pass, no final is needed */
@@ -201,21 +219,29 @@ ecdh_derive_secret(EVP_PKEY *sec, EVP_PKEY *peer, uint8_t *x, size_t *xlen)
 {
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(sec, NULL);
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Context allocation failed: %lu", ERR_peek_last_error());
         return false;
+        /* LCOV_EXCL_END */
     }
     bool res = false;
     if (EVP_PKEY_derive_init(ctx) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Key derivation init failed: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_derive_set_peer(ctx, peer) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Peer setting failed: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_derive(ctx, x, xlen) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to obtain shared secret size: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     res = true;
 done:
@@ -256,14 +282,18 @@ ecdh_encrypt_pkcs5(rnp::RNG *               rng,
     /* check whether we have valid wrap_alg before doing heavy operations */
     size_t keklen = ecdh_kek_len(key->key_wrap_alg);
     if (!keklen) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Unsupported key wrap algorithm: %d", (int) key->key_wrap_alg);
         return RNP_ERROR_NOT_SUPPORTED;
+        /* LCOV_EXCL_END */
     }
     /* load our public key */
     EVP_PKEY *pkey = ec_load_key(key->p, NULL, key->curve);
     if (!pkey) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to load public key.");
         return RNP_ERROR_BAD_PARAMETERS;
+        /* LCOV_EXCL_END */
     }
     rnp::secure_array<uint8_t, MAX_CURVE_BYTELEN + 1> sec;
     rnp::secure_array<uint8_t, MAX_AES_KEY_SIZE>      kek;
@@ -274,28 +304,36 @@ ecdh_encrypt_pkcs5(rnp::RNG *               rng,
     /* generate ephemeral key */
     EVP_PKEY *ephkey = ec_generate_pkey(PGP_PKA_ECDH, key->curve);
     if (!ephkey) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to generate ephemeral key.");
         ret = RNP_ERROR_KEY_GENERATION;
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* do ECDH derivation */
     if (!ecdh_derive_secret(ephkey, pkey, sec.data(), &seclen)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("ECDH derivation failed.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* here we got x value in sec, deriving kek */
     ret = ecdh_derive_kek(sec.data(), seclen, *key, fingerprint, kek.data(), keklen);
     if (ret) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to derive KEK.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* add PKCS#7 padding */
     size_t m_padded_len;
     m_padded_len = ((in_len / 8) + 1) * 8;
     memcpy(mpad.data(), in, in_len);
     if (!pad_pkcs7(mpad.data(), m_padded_len, in_len)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to add PKCS #7 padding.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* do RFC 3394 AES key wrap */
     static_assert(sizeof(out->m) == ECDH_WRAPPED_KEY_SIZE, "Wrong ECDH wrapped key size.");
@@ -303,13 +341,17 @@ ecdh_encrypt_pkcs5(rnp::RNG *               rng,
     ret = ecdh_rfc3394_wrap(
       out->m, &out->mlen, mpad.data(), m_padded_len, kek.data(), key->key_wrap_alg);
     if (ret) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to wrap key.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* write ephemeral public key */
     if (!ec_write_pubkey(ephkey, out->p, key->curve)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to write ec key.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     ret = RNP_SUCCESS;
 done:
@@ -351,32 +393,42 @@ ecdh_decrypt_pkcs5(uint8_t *                   out,
     rnp_result_t ret = RNP_ERROR_GENERIC;
     EVP_PKEY *   pkey = ec_load_key(key->p, &key->x, key->curve);
     if (!pkey) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to load secret key.");
         ret = RNP_ERROR_BAD_PARAMETERS;
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* do ECDH derivation */
     if (!ecdh_derive_secret(pkey, ephkey, sec.data(), &seclen)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("ECDH derivation failed.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* here we got x value in sec, deriving kek */
     ret = ecdh_derive_kek(sec.data(), seclen, *key, fingerprint, kek.data(), keklen);
     if (ret) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to derive KEK.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* do RFC 3394 AES key unwrap */
     ret = ecdh_rfc3394_unwrap(
       mpad.data(), &mpadlen, in->m, in->mlen, kek.data(), key->key_wrap_alg);
     if (ret) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to unwrap key.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* remove PKCS#7 padding */
     if (!unpad_pkcs7(mpad.data(), mpadlen, &mpadlen)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to unpad key.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     assert(mpadlen <= *out_len);
     *out_len = mpadlen;

--- a/src/lib/crypto/elgamal_ossl.cpp
+++ b/src/lib/crypto/elgamal_ossl.cpp
@@ -51,8 +51,10 @@ elgamal_validate_key(const pgp_eg_key_t *key, bool secret)
 {
     BN_CTX *ctx = BN_CTX_new();
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Allocation failed.");
         return false;
+        /* LCOV_EXCL_END */
     }
     BN_CTX_start(ctx);
     bool         res = false;
@@ -90,8 +92,10 @@ elgamal_validate_key(const pgp_eg_key_t *key, bool secret)
     }
     for (size_t i = 2; i < (1 << 17); i++) {
         if (!BN_mod_mul_reciprocal(r, r, g, rctx, ctx)) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Multiplication failed.");
             goto done;
+            /* LCOV_EXCL_END */
         }
         if (BN_cmp(r, BN_value_one()) == 0) {
             RNP_LOG("Small subgroup detected. Order %zu", i);
@@ -139,8 +143,10 @@ pkcs1v15_pad(uint8_t *out, size_t out_len, const uint8_t *in, size_t in_len)
         while (!out[i] && (cntr--) && (RAND_bytes(&out[i], 1) == 1)) {
         }
         if (!out[i]) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Something is wrong with RNG.");
             return false;
+            /* LCOV_EXCL_END */
         }
     }
     memcpy(out + rnd + 3, in, in_len);
@@ -180,14 +186,18 @@ elgamal_encrypt_pkcs1(rnp::RNG *          rng,
     pgp_mpi_t mm = {};
     mm.len = key->p.len;
     if (!pkcs1v15_pad(mm.mpi, mm.len, in, in_len)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to add PKCS1 v1.5 padding.");
         return RNP_ERROR_BAD_PARAMETERS;
+        /* LCOV_EXCL_END */
     }
     rnp_result_t ret = RNP_ERROR_GENERIC;
     BN_CTX *     ctx = BN_CTX_new();
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Allocation failed.");
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     BN_CTX_start(ctx);
     BN_MONT_CTX *mctx = BN_MONT_CTX_new();
@@ -199,41 +209,55 @@ elgamal_encrypt_pkcs1(rnp::RNG *          rng,
     bignum_t *   c2 = BN_CTX_get(ctx);
     bignum_t *   k = BN_secure_new();
     if (!mctx || !m || !p || !g || !y || !c1 || !c2 || !k) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Allocation failed.");
         ret = RNP_ERROR_OUT_OF_MEMORY;
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* initialize Montgomery context */
     if (BN_MONT_CTX_set(mctx, p, ctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to setup Montgomery context.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     int res;
     /* must not fail */
     res = BN_rshift1(c1, p);
     assert(res == 1);
     if (res < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("BN_rshift1 failed.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* generate k */
     if (BN_rand_range(k, c1) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to generate k.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* calculate c1 = g ^ k (mod p) */
     if (BN_mod_exp_mont_consttime(c1, g, k, p, ctx, mctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Exponentiation 1 failed");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* calculate c2 = m * y ^ k (mod p)*/
     if (BN_mod_exp_mont_consttime(c2, y, k, p, ctx, mctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Exponentiation 2 failed");
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (BN_mod_mul(c2, c2, m, p, ctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Multiplication failed");
         goto done;
+        /* LCOV_EXCL_END */
     }
     res = bn2mpi(c1, &out->g) && bn2mpi(c2, &out->m);
     assert(res == 1);
@@ -262,8 +286,10 @@ elgamal_decrypt_pkcs1(rnp::RNG *                rng,
     }
     BN_CTX *ctx = BN_CTX_new();
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Allocation failed.");
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     pgp_mpi_t    mm = {};
     size_t       padlen = 0;
@@ -278,37 +304,49 @@ elgamal_decrypt_pkcs1(rnp::RNG *                rng,
     bignum_t *   s = BN_CTX_get(ctx);
     bignum_t *   m = BN_secure_new();
     if (!mctx || !p || !g || !x || !c1 || !c2 || !m) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Allocation failed.");
         ret = RNP_ERROR_OUT_OF_MEMORY;
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* initialize Montgomery context */
     if (BN_MONT_CTX_set(mctx, p, ctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to setup Montgomery context.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* calculate s = c1 ^ x (mod p) */
     if (BN_mod_exp_mont_consttime(s, c1, x, p, ctx, mctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Exponentiation 1 failed");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* calculate s^-1 (mod p) */
     BN_set_flags(s, BN_FLG_CONSTTIME);
     if (!BN_mod_inverse(s, s, p, ctx)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to calculate inverse.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* calculate m = c2 * s ^ -1 (mod p)*/
     if (BN_mod_mul(m, c2, s, p, ctx) < 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Multiplication failed");
         goto done;
+        /* LCOV_EXCL_END */
     }
     bool res;
     res = bn2mpi(m, &mm);
     assert(res);
     if (!res) {
+        /* LCOV_EXCL_START */
         RNP_LOG("bn2mpi failed.");
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* unpad, handling skipped leftmost 0 case */
     if (!pkcs1v15_unpad(&padlen, mm.mpi, mm.len, mm.len == key->p.len - 1)) {
@@ -349,49 +387,67 @@ elgamal_generate(rnp::RNG *rng, pgp_eg_key_t *key, size_t keybits)
     /* Generate DH params, which usable for ElGamal as well */
     ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DH, NULL);
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to create ctx: %lu", ERR_peek_last_error());
         return ret;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_paramgen_init(ctx) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to init keygen: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx, keybits) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to set key bits: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     /* OpenSSL correctly handles case with g = 5, making sure that g is primitive root of
      * q-group */
     if (EVP_PKEY_CTX_set_dh_paramgen_generator(ctx, DH_GENERATOR_5) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to set key generator: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_paramgen(ctx, &parmkey) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to generate parameters: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     EVP_PKEY_CTX_free(ctx);
     /* Generate DH (ElGamal) key */
 start:
     ctx = EVP_PKEY_CTX_new(parmkey, NULL);
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to create ctx: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_keygen_init(ctx) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to init keygen: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
+        /* LCOV_EXCL_START */
         RNP_LOG("ElGamal keygen failed: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
 #if defined(CRYPTO_BACKEND_OPENSSL3)
     {
         rnp::bn y;
         if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, y.ptr())) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Failed to retrieve ElGamal public key: %lu", ERR_peek_last_error());
             goto done;
+            /* LCOV_EXCL_END */
         }
         if (y.bytes() != BITS_TO_BYTES(keybits)) {
             /* This code chunk is rarely hit, so ignoring it for the coverage report:
@@ -417,8 +473,10 @@ start:
 #else
     dh = EVP_PKEY_get0_DH(pkey);
     if (!dh) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to retrieve DH key: %lu", ERR_peek_last_error());
         goto done;
+        /* LCOV_EXCL_END */
     }
     if (BITS_TO_BYTES(BN_num_bits(DH_get0_pub_key(dh))) != BITS_TO_BYTES(keybits)) {
         /* This code chunk is rarely hit, so ignoring it for the coverage report:
@@ -440,8 +498,10 @@ start:
     y = DH_get0_pub_key(dh);
     x = DH_get0_priv_key(dh);
     if (!p || !g || !y || !x) {
+        /* LCOV_EXCL_START */
         ret = RNP_ERROR_BAD_STATE;
         goto done;
+        /* LCOV_EXCL_END */
     }
     bn2mpi(p, &key->p);
     bn2mpi(g, &key->g);

--- a/src/lib/crypto/symmetric_ossl.cpp
+++ b/src/lib/crypto/symmetric_ossl.cpp
@@ -94,8 +94,10 @@ pgp_cipher_cfb_start(pgp_crypt_t *  crypt,
 
     const EVP_CIPHER *cipher = EVP_get_cipherbyname(cipher_name);
     if (!cipher) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Cipher %s is not supported by OpenSSL.", cipher_name);
         return false;
+        /* LCOV_EXCL_END */
     }
 
     crypt->alg = alg;
@@ -104,9 +106,11 @@ pgp_cipher_cfb_start(pgp_crypt_t *  crypt,
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     int             res = EVP_EncryptInit_ex(ctx, cipher, NULL, key, iv);
     if (res != 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to initialize cipher.");
         EVP_CIPHER_CTX_free(ctx);
         return false;
+        /* LCOV_EXCL_END */
     }
     crypt->cfb.obj = ctx;
 
@@ -131,7 +135,7 @@ int
 pgp_cipher_cfb_finish(pgp_crypt_t *crypt)
 {
     if (!crypt) {
-        return 0;
+        return 0; // LCOV_EXCL_LINE
     }
     if (crypt->cfb.obj) {
         EVP_CIPHER_CTX_free(crypt->cfb.obj);
@@ -182,7 +186,7 @@ pgp_cipher_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
                     EVP_EncryptUpdate(
                       crypt->cfb.obj, (uint8_t *) iv64, &outlen, (uint8_t *) iv64, 16);
                     if (outlen != 16) {
-                        RNP_LOG("Bad outlen: must be 16");
+                        RNP_LOG("Bad outlen: must be 16"); // LCOV_EXCL_LINE
                     }
                     *in64 ^= iv64[0];
                     iv64[0] = *in64++;
@@ -196,7 +200,7 @@ pgp_cipher_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
                     EVP_EncryptUpdate(
                       crypt->cfb.obj, (uint8_t *) iv64, &outlen, (uint8_t *) iv64, 8);
                     if (outlen != 8) {
-                        RNP_LOG("Bad outlen: must be 8");
+                        RNP_LOG("Bad outlen: must be 8"); // LCOV_EXCL_LINE
                     }
                     *in64 ^= iv64[0];
                     iv64[0] = *in64++;
@@ -218,7 +222,7 @@ pgp_cipher_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     int outlen = blsize;
     EVP_EncryptUpdate(crypt->cfb.obj, crypt->cfb.iv, &outlen, crypt->cfb.iv, (int) blsize);
     if (outlen != (int) blsize) {
-        RNP_LOG("Bad outlen: must be %zu", blsize);
+        RNP_LOG("Bad outlen: must be %zu", blsize); // LCOV_EXCL_LINE
     }
     crypt->cfb.remaining = blsize;
 
@@ -279,7 +283,7 @@ pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
                     EVP_EncryptUpdate(
                       crypt->cfb.obj, (uint8_t *) iv64, &outlen, (uint8_t *) iv64, 16);
                     if (outlen != 16) {
-                        RNP_LOG("Bad outlen: must be 16");
+                        RNP_LOG("Bad outlen: must be 16"); // LCOV_EXCL_LINE
                     }
                     *out64++ = *in64 ^ iv64[0];
                     iv64[0] = *in64++;
@@ -293,7 +297,7 @@ pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
                     EVP_EncryptUpdate(
                       crypt->cfb.obj, (uint8_t *) iv64, &outlen, (uint8_t *) iv64, 8);
                     if (outlen != 8) {
-                        RNP_LOG("Bad outlen: must be 8");
+                        RNP_LOG("Bad outlen: must be 8"); // LCOV_EXCL_LINE
                     }
                     *out64++ = *in64 ^ iv64[0];
                     iv64[0] = *in64++;
@@ -315,7 +319,7 @@ pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     int outlen = blsize;
     EVP_EncryptUpdate(crypt->cfb.obj, crypt->cfb.iv, &outlen, crypt->cfb.iv, (int) blsize);
     if (outlen != (int) blsize) {
-        RNP_LOG("Bad outlen: must be %zu", blsize);
+        RNP_LOG("Bad outlen: must be %zu", blsize); // LCOV_EXCL_LINE
     }
     crypt->cfb.remaining = blsize;
 
@@ -435,14 +439,18 @@ pgp_cipher_aead_init(pgp_crypt_t *  crypt,
     }
     auto cipher = EVP_get_cipherbyname(algname);
     if (!cipher) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Cipher %s is not supported.", algname);
         return false;
+        /* LCOV_EXCL_END */
     }
     /* Create and setup context */
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     if (!ctx) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to create cipher context: %lu", ERR_peek_last_error());
         return false;
+        /* LCOV_EXCL_END */
     }
 
     crypt->aead.key = new rnp::secure_vector<uint8_t>(key, key + pgp_key_size(ealg));
@@ -510,21 +518,29 @@ pgp_cipher_aead_start(pgp_crypt_t *crypt, const uint8_t *nonce, size_t len)
     assert(len == aead.n_len);
     EVP_CIPHER_CTX_reset(ctx);
     if (EVP_CipherInit_ex(ctx, aead.cipher, NULL, NULL, NULL, enc) != 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to initialize cipher: %lu", ERR_peek_last_error());
         return false;
+        /* LCOV_EXCL_END */
     }
     if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, aead.n_len, NULL) != 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to set nonce length: %lu", ERR_peek_last_error());
         return false;
+        /* LCOV_EXCL_END */
     }
     if (EVP_CipherInit_ex(ctx, NULL, NULL, aead.key->data(), nonce, enc) != 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to start cipher: %lu", ERR_peek_last_error());
         return false;
+        /* LCOV_EXCL_END */
     }
     int adlen = 0;
     if (EVP_CipherUpdate(ctx, NULL, &adlen, aead.ad, aead.ad_len) != 1) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to set AD: %lu", ERR_peek_last_error());
         return false;
+        /* LCOV_EXCL_END */
     }
     return true;
 }
@@ -538,7 +554,7 @@ pgp_cipher_aead_update(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     int  out_len = 0;
     bool res = EVP_CipherUpdate(crypt->aead.obj, out, &out_len, in, len) == 1;
     if (!res) {
-        RNP_LOG("Failed to update cipher: %lu", ERR_peek_last_error());
+        RNP_LOG("Failed to update cipher: %lu", ERR_peek_last_error()); // LCOV_EXCL_LINE
     }
     assert(out_len == (int) len);
     return res;
@@ -558,26 +574,34 @@ pgp_cipher_aead_finish(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     if (aead.decrypt) {
         assert(len >= aead.taglen);
         if (len < aead.taglen) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Invalid state: too few input bytes.");
             return false;
+            /* LCOV_EXCL_END */
         }
         size_t data_len = len - aead.taglen;
         int    out_len = 0;
         if (EVP_CipherUpdate(ctx, out, &out_len, in, data_len) != 1) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Failed to update cipher: %lu", ERR_peek_last_error());
             return false;
+            /* LCOV_EXCL_END */
         }
         uint8_t tag[PGP_AEAD_MAX_TAG_LEN] = {0};
         memcpy(tag, in + data_len, aead.taglen);
         if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, aead.taglen, tag) != 1) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Failed to set tag: %lu", ERR_peek_last_error());
             return false;
+            /* LCOV_EXCL_END */
         }
         int out_len2 = 0;
         if (EVP_CipherFinal_ex(ctx, out + out_len, &out_len2) != 1) {
             /* Zero value if auth tag is incorrect */
             if (ERR_peek_last_error()) {
+                /* LCOV_EXCL_START */
                 RNP_LOG("Failed to finish AEAD decryption: %lu", ERR_peek_last_error());
+                /* LCOV_EXCL_END */
             }
             return false;
         }
@@ -585,18 +609,24 @@ pgp_cipher_aead_finish(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     } else {
         int out_len = 0;
         if (EVP_CipherUpdate(ctx, out, &out_len, in, len) != 1) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Failed to update cipher: %lu", ERR_peek_last_error());
             return false;
+            /* LCOV_EXCL_END */
         }
         int out_len2 = 0;
         if (EVP_CipherFinal_ex(ctx, out + out_len, &out_len2) != 1) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Failed to finish AEAD encryption: %lu", ERR_peek_last_error());
             return false;
+            /* LCOV_EXCL_END */
         }
         assert(out_len + out_len2 == (int) len);
         if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, aead.taglen, out + len) != 1) {
+            /* LCOV_EXCL_START */
             RNP_LOG("Failed to get tag: %lu", ERR_peek_last_error());
             return false;
+            /* LCOV_EXCL_END */
         }
     }
     return true;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -512,12 +512,14 @@ hex_encode_value(const uint8_t *value, size_t len, char **res)
     size_t hex_len = len * 2 + 1;
     *res = (char *) malloc(hex_len);
     if (!*res) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!rnp::hex_encode(value, len, *res, hex_len, rnp::HexFormat::Uppercase)) {
+        /* LCOV_EXCL_START */
         free(*res);
         *res = NULL;
         return RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
     return RNP_SUCCESS;
 }
@@ -531,7 +533,7 @@ get_map_value(const id_str_pair *map, int val, char **res)
     }
     char *strcp = strdup(str);
     if (!strcp) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     *res = strcp;
     return RNP_SUCCESS;
@@ -545,7 +547,7 @@ ret_str_value(const char *str, char **res)
     }
     char *strcp = strdup(str);
     if (!strcp) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     *res = strcp;
     return RNP_SUCCESS;
@@ -903,21 +905,25 @@ rnp_version_commit_timestamp()
 }
 
 #ifndef RNP_NO_DEPRECATED
+/* LCOV_EXCL_START */
 rnp_result_t
 rnp_enable_debug(const char *file)
 try {
     return RNP_SUCCESS;
 }
 FFI_GUARD
+/* LCOV_EXCL_END */
 #endif
 
 #ifndef RNP_NO_DEPRECATED
+/* LCOV_EXCL_START */
 rnp_result_t
 rnp_disable_debug()
 try {
     return RNP_SUCCESS;
 }
 FFI_GUARD
+/* LCOV_EXCL_END */
 #endif
 
 rnp_result_t
@@ -935,7 +941,7 @@ try {
     }
     *homedir = strdup(home.c_str());
     if (!*homedir) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     return RNP_SUCCESS;
 }
@@ -987,6 +993,7 @@ try {
         return RNP_SUCCESS;
     }
 
+    /* LCOV_EXCL_START */
     free(*pub_format);
     *pub_format = NULL;
     free(*pub_path);
@@ -996,6 +1003,7 @@ try {
     free(*sec_path);
     *sec_path = NULL;
     return RNP_ERROR_OUT_OF_MEMORY;
+    /* LCOV_EXCL_END */
 }
 FFI_GUARD
 
@@ -1029,7 +1037,7 @@ try {
     if (guess) {
         *format = strdup(guess);
         if (!*format) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
 
@@ -1093,7 +1101,7 @@ json_array_add_id_str(json_object *arr, const id_str_pair *map, bool (*check)(in
 {
     while (map->str) {
         if (check(map->id) && !json_array_add(arr, map->str)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         map++;
     }
@@ -1109,7 +1117,7 @@ try {
 
     json_object *features = json_object_new_array();
     if (!features) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp::JSONObject featwrap(features);
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
@@ -1132,13 +1140,13 @@ try {
              curve = (pgp_curve_t)(curve + 1)) {
             const ec_curve_desc_t *desc = get_curve_desc(curve);
             if (!desc) {
-                return RNP_ERROR_BAD_STATE;
+                return RNP_ERROR_BAD_STATE; // LCOV_EXCL_LINE
             }
             if (!desc->supported) {
                 continue;
             }
             if (!json_array_add(features, desc->pgp_name)) {
-                return RNP_ERROR_OUT_OF_MEMORY;
+                return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
             }
         }
         ret = RNP_SUCCESS;
@@ -1150,11 +1158,11 @@ try {
 
     *result = (char *) json_object_to_json_string_ext(features, JSON_C_TO_STRING_PRETTY);
     if (!*result) {
-        return RNP_ERROR_BAD_STATE;
+        return RNP_ERROR_BAD_STATE; // LCOV_EXCL_LINE
     }
     *result = strdup(*result);
     if (!*result) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     return RNP_SUCCESS;
 }
@@ -1322,8 +1330,10 @@ try {
         *level = RNP_SECURITY_DEFAULT;
         break;
     default:
+        /* LCOV_EXCL_START */
         FFI_LOG(ffi, "Invalid security level.");
         return RNP_ERROR_BAD_STATE;
+        /* LCOV_EXCL_END */
     }
     return RNP_SUCCESS;
 }
@@ -1401,7 +1411,7 @@ try {
     size_t pass_len = strlen(pass.data()) + 1;
     *password = (char *) malloc(pass_len);
     if (!*password) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     memcpy(*password, pass.data(), pass_len);
     return RNP_SUCCESS;
@@ -1665,14 +1675,16 @@ add_key_status(json_object *           keys,
 {
     json_object *jsokey = json_object_new_object();
     if (!jsokey) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     if (!json_add(jsokey, "public", key_status_to_str(pub)) ||
         !json_add(jsokey, "secret", key_status_to_str(sec)) ||
         !json_add(jsokey, "fingerprint", key->fp()) || !json_array_add(keys, jsokey)) {
+        /* LCOV_EXCL_START */
         json_object_put(jsokey);
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
 
     return RNP_SUCCESS;
@@ -1734,12 +1746,12 @@ try {
 
     json_object *jsores = json_object_new_object();
     if (!jsores) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp::JSONObject jsowrap(jsores);
     json_object *   jsokeys = json_object_new_array();
     if (!json_add(jsores, "keys", jsokeys)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     // import keys to the main keystore.
@@ -1774,11 +1786,11 @@ try {
     if (results) {
         *results = (char *) json_object_to_json_string_ext(jsores, JSON_C_TO_STRING_PRETTY);
         if (!*results) {
-            return RNP_ERROR_GENERIC;
+            return RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
         }
         *results = strdup(*results);
         if (!*results) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     return RNP_SUCCESS;
@@ -1802,26 +1814,32 @@ add_sig_status(json_object *           sigs,
 {
     json_object *jsosig = json_object_new_object();
     if (!jsosig) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     if (!json_add(jsosig, "public", sig_status_to_str(pub)) ||
         !json_add(jsosig, "secret", sig_status_to_str(sec))) {
+        /* LCOV_EXCL_START */
         json_object_put(jsosig);
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
 
     if (signer) {
         const pgp_fingerprint_t &fp = signer->fp();
         if (!json_add(jsosig, "signer fingerprint", fp)) {
+            /* LCOV_EXCL_START */
             json_object_put(jsosig);
             return RNP_ERROR_OUT_OF_MEMORY;
+            /* LCOV_EXCL_END */
         }
     }
 
     if (!json_array_add(sigs, jsosig)) {
+        /* LCOV_EXCL_START */
         json_object_put(jsosig);
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
 
     return RNP_SUCCESS;
@@ -1847,12 +1865,12 @@ try {
 
     json_object *jsores = json_object_new_object();
     if (!jsores) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp::JSONObject jsowrap(jsores);
     json_object *   jsosigs = json_object_new_array();
     if (!json_add(jsores, "sigs", jsosigs)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     for (auto &sig : sigs) {
@@ -1862,18 +1880,18 @@ try {
         pgp_key_t *             skey = ffi->secring->import_signature(sig, &sec_status);
         sigret = add_sig_status(jsosigs, pkey ? pkey : skey, pub_status, sec_status);
         if (sigret) {
-            return sigret;
+            return sigret; // LCOV_EXCL_LINE
         }
     }
 
     if (results) {
         *results = (char *) json_object_to_json_string_ext(jsores, JSON_C_TO_STRING_PRETTY);
         if (!*results) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         *results = strdup(*results);
         if (!*results) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     return RNP_SUCCESS;
@@ -1903,23 +1921,27 @@ do_save_keys(rnp_ffi_t              ffi,
     try {
         tmp_store = new rnp::KeyStore(format, "", ffi->context);
     } catch (const std::invalid_argument &e) {
+        /* LCOV_EXCL_START */
         FFI_LOG(ffi, "Failed to create key store of format: %d", (int) format);
         return RNP_ERROR_BAD_PARAMETERS;
+        /* LCOV_EXCL_END */
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         FFI_LOG(ffi, "%s", e.what());
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     std::unique_ptr<rnp::KeyStore> tmp_store_ptr(tmp_store);
     // include the public keys, if desired
     if (key_type == KEY_TYPE_PUBLIC || key_type == KEY_TYPE_ANY) {
         if (!copy_store_keys(ffi, tmp_store, ffi->pubring)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     // include the secret keys, if desired
     if (key_type == KEY_TYPE_SECRET || key_type == KEY_TYPE_ANY) {
         if (!copy_store_keys(ffi, tmp_store, ffi->secring)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     // preliminary check on the format
@@ -2061,9 +2083,11 @@ try {
     *input = new rnp_input_st();
     rnp_result_t ret = init_stdin_src(&(*input)->src);
     if (ret) {
+        /* LCOV_EXCL_START */
         delete *input;
         *input = NULL;
         return ret;
+        /* LCOV_EXCL_END */
     }
     return RNP_SUCCESS;
 }
@@ -2083,22 +2107,25 @@ try {
     if (do_copy) {
         data = (uint8_t *) malloc(buf_len);
         if (!data) {
+            /* LCOV_EXCL_START */
             delete *input;
             *input = NULL;
             return RNP_ERROR_OUT_OF_MEMORY;
+            /* LCOV_EXCL_END */
         }
         memcpy(data, buf, buf_len);
     }
     rnp_result_t ret = init_mem_src(&(*input)->src, data, buf_len, do_copy);
     if (ret) {
+        /* LCOV_EXCL_START */
         if (do_copy) {
             free(data);
         }
         delete *input;
         *input = NULL;
-        return ret;
+        /* LCOV_EXCL_END */
     }
-    return RNP_SUCCESS;
+    return ret;
 }
 FFI_GUARD
 
@@ -2137,8 +2164,10 @@ try {
     obj->closer = closer;
     obj->app_ctx = app_ctx;
     if (!init_src_common(src, 0)) {
+        /* LCOV_EXCL_START */
         delete obj;
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     src->param = obj;
     src->raw_read = input_reader_bounce;
@@ -2168,14 +2197,16 @@ try {
     }
     ob = (rnp_output_st *) calloc(1, sizeof(*ob));
     if (!ob) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (rnp_stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
         // a bit hacky, just save the directory path
         ob->dst_directory = strdup(path);
         if (!ob->dst_directory) {
+            /* LCOV_EXCL_START */
             free(ob);
             return RNP_ERROR_OUT_OF_MEMORY;
+            /* LCOV_EXCL_END */
         }
     } else {
         // simple output to a file
@@ -2203,7 +2234,7 @@ try {
     }
     rnp_output_t res = (rnp_output_t) calloc(1, sizeof(*res));
     if (!res) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp_result_t ret = RNP_ERROR_GENERIC;
     if (random) {
@@ -2228,7 +2259,7 @@ try {
     }
     rnp_output_t res = (rnp_output_t) calloc(1, sizeof(*res));
     if (!res) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp_result_t ret = init_stdout_dest(&res->dst);
     if (ret) {
@@ -2250,15 +2281,16 @@ try {
 
     *output = (rnp_output_t) calloc(1, sizeof(**output));
     if (!*output) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp_result_t ret = init_mem_dest(&(*output)->dst, NULL, max_alloc);
     if (ret) {
+        /* LCOV_EXCL_START */
         free(*output);
         *output = NULL;
-        return ret;
+        /* LCOV_EXCL_END */
     }
-    return RNP_SUCCESS;
+    return ret;
 }
 FFI_GUARD
 
@@ -2279,13 +2311,15 @@ try {
     }
     *output = (rnp_output_t) calloc(1, sizeof(**output));
     if (!*output) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp_result_t ret = init_armored_dst(&(*output)->dst, &base->dst, msgtype);
     if (ret) {
+        /* LCOV_EXCL_START */
         free(*output);
         *output = NULL;
         return ret;
+        /* LCOV_EXCL_END */
     }
     (*output)->app_ctx = base;
     return RNP_SUCCESS;
@@ -2308,7 +2342,7 @@ try {
         uint8_t *tmp_buf = *buf;
         *buf = (uint8_t *) malloc(*len);
         if (!*buf) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         memcpy(*buf, tmp_buf, *len);
     }
@@ -2348,15 +2382,16 @@ try {
 
     *output = (rnp_output_t) calloc(1, sizeof(**output));
     if (!*output) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp_result_t ret = init_null_dest(&(*output)->dst);
     if (ret) {
+        /* LCOV_EXCL_START */
         free(*output);
         *output = NULL;
-        return ret;
+        /* LCOV_EXCL_END */
     }
-    return RNP_SUCCESS;
+    return ret;
 }
 FFI_GUARD
 
@@ -2395,7 +2430,7 @@ try {
 
     *output = (rnp_output_t) calloc(1, sizeof(**output));
     if (!*output) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     (*output)->writer = writer;
     (*output)->closer = closer;
@@ -2457,8 +2492,10 @@ rnp_op_add_signature(rnp_ffi_t                 ffi,
     try {
         signatures.emplace_back();
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         FFI_LOG(ffi, "%s", e.what());
         return RNP_ERROR_BAD_PARAMETERS;
+        /* LCOV_EXCL_END */
     }
     rnp_op_sign_signature_t newsig = &signatures.back();
     newsig->signer.key = signkey;
@@ -3101,7 +3138,7 @@ rnp_op_verify_on_signatures(const std::vector<pgp_signature_info_t> &sigs, void 
             res.ffi = op->ffi;
         }
     } catch (const std::exception &e) {
-        FFI_LOG(op->ffi, "%s", e.what());
+        FFI_LOG(op->ffi, "%s", e.what()); // LCOV_EXCL_LINE
     }
 }
 
@@ -3466,13 +3503,13 @@ try {
     if (mode) {
         *mode = strdup(get_protection_mode(op));
         if (!*mode) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     if (cipher) {
         *cipher = strdup(get_protection_cipher(op));
         if (!*cipher) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     if (valid) {
@@ -3661,15 +3698,17 @@ try {
 
     *handle = (rnp_signature_handle_t) calloc(1, sizeof(**handle));
     if (!*handle) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     try {
         (*handle)->sig = new pgp_subsig_t(sig->sig_pkt);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         FFI_LOG(sig->ffi, "%s", e.what());
         free(*handle);
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     (*handle)->ffi = sig->ffi;
     (*handle)->key = NULL;
@@ -3738,7 +3777,7 @@ try {
     rnp_op_verify_t op = NULL;
     rnp_result_t    ret = rnp_op_verify_create(&op, ffi, input, output);
     if (ret) {
-        return ret;
+        return ret; // LCOV_EXCL_LINE
     }
     ret = rnp_op_verify_set_flags(op, RNP_VERIFY_IGNORE_SIGS_ON_DECRYPT);
     if (!ret) {
@@ -4204,8 +4243,10 @@ report_signature_removal(rnp_ffi_t             ffi,
     }
     rnp_signature_handle_t sig = (rnp_signature_handle_t) calloc(1, sizeof(*sig));
     if (!sig) {
+        /* LCOV_EXCL_START */
         FFI_LOG(ffi, "Signature handle allocation failed.");
         return;
+        /* LCOV_EXCL_END */
     }
     sig->ffi = ffi;
     sig->key = &key;

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -514,9 +514,11 @@ decrypt_protected_section(const sexp_simple_string_t &encrypted_data,
 
     // decrypt
     decrypted_data = (uint8_t *) malloc(encrypted_data.size());
-    if (decrypted_data == NULL) {
+    if (!decrypted_data) {
+        /* LCOV_EXCL_START */
         RNP_LOG("can't allocate memory");
         goto done;
+        /* LCOV_EXCL_END */
     }
     dec = Cipher::decryption(
       info->cipher, info->cipher_mode, info->tag_length, info->disable_padding);
@@ -935,8 +937,10 @@ KeyStore::load_g10(pgp_source_t &src, const KeyProvider *key_provider)
         }
         return true;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return false;
+        /* LCOV_EXCL_END */
     }
 }
 } // namespace rnp

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -372,8 +372,10 @@ kbx_parse_blob(const uint8_t *image, size_t image_len)
             return NULL;
         }
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return NULL;
+        /* LCOV_EXCL_END */
     }
     return blob;
 }
@@ -441,8 +443,10 @@ KeyStore::load_kbx(pgp_source_t &src, const KeyProvider *key_provider)
         }
         return true;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return false;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -712,8 +716,10 @@ KeyStore::write_kbx(pgp_dest_t &dst)
         }
         return true;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Failed to write KBX store: %s", e.what());
         return false;
+        /* LCOV_EXCL_END */
     }
 }
 } // namespace rnp

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -46,10 +46,12 @@ KeyStore::add_ts_subkey(const pgp_transferable_subkey_t &tskey, pgp_key_t *pkey)
         /* add it to the storage */
         return add_key(skey);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         RNP_LOG_KEY_PKT("failed to create subkey %s", tskey.subkey);
         RNP_LOG_KEY("primary key is %s", pkey);
         return false;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -144,8 +146,10 @@ KeyStore::load_pgp(pgp_source_t &src, bool skiperrors)
         }
         return RNP_SUCCESS;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return RNP_ERROR_BAD_PARAMETERS;
+        /* LCOV_EXCL_END */
     }
 }
 } // namespace rnp

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -252,8 +252,10 @@ KeyStore::refresh_subkey_grips(pgp_key_t &key)
             try {
                 key.link_subkey_fp(skey);
             } catch (const std::exception &e) {
+                /* LCOV_EXCL_START */
                 RNP_LOG("%s", e.what());
                 return false;
+                /* LCOV_EXCL_END */
             }
         }
     }
@@ -298,6 +300,7 @@ KeyStore::add_subkey(pgp_key_t &srckey, pgp_key_t *oldkey)
                 primary->link_subkey_fp(*oldkey);
             }
         } catch (const std::exception &e) {
+            /* LCOV_EXCL_START */
             RNP_LOG_KEY("key %s copying failed", &srckey);
             RNP_LOG_KEY("primary key is %s", primary);
             RNP_LOG("%s", e.what());
@@ -306,6 +309,7 @@ KeyStore::add_subkey(pgp_key_t &srckey, pgp_key_t *oldkey)
                 keybyfp.erase(srckey.fp());
             }
             return nullptr;
+            /* LCOV_EXCL_END */
         }
     }
 
@@ -351,6 +355,7 @@ KeyStore::add_key(pgp_key_t &srckey)
                 RNP_LOG_KEY("failed to refresh subkey grips for %s", added_key);
             }
         } catch (const std::exception &e) {
+            /* LCOV_EXCL_START */
             RNP_LOG_KEY("key %s copying failed", &srckey);
             RNP_LOG("%s", e.what());
             if (added_key) {
@@ -358,6 +363,7 @@ KeyStore::add_key(pgp_key_t &srckey)
                 keybyfp.erase(srckey.fp());
             }
             return NULL;
+            /* LCOV_EXCL_END */
         }
     }
 
@@ -440,9 +446,11 @@ KeyStore::import_key(pgp_key_t &srckey, bool pubkey, pgp_key_import_status_t *st
         }
         return exkey;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         disable_validation = false;
         return nullptr;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -479,8 +487,10 @@ KeyStore::import_subkey_signature(pgp_key_t &key, const pgp_signature_t &sig)
         return (nkey->rawpkt_count() > expackets) ? PGP_SIG_IMPORT_STATUS_NEW :
                                                     PGP_SIG_IMPORT_STATUS_UNCHANGED;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -512,8 +522,10 @@ KeyStore::import_signature(pgp_key_t &key, const pgp_signature_t &sig)
         return (nkey->rawpkt_count() > expackets) ? PGP_SIG_IMPORT_STATUS_NEW :
                                                     PGP_SIG_IMPORT_STATUS_UNCHANGED;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;
+        /* LCOV_EXCL_END */
     }
 }
 

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -277,7 +277,7 @@ init_indent_dest(pgp_dest_t *dst, pgp_dest_t *origdst)
     pgp_dest_indent_param_t *param;
 
     if (!init_dst_common(dst, sizeof(*param))) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     dst->write = indent_dst_write;
@@ -796,8 +796,10 @@ stream_dump_signature_pkt(rnp_dump_ctx_t *ctx, pgp_signature_t *sig, pgp_dest_t 
     try {
         sig->parse_material(material);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return;
+        /* LCOV_EXCL_END */
     }
     switch (sig->palg) {
     case PGP_PKA_RSA:
@@ -863,8 +865,10 @@ stream_dump_signature(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
     try {
         ret = sig.parse(*src);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         ret = RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
     if (ret) {
         indent_dest_increase(dst);
@@ -886,8 +890,10 @@ stream_dump_key(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
     try {
         ret = key.parse(*src);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         ret = RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
     if (ret) {
         return ret;
@@ -1067,7 +1073,7 @@ stream_dump_userid(pgp_source_t *src, pgp_dest_t *dst)
     try {
         ret = uid.parse(*src);
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
@@ -1208,7 +1214,7 @@ stream_dump_sk_session_key(pgp_source_t *src, pgp_dest_t *dst)
     try {
         ret = skey.parse(*src);
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
@@ -1238,7 +1244,7 @@ stream_dump_get_aead_hdr(pgp_source_t *src, pgp_aead_hdr_t *hdr)
     uint8_t    encpkt[64] = {};
 
     if (init_mem_dest(&encdst, &encpkt, sizeof(encpkt))) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     mem_dest_discard_overflow(&encdst, true);
 
@@ -1251,7 +1257,7 @@ stream_dump_get_aead_hdr(pgp_source_t *src, pgp_aead_hdr_t *hdr)
 
     pgp_source_t memsrc = {};
     if (init_mem_src(&memsrc, encpkt, len, false)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     bool res = get_aead_src_hdr(&memsrc, hdr);
     memsrc.close();
@@ -1310,7 +1316,7 @@ stream_dump_one_pass(pgp_source_t *src, pgp_dest_t *dst)
     try {
         ret = onepass.parse(*src);
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
@@ -1619,7 +1625,7 @@ static bool
 obj_add_intstr_json(json_object *obj, const char *name, int val, const id_str_pair map[])
 {
     if (!json_add(obj, name, val)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (!map) {
         return true;
@@ -1636,7 +1642,7 @@ obj_add_mpi_json(json_object *obj, const char *name, const pgp_mpi_t *mpi, bool 
     char strname[64] = {0};
     snprintf(strname, sizeof(strname), "%s.bits", name);
     if (!json_add(obj, strname, (int) mpi_bits(mpi))) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (!contents) {
         return true;
@@ -1651,11 +1657,11 @@ subpacket_obj_add_algs(
 {
     json_object *jso_algs = json_object_new_array();
     if (!jso_algs || !json_add(obj, name, jso_algs)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     for (size_t i = 0; i < len; i++) {
         if (!json_array_add(jso_algs, json_object_new_int(algs[i]))) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
     }
     if (!map) {
@@ -1667,11 +1673,11 @@ subpacket_obj_add_algs(
 
     jso_algs = json_object_new_array();
     if (!jso_algs || !json_add(obj, strname, jso_algs)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     for (size_t i = 0; i < len; i++) {
         if (!json_array_add(jso_algs, id_str_pair::lookup(map, algs[i], "Unknown"))) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
     }
     return true;
@@ -1682,19 +1688,19 @@ obj_add_s2k_json(json_object *obj, pgp_s2k_t *s2k)
 {
     json_object *s2k_obj = json_object_new_object();
     if (!json_add(obj, "s2k", s2k_obj)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (!json_add(s2k_obj, "specifier", (int) s2k->specifier)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if ((s2k->specifier == PGP_S2KS_EXPERIMENTAL) && s2k->gpg_ext_num) {
         if (!json_add(s2k_obj, "gpg extension", (int) s2k->gpg_ext_num)) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if (s2k->gpg_ext_num == PGP_S2K_GPG_SMARTCARD) {
             size_t slen = s2k->gpg_serial_len > 16 ? 16 : s2k->gpg_serial_len;
             if (!json_add_hex(s2k_obj, "card serial number", s2k->gpg_serial, slen)) {
-                return false;
+                return false; // LCOV_EXCL_LINE
             }
         }
     }
@@ -1703,17 +1709,17 @@ obj_add_s2k_json(json_object *obj, pgp_s2k_t *s2k)
           s2k_obj, "unknown experimental", s2k->experimental.data(), s2k->experimental.size());
     }
     if (!obj_add_intstr_json(s2k_obj, "hash algorithm", s2k->hash_alg, hash_alg_map)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (((s2k->specifier == PGP_S2KS_SALTED) ||
          (s2k->specifier == PGP_S2KS_ITERATED_AND_SALTED)) &&
         !json_add_hex(s2k_obj, "salt", s2k->salt, PGP_SALT_SIZE)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (s2k->specifier == PGP_S2KS_ITERATED_AND_SALTED) {
         size_t real_iter = pgp_s2k_decode_iterations(s2k->iterations);
         if (!json_add(s2k_obj, "iterations", (uint64_t) real_iter)) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
     }
     return true;
@@ -1787,32 +1793,32 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *        ctx,
     case PGP_SIG_SUBPKT_KEY_FLAGS: {
         uint8_t flg = subpkt.fields.key_flags;
         if (!json_add(obj, "flags", (int) flg)) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         json_object *jso_flg = json_object_new_array();
         if (!jso_flg || !json_add(obj, "flags.str", jso_flg)) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_CERTIFY) && !json_array_add(jso_flg, "certify")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_SIGN) && !json_array_add(jso_flg, "sign")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_ENCRYPT_COMMS) && !json_array_add(jso_flg, "encrypt_comm")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_ENCRYPT_STORAGE) && !json_array_add(jso_flg, "encrypt_storage")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_SPLIT) && !json_array_add(jso_flg, "split")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_AUTH) && !json_array_add(jso_flg, "auth")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if ((flg & PGP_KF_SHARED) && !json_array_add(jso_flg, "shared")) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         return true;
     }
@@ -1835,7 +1841,7 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *        ctx,
     case PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE: {
         json_object *sig = json_object_new_object();
         if (!sig || !json_add(obj, "signature", sig)) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         return !stream_dump_signature_pkt_json(ctx, subpkt.fields.sig, sig);
     }
@@ -1848,7 +1854,7 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *        ctx,
                                                         "name",
                                                         (char *) subpkt.fields.notation.name,
                                                         subpkt.fields.notation.nlen)) {
-            return false;
+            return false; // LCOV_EXCL_LINE
         }
         if (human) {
             return json_add(obj,
@@ -1873,7 +1879,7 @@ signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp_signature_t *sig)
 {
     json_object *res = json_object_new_array();
     if (!res) {
-        return NULL;
+        return NULL; // LCOV_EXCL_LINE
     }
     rnp::JSONObject reswrap(res);
 
@@ -1881,24 +1887,24 @@ signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp_signature_t *sig)
         json_object *jso_subpkt = json_object_new_object();
         if (json_object_array_add(res, jso_subpkt)) {
             json_object_put(jso_subpkt);
-            return NULL;
+            return NULL; // LCOV_EXCL_LINE
         }
 
         if (!obj_add_intstr_json(jso_subpkt, "type", subpkt.type, sig_subpkt_type_map)) {
-            return NULL;
+            return NULL; // LCOV_EXCL_LINE
         }
         if (!json_add(jso_subpkt, "length", (int) subpkt.len)) {
-            return NULL;
+            return NULL; // LCOV_EXCL_LINE
         }
         if (!json_add(jso_subpkt, "hashed", subpkt.hashed)) {
-            return NULL;
+            return NULL; // LCOV_EXCL_LINE
         }
         if (!json_add(jso_subpkt, "critical", subpkt.critical)) {
-            return NULL;
+            return NULL; // LCOV_EXCL_LINE
         }
 
         if (ctx->dump_packets && !json_add_hex(jso_subpkt, "raw", subpkt.data, subpkt.len)) {
-            return NULL;
+            return NULL; // LCOV_EXCL_LINE
         }
 
         if (!signature_dump_subpacket_json(ctx, subpkt, jso_subpkt)) {
@@ -1917,61 +1923,63 @@ stream_dump_signature_pkt_json(rnp_dump_ctx_t *       ctx,
     pgp_signature_material_t sigmaterial = {};
 
     if (!json_add(pkt, "version", (int) sig->version)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_intstr_json(pkt, "type", sig->type(), sig_type_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     if (sig->version < PGP_V4) {
         if (!json_add(pkt, "creation time", (uint64_t) sig->creation_time)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (!json_add(pkt, "signer", sig->signer)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     if (!obj_add_intstr_json(pkt, "algorithm", sig->palg, pubkey_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_intstr_json(pkt, "hash algorithm", sig->halg, hash_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     if (sig->version >= PGP_V4) {
         json_object *subpkts = signature_dump_subpackets_json(ctx, sig);
         if (!subpkts || !json_add(pkt, "subpackets", subpkts)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
 
     if (!json_add_hex(pkt, "lbits", sig->lbits, sizeof(sig->lbits))) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     material = json_object_new_object();
     if (!material || !json_add(pkt, "material", material)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     try {
         sig->parse_material(sigmaterial);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     switch (sig->palg) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
         if (!obj_add_mpi_json(material, "s", &sigmaterial.rsa.s, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_DSA:
         if (!obj_add_mpi_json(material, "r", &sigmaterial.dsa.r, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "s", &sigmaterial.dsa.s, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_EDDSA:
@@ -1980,14 +1988,14 @@ stream_dump_signature_pkt_json(rnp_dump_ctx_t *       ctx,
     case PGP_PKA_ECDH:
         if (!obj_add_mpi_json(material, "r", &sigmaterial.ecc.r, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "s", &sigmaterial.ecc.s, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
         if (!obj_add_mpi_json(material, "r", &sigmaterial.eg.r, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "s", &sigmaterial.eg.s, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
 #if defined(ENABLE_CRYPTO_REFRESH)
@@ -2028,8 +2036,10 @@ stream_dump_signature_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *
     try {
         ret = sig.parse(*src);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         ret = RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
     if (ret) {
         return ret;
@@ -2047,33 +2057,35 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
     try {
         ret = key.parse(*src);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         ret = RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
     if (ret) {
         return ret;
     }
 
     if (!json_add(pkt, "version", (int) key.version)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!json_add(pkt, "creation time", (uint64_t) key.creation_time)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if ((key.version < PGP_V4) && !json_add(pkt, "v3 days", (int) key.v3_days)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_intstr_json(pkt, "algorithm", key.alg, pubkey_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if ((key.version == PGP_V5) &&
         !json_add(pkt, "v5 public key material length", (int) key.v5_pub_len)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     material = json_object_new_object();
     if (!material || !json_add(pkt, "material", material)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     switch (key.alg) {
@@ -2082,7 +2094,7 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
     case PGP_PKA_RSA_SIGN_ONLY:
         if (!obj_add_mpi_json(material, "n", &key.material.rsa.n, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "e", &key.material.rsa.e, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_DSA:
@@ -2090,7 +2102,7 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
             !obj_add_mpi_json(material, "q", &key.material.dsa.q, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "g", &key.material.dsa.g, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "y", &key.material.dsa.y, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_ELGAMAL:
@@ -2098,7 +2110,7 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
         if (!obj_add_mpi_json(material, "p", &key.material.eg.p, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "g", &key.material.eg.g, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "y", &key.material.eg.y, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_ECDSA:
@@ -2106,28 +2118,28 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
     case PGP_PKA_SM2: {
         const ec_curve_desc_t *cdesc = get_curve_desc(key.material.ec.curve);
         if (!obj_add_mpi_json(material, "p", &key.material.ec.p, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (!json_add(material, "curve", cdesc ? cdesc->pgp_name : "unknown")) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     }
     case PGP_PKA_ECDH: {
         const ec_curve_desc_t *cdesc = get_curve_desc(key.material.ec.curve);
         if (!obj_add_mpi_json(material, "p", &key.material.ec.p, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (!json_add(material, "curve", cdesc ? cdesc->pgp_name : "unknown")) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (!obj_add_intstr_json(
               material, "hash algorithm", key.material.ec.kdf_hash_alg, hash_alg_map)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (!obj_add_intstr_json(
               material, "key wrap algorithm", key.material.ec.key_wrap_alg, symm_alg_map)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     }
@@ -2174,41 +2186,41 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
 
     if (is_secret_key_pkt(key.tag)) {
         if (!json_add(material, "s2k usage", (int) key.sec_protection.s2k.usage)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if ((key.version == PGP_V5) &&
             !json_add(material, "v5 s2k length", (int) key.v5_s2k_len)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (!obj_add_s2k_json(material, &key.sec_protection.s2k)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (key.sec_protection.s2k.usage &&
             !obj_add_intstr_json(
               material, "symmetric algorithm", key.sec_protection.symm_alg, symm_alg_map)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if ((key.version == PGP_V5) &&
             !json_add(material, "v5 secret key data length", (int) key.v5_sec_len)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
 
     pgp_key_id_t keyid = {};
     if (pgp_keyid(keyid, key) || !json_add(pkt, "keyid", keyid)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     if (ctx->dump_grips) {
         pgp_fingerprint_t keyfp = {};
         if (pgp_fingerprint(keyfp, key) || !json_add(pkt, "fingerprint", keyfp)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
 
         pgp_key_grip_t grip;
         if (!key.material.get_grip(grip) ||
             !json_add_hex(pkt, "grip", grip.data(), grip.size())) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
     }
     return RNP_SUCCESS;
@@ -2223,7 +2235,7 @@ stream_dump_userid_json(pgp_source_t *src, json_object *pkt)
     try {
         ret = uid.parse(*src);
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
@@ -2232,12 +2244,12 @@ stream_dump_userid_json(pgp_source_t *src, json_object *pkt)
     switch (uid.tag) {
     case PGP_PKT_USER_ID:
         if (!json_add(pkt, "userid", (char *) uid.uid, uid.uid_len)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKT_USER_ATTR:
         if (!json_add_hex(pkt, "userattr", uid.uid, uid.uid_len)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     default:;
@@ -2258,7 +2270,7 @@ stream_dump_pk_session_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_obj
             ret = RNP_ERROR_BAD_FORMAT;
         }
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
@@ -2267,12 +2279,12 @@ stream_dump_pk_session_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_obj
     if (!json_add(pkt, "version", (int) pkey.version) ||
         !json_add(pkt, "keyid", pkey.key_id) ||
         !obj_add_intstr_json(pkt, "algorithm", pkey.alg, pubkey_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     json_object *material = json_object_new_object();
     if (!json_add(pkt, "material", material)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     switch (pkey.alg) {
@@ -2280,29 +2292,29 @@ stream_dump_pk_session_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_obj
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
         if (!obj_add_mpi_json(material, "m", &pkmaterial.rsa.m, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
         if (!obj_add_mpi_json(material, "g", &pkmaterial.eg.g, ctx->dump_mpi) ||
             !obj_add_mpi_json(material, "m", &pkmaterial.eg.m, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_SM2:
         if (!obj_add_mpi_json(material, "m", &pkmaterial.sm2.m, ctx->dump_mpi)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
     case PGP_PKA_ECDH:
         if (!obj_add_mpi_json(material, "p", &pkmaterial.ecdh.p, ctx->dump_mpi) ||
             !json_add(material, "m.bytes", (int) pkmaterial.ecdh.mlen)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         if (ctx->dump_mpi &&
             !json_add_hex(material, "m", pkmaterial.ecdh.m, pkmaterial.ecdh.mlen)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         break;
 #if defined(ENABLE_CRYPTO_REFRESH)
@@ -2340,7 +2352,7 @@ stream_dump_sk_session_key_json(pgp_source_t *src, json_object *pkt)
     try {
         ret = skey.parse(*src);
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
@@ -2348,20 +2360,20 @@ stream_dump_sk_session_key_json(pgp_source_t *src, json_object *pkt)
 
     if (!json_add(pkt, "version", (int) skey.version) ||
         !obj_add_intstr_json(pkt, "algorithm", skey.alg, symm_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if ((skey.version == PGP_SKSK_V5) &&
         !obj_add_intstr_json(pkt, "aead algorithm", skey.aalg, aead_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_s2k_json(pkt, &skey.s2k)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if ((skey.version == PGP_SKSK_V5) && !json_add_hex(pkt, "aead iv", skey.iv, skey.ivlen)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!json_add_hex(pkt, "encrypted key", skey.enckey, skey.enckeylen)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     return RNP_SUCCESS;
 }
@@ -2385,7 +2397,7 @@ stream_dump_encrypted_json(pgp_source_t *src, json_object *pkt, pgp_pkt_type_t t
         !obj_add_intstr_json(pkt, "aead algorithm", aead.aalg, aead_alg_map) ||
         !json_add(pkt, "chunk size", (int) aead.csize) ||
         !json_add_hex(pkt, "aead iv", aead.iv, aead.ivlen)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     return RNP_SUCCESS;
@@ -2400,29 +2412,29 @@ stream_dump_one_pass_json(pgp_source_t *src, json_object *pkt)
     try {
         ret = onepass.parse(*src);
     } catch (const std::exception &e) {
-        ret = RNP_ERROR_GENERIC;
+        ret = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
     }
     if (ret) {
         return ret;
     }
 
     if (!json_add(pkt, "version", (int) onepass.version)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_intstr_json(pkt, "type", onepass.type, sig_type_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_intstr_json(pkt, "hash algorithm", onepass.halg, hash_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!obj_add_intstr_json(pkt, "public key algorithm", onepass.palg, pubkey_alg_map)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!json_add(pkt, "signer", onepass.keyid)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     if (!json_add(pkt, "nested", (bool) onepass.nested)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     return RNP_SUCCESS;
 }
@@ -2433,7 +2445,7 @@ stream_dump_marker_json(pgp_source_t &src, json_object *pkt)
     rnp_result_t ret = stream_parse_marker(src);
 
     if (!json_add(pkt, "contents", ret ? "invalid" : PGP_MARKER_CONTENTS)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     return ret;
 }
@@ -2456,14 +2468,16 @@ stream_dump_compressed_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object 
 
     get_compressed_src_alg(&zsrc, &zalg);
     if (!obj_add_intstr_json(pkt, "algorithm", zalg, z_alg_map)) {
+        /* LCOV_EXCL_START */
         ret = RNP_ERROR_OUT_OF_MEMORY;
         goto done;
+        /* LCOV_EXCL_END */
     }
 
     ret = stream_dump_raw_packets_json(ctx, &zsrc, &contents);
     if (!ret && !json_add(pkt, "contents", contents)) {
         json_object_put(contents);
-        ret = RNP_ERROR_OUT_OF_MEMORY;
+        ret = RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 done:
     zsrc.close();
@@ -2484,7 +2498,7 @@ stream_dump_literal_json(pgp_source_t *src, json_object *pkt)
     if (!json_add(pkt, "format", (char *) &lhdr.format, 1) ||
         !json_add(pkt, "filename", (char *) lhdr.fname, lhdr.fname_len) ||
         !json_add(pkt, "timestamp", (uint64_t) lhdr.timestamp)) {
-        goto done;
+        goto done; // LCOV_EXCL_LINE
     }
 
     while (!lsrc.eof()) {
@@ -2497,7 +2511,7 @@ stream_dump_literal_json(pgp_source_t *src, json_object *pkt)
     }
 
     if (!json_add(pkt, "datalen", (uint64_t) lsrc.readb)) {
-        goto done;
+        goto done; // LCOV_EXCL_LINE
     }
     ret = RNP_SUCCESS;
 done:
@@ -2522,16 +2536,16 @@ stream_dump_hdr_json(pgp_source_t *src, pgp_packet_hdr_t *hdr, json_object *pkt)
     if (!json_add(jso_hdr, "offset", (uint64_t) src->readb) ||
         !obj_add_intstr_json(jso_hdr, "tag", hdr->tag, packet_tag_map) ||
         !json_add_hex(jso_hdr, "raw", hdr->hdr, hdr->hdr_len)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (!hdr->partial && !hdr->indeterminate &&
         !json_add(jso_hdr, "length", (uint64_t) hdr->pkt_len)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     if (!json_add(jso_hdr, "partial", hdr->partial) ||
         !json_add(jso_hdr, "indeterminate", hdr->indeterminate) ||
         !json_add(pkt, "header", jso_hdr)) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
     jso_hdrwrap.release();
     return true;
@@ -2544,7 +2558,7 @@ stream_dump_raw_packets_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object
 
     json_object *pkts = json_object_new_array();
     if (!pkts) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp::JSONObject pktswrap(pkts);
 
@@ -2582,7 +2596,7 @@ stream_dump_raw_packets_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object
                 return RNP_ERROR_READ;
             }
             if (!json_add_hex(pkt, "raw", buf + hdr.hdr_len, rlen - hdr.hdr_len)) {
-                return RNP_ERROR_OUT_OF_MEMORY;
+                return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
             }
         }
 
@@ -2650,7 +2664,7 @@ stream_dump_raw_packets_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object
         }
 
         if (json_object_array_add(pkts, pkt)) {
-            return RNP_ERROR_OUT_OF_MEMORY;
+            return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         pktwrap.release();
         if (ctx->stream_pkts > MAXIMUM_STREAM_PKTS) {

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -297,7 +297,7 @@ init_partial_pkt_src(pgp_source_t *src, pgp_source_t *readsrc, pgp_packet_hdr_t 
 {
     pgp_source_partial_param_t *param;
     if (!init_src_common(src, sizeof(*param))) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     assert(hdr.partial);
@@ -353,7 +353,7 @@ compressed_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
     pgp_source_compressed_param_t *param = (pgp_source_compressed_param_t *) src->param;
     if (!param) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
 
     if (src->eof_ || param->zend) {
@@ -457,7 +457,7 @@ compressed_src_close(pgp_source_t *src)
 {
     pgp_source_compressed_param_t *param = (pgp_source_compressed_param_t *) src->param;
     if (!param) {
-        return;
+        return; // LCOV_EXCL_LINE
     }
 
     if (param->pkt.hdr.partial) {
@@ -707,8 +707,8 @@ static bool
 encrypted_src_read_cfb(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
     pgp_source_encrypted_param_t *param = (pgp_source_encrypted_param_t *) src->param;
-    if (param == NULL) {
-        return false;
+    if (!param) {
+        return false; // LCOV_EXCL_LINE
     }
 
     if (src->eof_) {
@@ -771,8 +771,10 @@ encrypted_src_read_cfb(pgp_source_t *src, void *buf, size_t len, size_t *readres
                 param->auth_validated = true;
             }
         } catch (const std::exception &e) {
+            /* LCOV_EXCL_START */
             RNP_LOG("mdc update failed: %s", e.what());
             return false;
+            /* LCOV_EXCL_END */
         }
     }
     *readres = read;
@@ -894,8 +896,10 @@ signed_validate_signature(pgp_source_signed_param_t &param, pgp_signature_info_t
         key->validate_sig(
           sinfo, *shash, *param.handler->ctx->ctx, param.has_lhdr ? &param.lhdr : NULL);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("Signature validation failed: %s", e.what());
         sinfo.valid = false;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -935,7 +939,7 @@ signed_src_update(pgp_source_t *src, const void *buf, size_t len)
     try {
         param->hashes.add(buf, len);
     } catch (const std::exception &e) {
-        RNP_LOG("%s", e.what());
+        RNP_LOG("%s", e.what()); // LCOV_EXCL_LINE
     }
     /* update text-mode sig hashes */
     if (param->txt_hashes.hashes.empty()) {
@@ -954,7 +958,7 @@ signed_src_update(pgp_source_t *src, const void *buf, size_t len)
                     try {
                         param->txt_hashes.add(ST_CR, 1);
                     } catch (const std::exception &e) {
-                        RNP_LOG("%s", e.what());
+                        RNP_LOG("%s", e.what()); // LCOV_EXCL_LINE
                     }
                 }
                 param->stripped_crs = 0;
@@ -980,7 +984,7 @@ signed_src_update(pgp_source_t *src, const void *buf, size_t len)
                 try {
                     param->txt_hashes.add(linebeg, stripped_len);
                 } catch (const std::exception &e) {
-                    RNP_LOG("%s", e.what());
+                    RNP_LOG("%s", e.what()); // LCOV_EXCL_LINE
                 }
             }
         }
@@ -988,7 +992,7 @@ signed_src_update(pgp_source_t *src, const void *buf, size_t len)
         try {
             param->txt_hashes.add(ST_CRLF, 2);
         } catch (const std::exception &e) {
-            RNP_LOG("%s", e.what());
+            RNP_LOG("%s", e.what()); // LCOV_EXCL_LINE
         }
         ch++;
         linebeg = ch;
@@ -1003,7 +1007,7 @@ signed_src_update(pgp_source_t *src, const void *buf, size_t len)
             try {
                 param->txt_hashes.add(linebeg, stripped_len);
             } catch (const std::exception &e) {
-                RNP_LOG("%s", e.what());
+                RNP_LOG("%s", e.what()); // LCOV_EXCL_LINE
             }
         }
     }
@@ -1023,9 +1027,6 @@ static void
 signed_src_close(pgp_source_t *src)
 {
     pgp_source_signed_param_t *param = (pgp_source_signed_param_t *) src->param;
-    if (!param) {
-        return;
-    }
     delete param;
     src->param = NULL;
 }
@@ -1073,8 +1074,10 @@ signed_read_single_signature(pgp_source_signed_param_t *param,
         }
         return RNP_SUCCESS;
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -1091,11 +1094,15 @@ signed_read_cleartext_signatures(pgp_source_t &src, pgp_source_signed_param_t *p
         }
         return RNP_SUCCESS;
     } catch (const rnp::rnp_exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return e.code();
+        /* LCOV_EXCL_END */
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return RNP_ERROR_BAD_FORMAT;
+        /* LCOV_EXCL_END */
     }
 }
 
@@ -1248,8 +1255,10 @@ cleartext_parse_headers(pgp_source_signed_param_t *param)
                 RNP_LOG("unknown header '%s'", hdr);
             }
         } catch (const std::exception &e) {
+            /* LCOV_EXCL_START */
             RNP_LOG("%s", e.what());
             return false;
+            /* LCOV_EXCL_END */
         }
 
         param->readsrc->skip(hdrlen);
@@ -1293,8 +1302,10 @@ cleartext_process_line(pgp_source_t *src, const uint8_t *buf, size_t len, bool e
     }
 
     if (len + param->outlen > sizeof(param->out)) {
+        /* LCOV_EXCL_START */
         RNP_LOG("wrong state");
         return;
+        /* LCOV_EXCL_END */
     }
 
     /* if we have eol after this line then strip trailing spaces and tabs */
@@ -1317,7 +1328,7 @@ cleartext_src_read(pgp_source_t *src, void *buf, size_t len, size_t *readres)
 {
     pgp_source_signed_param_t *param = (pgp_source_signed_param_t *) src->param;
     if (!param) {
-        return false;
+        return false; // LCOV_EXCL_LINE
     }
 
     uint8_t  srcb[CT_BUF_LEN];
@@ -1456,8 +1467,10 @@ encrypted_decrypt_cfb_header(pgp_source_encrypted_param_t *param,
         param->mdc = rnp::Hash::create(PGP_HASH_SHA1);
         param->mdc->add(dechdr, blsize + 2);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("cannot create sha1 hash: %s", e.what());
         goto error;
+        /* LCOV_EXCL_END */
     }
     return true;
 error:
@@ -1556,8 +1569,10 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
             return false;
         }
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return false;
+        /* LCOV_EXCL_END */
     }
 
 #if defined(ENABLE_CRYPTO_REFRESH)
@@ -1634,8 +1649,10 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
         }
         pgp_fingerprint_t fingerprint;
         if (pgp_fingerprint(fingerprint, *seckey)) {
+            /* LCOV_EXCL_START */
             RNP_LOG("ECDH fingerprint calculation failed");
             return false;
+            /* LCOV_EXCL_END */
         }
         if ((keymaterial->ec.curve == PGP_CURVE_25519) &&
             !x25519_bits_tweaked(keymaterial->ec)) {
@@ -1644,7 +1661,7 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
         declen = decbuf.size();
         err = ecdh_decrypt_pkcs5(
           decbuf.data(), &declen, &encmaterial.ecdh, &keymaterial->ec, fingerprint);
-        if (err != RNP_SUCCESS) {
+        if (err) {
             RNP_LOG("ECDH decryption error %u", err);
             return false;
         }
@@ -1950,7 +1967,7 @@ init_literal_src(pgp_source_t *src, pgp_source_t *readsrc)
     uint8_t                     timestamp[4];
 
     if (!init_src_common(src, sizeof(*param))) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     param = (pgp_source_literal_param_t *) src->param;
@@ -2017,7 +2034,7 @@ init_literal_src(pgp_source_t *src, pgp_source_t *readsrc)
     }
     ret = RNP_SUCCESS;
 finish:
-    if (ret != RNP_SUCCESS) {
+    if (ret) {
         src->close();
     }
     return ret;
@@ -2038,7 +2055,7 @@ init_compressed_src(pgp_source_t *src, pgp_source_t *readsrc)
     int                            zret;
 
     if (!init_src_common(src, sizeof(*param))) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
 
     param = (pgp_source_compressed_param_t *) src->param;
@@ -2236,11 +2253,15 @@ encrypted_read_packet_data(pgp_source_encrypted_param_t *param)
             }
         }
     } catch (const rnp::rnp_exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s: %d", e.what(), e.code());
         return e.code();
+        /* LCOV_EXCL_END */
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return RNP_ERROR_GENERIC;
+        /* LCOV_EXCL_END */
     }
 
     /* Reading packet length/checking whether it is partial */
@@ -2354,11 +2375,11 @@ static rnp_result_t
 init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *readsrc)
 {
     if (!init_src_common(src, 0)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     pgp_source_encrypted_param_t *param = new (std::nothrow) pgp_source_encrypted_param_t();
     if (!param) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     src->param = param;
     param->pkt.readsrc = readsrc;
@@ -2384,9 +2405,11 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
 
     /* Obtaining the symmetric key */
     if (!handler->password_provider) {
+        /* LCOV_EXCL_START */
         RNP_LOG("no password provider");
         errcode = RNP_ERROR_BAD_PARAMETERS;
         goto finish;
+        /* LCOV_EXCL_END */
     }
 
     /* informing handler about the available pubencs/symencs */
@@ -2399,9 +2422,11 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
     /* Trying public-key decryption */
     if (!param->pubencs.empty()) {
         if (!handler->key_provider) {
+            /* LCOV_EXCL_START */
             RNP_LOG("no key provider");
             errcode = RNP_ERROR_BAD_PARAMETERS;
             goto finish;
+            /* LCOV_EXCL_END */
         }
 
         size_t pubidx = 0;
@@ -2558,13 +2583,15 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
     size_t                     sigerrors = 0;
 
     if (!init_src_common(src, 0)) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     try {
         param = new pgp_source_signed_param_t();
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     src->param = param;
 
@@ -2580,9 +2607,11 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
 
     /* we need key provider to validate signatures */
     if (!handler->key_provider) {
+        /* LCOV_EXCL_START */
         RNP_LOG("no key provider");
         errcode = RNP_ERROR_BAD_PARAMETERS;
         goto finish;
+        /* LCOV_EXCL_END */
     }
 
     if (cleartext) {
@@ -2618,7 +2647,7 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
             try {
                 errcode = onepass.parse(*readsrc);
             } catch (const std::exception &e) {
-                errcode = RNP_ERROR_GENERIC;
+                errcode = RNP_ERROR_GENERIC; // LCOV_EXCL_LINE
             }
             if (errcode) {
                 if (errcode == RNP_ERROR_READ) {
@@ -2635,9 +2664,11 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
             try {
                 param->onepasses.push_back(onepass);
             } catch (const std::exception &e) {
+                /* LCOV_EXCL_START */
                 RNP_LOG("%s", e.what());
                 errcode = RNP_ERROR_OUT_OF_MEMORY;
                 goto finish;
+                /* LCOV_EXCL_END */
             }
 
             /* adding hash context */
@@ -2789,9 +2820,11 @@ init_packet_sequence(pgp_processing_ctx_t &ctx, pgp_source_t &src)
             ctx.sources.push_back(psrc);
             lsrc = &ctx.sources.back();
         } catch (const std::exception &e) {
+            /* LCOV_EXCL_START */
             psrc.close();
             RNP_LOG("%s", e.what());
             return RNP_ERROR_OUT_OF_MEMORY;
+            /* LCOV_EXCL_END */
         }
 
         if (lsrc->type == PGP_STREAM_LITERAL) {
@@ -2822,9 +2855,11 @@ init_cleartext_sequence(pgp_processing_ctx_t &ctx, pgp_source_t &src)
     try {
         ctx.sources.push_back(clrsrc);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         clrsrc.close();
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     return RNP_SUCCESS;
 }
@@ -2842,9 +2877,11 @@ init_armored_sequence(pgp_processing_ctx_t &ctx, pgp_source_t &src)
     try {
         ctx.sources.push_back(armorsrc);
     } catch (const std::exception &e) {
+        /* LCOV_EXCL_START */
         RNP_LOG("%s", e.what());
         armorsrc.close();
         return RNP_ERROR_OUT_OF_MEMORY;
+        /* LCOV_EXCL_END */
     }
     return init_packet_sequence(ctx, ctx.sources.back());
 }
@@ -2884,10 +2921,12 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t &src)
         goto finish;
     }
 
-    if ((readbuf = (uint8_t *) calloc(1, PGP_INPUT_CACHE_SIZE)) == NULL) {
+    if (!(readbuf = (uint8_t *) calloc(1, PGP_INPUT_CACHE_SIZE))) {
+        /* LCOV_EXCL_START */
         RNP_LOG("allocation failure");
         res = RNP_ERROR_OUT_OF_MEMORY;
         goto finish;
+        /* LCOV_EXCL_END */
     }
 
     if (ctx.msg_type == PGP_MESSAGE_DETACHED) {
@@ -2960,7 +2999,7 @@ process_pgp_source(pgp_parse_handler_t *handler, pgp_source_t &src)
     }
 
     /* finalizing the input. Signatures are checked on this step */
-    if (res == RNP_SUCCESS) {
+    if (!res) {
         for (auto &ctxsrc : ctx.sources) {
             fres = ctxsrc.finish();
             if (fres) {

--- a/src/tests/ffi-key-sig.cpp
+++ b/src/tests/ffi-key-sig.cpp
@@ -303,8 +303,6 @@ TEST_F(rnp_tests, test_ffi_import_signatures)
     assert_false(revoked);
     /* some import edge cases */
     assert_rnp_failure(rnp_import_signatures(ffi, NULL, 0, &results));
-    assert_rnp_failure(rnp_import_signatures(NULL, input, 0, &results));
-    assert_rnp_failure(rnp_import_signatures(ffi, input, 0x18, &results));
     /* import revocation signature */
     json_object *jso = NULL;
     json_object *jsosigs = NULL;
@@ -342,6 +340,8 @@ TEST_F(rnp_tests, test_ffi_import_signatures)
     assert_int_equal(till, 1578663151);
     /* check import with NULL results param */
     assert_rnp_success(rnp_input_from_path(&input, "data/test_key_validity/alice-rev.pgp"));
+    assert_rnp_failure(rnp_import_signatures(NULL, input, 0, &results));
+    assert_rnp_failure(rnp_import_signatures(ffi, input, 0x18, &results));
     assert_rnp_success(rnp_import_signatures(ffi, input, 0, NULL));
     assert_rnp_success(rnp_input_destroy(input));
     /* import signature again, making sure it is not duplicated */
@@ -1355,6 +1355,7 @@ TEST_F(rnp_tests, test_ffi_remove_signatures)
     assert_rnp_failure(rnp_key_remove_signatures(NULL, RNP_KEY_SIGNATURE_INVALID, NULL, NULL));
     assert_rnp_failure(rnp_key_remove_signatures(NULL, 0, NULL, NULL));
     assert_rnp_failure(rnp_key_remove_signatures(key, 0, NULL, ffi));
+    assert_rnp_failure(rnp_key_remove_signatures(key, 0x77, NULL, ffi));
     /* remove unknown signatures */
     assert_rnp_success(
       rnp_key_remove_signatures(key, RNP_KEY_SIGNATURE_UNKNOWN_KEY, NULL, NULL));


### PR DESCRIPTION
...to make codecov happy. Most of those code lines could never hit (like allocation failure) and are left only to gently handle unexpected conditions.