### PR TITLE
Fix for ML-KEM PKESK and adding PQC CLI tests

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -104,7 +104,7 @@ typedef uint32_t rnp_result_t;
  * Flags for default key selection.
  */
 #define RNP_KEY_SUBKEYS_ONLY (1U << 0)
-#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
+#if defined(RNP_EXPERIMENTAL_PQC)
 #define RNP_KEY_PREFER_PQC_ENC_SUBKEY (1U << 1)
 #endif
 

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -104,6 +104,9 @@ typedef uint32_t rnp_result_t;
  * Flags for default key selection.
  */
 #define RNP_KEY_SUBKEYS_ONLY (1U << 0)
+#if defined(RNP_EXPERIMENTAL_CRYPTO_REFRESH)
+#define RNP_KEY_PREFER_PQC_ENC_SUBKEY (1U << 1)
+#endif
 
 /**
  * User id type
@@ -2349,6 +2352,9 @@ RNP_API rnp_result_t rnp_key_get_subkey_at(rnp_key_handle_t  key,
  *  @param flags possible values:  RNP_KEY_SUBKEYS_ONLY - select only subkeys,
  *               otherwise if flags is 0, primary key can be returned if
  *               it is suitable for specified usage.
+ *               Note: If RNP_EXPERIMENTAL_PQC is set, then the flag
+ *               RNP_KEY_PREFER_PQC_ENC_SUBKEY can be used to prefer PQC-encryption subkeys
+ *               over non-PQC-encryption subkeys
  *  @param default_key on success resulting key handle will be stored here, otherwise it
  *                     will contain NULL value. You must free this handle after use with
  *                     rnp_key_handle_destroy().
@@ -3613,6 +3619,18 @@ RNP_API rnp_result_t rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_h
  * @return RNP_SUCCESS or errorcode if failed.
  */
 RNP_API rnp_result_t rnp_op_encrypt_enable_pkesk_v6(rnp_op_encrypt_t op);
+#endif
+
+#if defined(RNP_EXPERIMENTAL_PQC)
+/**
+ * @brief Prefer using PQC subkeys over non-PQC subkeys when encrypting.
+ *        NOTE: This is an experimental feature and this function can be replaced (or removed)
+ *        at any time.
+ *
+ * @param op opaque encrypting context. Must be allocated and initialized.
+ * @return RNP_SUCCESS or errorcode if failed.
+ */
+RNP_API rnp_result_t rnp_op_encrypt_prefer_pqc_enc_subkey(rnp_op_encrypt_t op);
 #endif
 
 /**

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -691,6 +691,7 @@ bool pgp_subkey_set_expiration(pgp_key_t *                    sub,
 pgp_key_t *find_suitable_key(pgp_op_t          op,
                              pgp_key_t *       key,
                              rnp::KeyProvider *key_provider,
-                             bool              no_primary = false);
+                             bool              no_primary = false,
+                             bool              pref_pqc_sub = false);
 
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -229,6 +229,9 @@ struct pgp_key_t {
     bool             can_certify() const noexcept;
     bool             can_encrypt() const noexcept;
     bool             has_secret() const noexcept;
+#if defined(ENABLE_PQC)
+    bool is_pqc_alg() const;
+#endif
     /**
      * @brief Check whether key is usable for the specified operation.
      *

--- a/src/librepgp/stream-ctx.h
+++ b/src/librepgp/stream-ctx.h
@@ -111,7 +111,7 @@ typedef struct rnp_ctx_t {
 #if defined(ENABLE_CRYPTO_REFRESH)
     bool enable_pkesk_v6{}; /* allows pkesk v6 if list of recipients is suitable */
 #endif
-#if defined(ENABLE_CRYPTO_REFRESH)
+#if defined(ENABLE_PQC)
     bool pref_pqc_enc_subkey{}; /* prefer to encrypt to PQC subkey */
 #endif
     std::list<pgp_key_t *> recipients{};              /* recipients of the encrypted message */

--- a/src/librepgp/stream-ctx.h
+++ b/src/librepgp/stream-ctx.h
@@ -70,8 +70,10 @@ typedef struct rnp_symmetric_pass_info_t {
  *  - halg : hash algorithm used during key derivation for password-based encryption
  *  - ealg, aalg, abits : symmetric encryption algorithm and AEAD parameters if used
  *  - recipients : list of key ids used to encrypt data to
- *  - enable_pkesk_v6 : if true and each recipient in the  list of recipients has the
- * capability, allows PKESKv5/SEIPDv2
+ *  - enable_pkesk_v6 (Only if defined: ENABLE_CRYPTO_REFRESH): if true and each recipient in
+ * the  list of recipients has the capability, allows PKESKv6/SEIPDv2
+ *  - pref_pqc_enc_subkey (Only if defined: ENABLE_PQC): if true, prefers PQC subkey over
+ * non-PQC subkey for encryption.
  *  - passwords : list of passwords used for password-based encryption
  *  - filename, filemtime, zalg, zlevel : see previous
  *  - pkeskv6_capable() : returns true if all keys support PKESKv6+SEIPDv2, false otherwise
@@ -108,6 +110,9 @@ typedef struct rnp_ctx_t {
     bool           no_wrap{};   /* do not wrap source in literal data packet */
 #if defined(ENABLE_CRYPTO_REFRESH)
     bool enable_pkesk_v6{}; /* allows pkesk v6 if list of recipients is suitable */
+#endif
+#if defined(ENABLE_CRYPTO_REFRESH)
+    bool pref_pqc_enc_subkey{}; /* prefer to encrypt to PQC subkey */
 #endif
     std::list<pgp_key_t *> recipients{};              /* recipients of the encrypted message */
     std::list<rnp_symmetric_pass_info_t> passwords{}; /* passwords to encrypt message */

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -1373,14 +1373,17 @@ pgp_pk_sesskey_t::write_material(const pgp_encrypted_material_t &material)
         FALLTHROUGH_STATEMENT;
     case PGP_PKA_KYBER768_BP256:
         FALLTHROUGH_STATEMENT;
-    case PGP_PKA_KYBER1024_BP384:
+    case PGP_PKA_KYBER1024_BP384: {
         pktbody.add(material.kyber_ecdh.composite_ciphertext);
-        pktbody.add_byte(static_cast<uint8_t>(material.kyber_ecdh.wrapped_sesskey.size()) + 1);
+        uint8_t opt_salg_length = (version == PGP_PKSK_V3) ? 1 : 0;
+        pktbody.add_byte(static_cast<uint8_t>(material.kyber_ecdh.wrapped_sesskey.size()) +
+                         opt_salg_length);
         if (version == PGP_PKSK_V3) {
             pktbody.add_byte(salg); /* added as plaintext */
         }
         pktbody.add(material.kyber_ecdh.wrapped_sesskey);
         break;
+    }
 #endif
     default:
         RNP_LOG("Unknown pk alg: %d", (int) alg);

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -328,8 +328,10 @@ def rnp_genkey_rsa(userid, bits=2048, pswd=PASSWORD):
     if ret != 0:
         raise_err('rsa key generation failed', err)
 
-def rnp_genkey_pqc(userid, algo_cli_nr, pswd=PASSWORD):
+def rnp_genkey_pqc(userid, algo_cli_nr, algo_param = None, pswd=PASSWORD):
     algo_pipe = str(algo_cli_nr)
+    if algo_param:
+        algo_pipe += "\n" + str(algo_param)
     ret, _, err = run_proc(RNPK, ['--homedir', RNPDIR, '--password', pswd,
                                   '--notty', '--userid', userid, '--generate-key', '--expert'], algo_pipe)
     #os.close(algo_pipe)
@@ -4619,12 +4621,13 @@ class Encryption(unittest.TestCase):
     """
     def test_zzz_encryption_and_signing_pqc(self):
         USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign31@rnp','enc-sign32@rnp','enc-sign33@rnp','enc-sign34@rnp']
-        ALGO = [25, 27, 28, 29, 30, 31, 32, 33, 34,]
+        ALGO = [      25,   27,   28,   29,   30,   31,   32,  ]
+        ALGO_PARAM = [None, None, None, None, None, 1,    6, ]
         passwds = [ ]
         for x in range(len(ALGO)): passwds.append('testpw' if x % 1 == 0 else '')
         # Generate multiple keys and import to GnuPG
-        for uid, algo, passwd in zip(USERIDS, ALGO, passwds):
-            rnp_genkey_pqc(uid, algo, passwd)
+        for uid, algo, param, passwd in zip(USERIDS, ALGO, ALGO_PARAM, passwds):
+            rnp_genkey_pqc(uid, algo, param, passwd)
 
         #gpg_import_pubring()
         #gpg_import_secring()

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4620,9 +4620,11 @@ class Encryption(unittest.TestCase):
     def test_zzz_encryption_and_signing_pqc(self):
         USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign31@rnp','enc-sign32@rnp','enc-sign33@rnp','enc-sign34@rnp']
         ALGO = [25, 27, 28, 29, 30, 31, 32, 33, 34,]
+        passwds = [ ]
+        for x in range(len(ALGO)): passwds.append('testpw' if x % 1 == 0 else '')
         # Generate multiple keys and import to GnuPG
-        for uid, algo in zip(USERIDS, ALGO):
-            rnp_genkey_pqc(uid, algo, 'testpw')
+        for uid, algo, passwd in zip(USERIDS, ALGO, passwds):
+            rnp_genkey_pqc(uid, algo, passwd)
 
         #gpg_import_pubring()
         #gpg_import_secring()
@@ -4638,11 +4640,12 @@ class Encryption(unittest.TestCase):
             #keynum, pswdnum = KEYPSWD[i]
             recipients = [USERIDS[i]]
             passwords = [] # SKESK for v6 not yet supported
+            signerpws = [passwds[i]]
 
             rnp_encrypt_and_sign_file(src, dst, recipients, passwords, signers,
-                                      ['testpw'])
+                                      signerpws)
             # Decrypt file with each of the keys, we have different password for each key
-            rnp_decrypt_file(dst, dec, 'testpw')
+            rnp_decrypt_file(dst, dec, passwds[i])
             remove_files(dec)
 
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4628,7 +4628,8 @@ class Encryption(unittest.TestCase):
             return
         USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign32a@rnp','enc-sign32b@rnp','enc-sign32c@rnp','enc-sign24-v4-key@rnp']
 
-        # '24' in the below array creates a v4 primary signature key with a v4 pqc subkey without a Features Subpacket. This way we test PQC encryption to a v4 subkey.
+        # '24' in the below array creates a v4 primary signature key with a v4 pqc subkey without a Features Subpacket. This way we test PQC encryption to a v4 subkey. RNP prefers the PQC subkey in case of a certificate having a PQC and a
+        # non-PQC subkey.
         ALGO       = [25,   27,   28,   29,   30,   32, 32, 32, 24, ]
         ALGO_PARAM = [None, None, None, None, None, 1,  2,  6,  None,  ]
         passwds = [ ]

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4626,13 +4626,15 @@ class Encryption(unittest.TestCase):
     def test_zzz_encryption_and_signing_pqc(self):
         if not RNP_PQC:
             return
-        USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign31@rnp','enc-sign32@rnp','enc-sign33@rnp','enc-sign34@rnp', 'enc-sign24-v4-key@rnp']
+        USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign32a@rnp','enc-sign32b@rnp','enc-sign32c@rnp','enc-sign24-v4-key@rnp']
 
         # '24' in the below array creates a v4 primary signature key with a v4 pqc subkey without a Features Subpacket. This way we test PQC encryption to a v4 subkey.
         ALGO       = [25,   27,   28,   29,   30,   32, 32, 32, 24, ]
         ALGO_PARAM = [None, None, None, None, None, 1,  2,  6,  None,  ]
         passwds = [ ]
         for x in range(len(ALGO)): passwds.append('testpw' if x % 1 == 0 else '')
+        if any(len(USERIDS) != len(x) for x in [ALGO, ALGO_PARAM]):
+            raise  RuntimeError("test_zzz_encryption_and_signing_pqc: internal error: lengths of test data arrays matching")
         # Generate multiple keys and import to GnuPG
         for uid, algo, param, passwd in zip(USERIDS, ALGO, ALGO_PARAM, passwds):
             rnp_genkey_pqc(uid, algo, param, passwd)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4622,7 +4622,7 @@ class Encryption(unittest.TestCase):
             remove_files(dst, dec)
 
 
-    def verify_pqc_algo_ui_nb_to_algo_ui_str(self, stdout: str, algo_ui_exp_strs: list[str]) -> None:
+    def verify_pqc_algo_ui_nb_to_algo_ui_str(self, stdout: str, algo_ui_exp_strs) -> None:
         stdout_lines = stdout.split('\n')
         for expected_line in algo_ui_exp_strs:
             found_this_entry : bool = False

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -332,12 +332,11 @@ def rnp_genkey_pqc(userid, algo_cli_nr, algo_param = None, pswd=PASSWORD):
     algo_pipe = str(algo_cli_nr)
     if algo_param:
         algo_pipe += "\n" + str(algo_param)
-    ret, output, errout = run_proc(RNPK, ['--homedir', RNPDIR, '--password', pswd,
+    ret, _, err = run_proc(RNPK, ['--homedir', RNPDIR, '--password', pswd,
                                   '--notty', '--userid', userid, '--generate-key', '--expert'], algo_pipe)
     #os.close(algo_pipe)
     if ret != 0:
-        raise_err('pqc key generation failed', errout)
-    return output
+        raise_err('pqc key generation failed', err)
 
 def rnp_params_insert_z(params, pos, z):
     if z:
@@ -4628,23 +4627,16 @@ class Encryption(unittest.TestCase):
         if not RNP_PQC:
             return
         USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign31@rnp','enc-sign32@rnp','enc-sign33@rnp','enc-sign34@rnp', 'enc-sign24-v4-key@rnp']
+
+        # '24' in the below array creates a v4 primary signature key with a v4 pqc subkey without a Features Subpacket. This way we test PQC encryption to a v4 subkey.
         ALGO       = [25,   27,   28,   29,   30,   32, 32, 32, 24, ]
-        # '24' in the above array creates a v4 primary signature key with a v4 pqc subkey without a Features Subpacket. This way we test PQC encryption to a v4 subkey.
         ALGO_PARAM = [None, None, None, None, None, 1,  2,  6,  None,  ]
         passwds = [ ]
-        pqc_subkey_ids = [ ]
         for x in range(len(ALGO)): passwds.append('testpw' if x % 1 == 0 else '')
         # Generate multiple keys and import to GnuPG
         for uid, algo, param, passwd in zip(USERIDS, ALGO, ALGO_PARAM, passwds):
-            output = rnp_genkey_pqc(uid, algo, param, passwd)
-            # parse output for PQC encryption subkey
-            pqc_enc_subkey_match = re.search(r'ssb * [0-9]+/ML-KEM-[0-9]+\+[^ ]* *([0-9a-fA-F]+)', output)
-            if pqc_enc_subkey_match:
-                pqc_subkey_ids.append(pqc_enc_subkey_match.group(1))
-                print("appended  found PQC subkey id = " + str(pqc_subkey_ids[-1]))
-            else:
-                pqc_subkey_ids.append(None)
-            # TODO: use pqc_enc_subkey_match during encryption call
+            rnp_genkey_pqc(uid, algo, param, passwd)
+
         #gpg_import_pubring()
         #gpg_import_secring()
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -409,7 +409,6 @@ def rnp_encrypt_and_sign_file(src, dst, recipients, encrpswd, signers, signpswd,
     if ret != 0:
         raise_err('rnp encrypt-and-sign failed', err)
 
-
 def rnp_decrypt_file(src, dst, password = PASSWORD):
     pipe = pswd_pipe(password)
     ret, out, err = run_proc(

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -335,8 +335,6 @@ def rnp_genkey_pqc(userid, algo_cli_nr, pswd=PASSWORD):
     #os.close(algo_pipe)
     if ret != 0:
         raise_err('pqc key generation failed', err)
-    else:
-        print("genkey PQC successful")
 
 def rnp_params_insert_z(params, pos, z):
     if z:
@@ -4623,11 +4621,8 @@ class Encryption(unittest.TestCase):
         USERIDS = ['enc-sign25@rnp', 'enc-sign27@rnp', 'enc-sign28@rnp', 'enc-sign29@rnp', 'enc-sign30@rnp','enc-sign31@rnp','enc-sign32@rnp','enc-sign33@rnp','enc-sign34@rnp']
         ALGO = [25, 27, 28, 29, 30, 31, 32, 33, 34,]
         # Generate multiple keys and import to GnuPG
-        print("starting pqc sign / encrypt tests")
         for uid, algo in zip(USERIDS, ALGO):
-            print("    generating pqc key...")
             rnp_genkey_pqc(uid, algo, 'testpw')
-            print("    ... done")
 
         #gpg_import_pubring()
         #gpg_import_secring()
@@ -4653,7 +4648,6 @@ class Encryption(unittest.TestCase):
 
 
             remove_files(dst, dec)
-        print("finished pqc sign / encrypt tests")
 
     def test_encryption_weird_userids_special_1(self):
         uid = WEIRD_USERID_SPECIAL_CHARS

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -4632,8 +4632,10 @@ class Encryption(unittest.TestCase):
         # non-PQC subkey.
         ALGO       = [25,   27,   28,   29,   30,   32, 32, 32, 24, ]
         ALGO_PARAM = [None, None, None, None, None, 1,  2,  6,  None,  ]
+        aead_list = []
         passwds = [ ]
         for x in range(len(ALGO)): passwds.append('testpw' if x % 1 == 0 else '')
+        for x in range(len(ALGO)): aead_list.append(None if x % 3 == 0 else ('ocb' if x % 3 == 1 else 'eax' ))
         if any(len(USERIDS) != len(x) for x in [ALGO, ALGO_PARAM]):
             raise  RuntimeError("test_zzz_encryption_and_signing_pqc: internal error: lengths of test data arrays matching")
         # Generate multiple keys and import to GnuPG
@@ -4657,7 +4659,7 @@ class Encryption(unittest.TestCase):
             signerpws = [passwds[i]]
 
             rnp_encrypt_and_sign_file(src, dst, recipients, passwords, signers,
-                                      signerpws)
+                                      signerpws, aead=[aead_list[i]])
             # Decrypt file with each of the keys, we have different password for each key
             rnp_decrypt_file(dst, dec, passwds[i])
             remove_files(dec)


### PR DESCRIPTION
Fix for ML-KEM PKESK decryption failure.

Added PQC CLI tests that are executed only for RNP build that supports PQC.