### PR TITLE
Update windows-native runner to windows-2022

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -123,6 +123,15 @@ jobs:
           echo "VCPKG_DIR_U=$dir_u" >> $GITHUB_ENV
           vcpkg install --triplet ${{ matrix.arch.triplet }} bzip2 zlib json-c getopt dirent ${{ matrix.backend }}
 
+      - name: Upload vcpkg logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcpkg-error-logs
+          path: |
+            C:\vcpkg\buildtrees\*\*.log
+            C:\vcpkg\installed\vcpkg\issue_body.md
+
       - name: Set OPENSSL_ROOT_DIR
         # Ensure consistent access to openssl installation for test_backend_version test
         # There is another one instance of ssl at /mingw and /mingw/bin is always at the first position at PATH

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Ribose Inc.
+# Copyright (c) 2023-2024 Ribose Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -65,21 +65,21 @@ env:
 
 jobs:
   build_and_test:
-    name: Windows-2019 [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
-    runs-on: windows-2019
+    name: Windows-2022 [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
+    runs-on: windows-2022
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       fail-fast: false
       matrix:
         arch: [ { name: 'x64',    triplet: 'x64-windows' } ]
-        toolset: [ 'v142',  'ClangCL' ]
+        toolset: [ 'v143',  'ClangCL' ]
         backend: [ 'botan', 'openssl' ]
         shared_libs: [ 'off']
         use_cmake_prefix_path: [ 'on', 'off' ]
         sanitizers: [ 'off' ]
         include:
           - arch:  { name: 'x64',    triplet: 'x64-windows' }
-            toolset:                'v142'
+            toolset:                'v143'
             backend:                'botan'
             use_cmake_prefix_path:  'off'
             shared_libs:            'off'
@@ -91,7 +91,7 @@ jobs:
             shared_libs:            'off'
             sanitizers:             'off'
           - arch:  { name: 'Win32',  triplet: 'x86-windows' }
-            toolset:                'v142'
+            toolset:                'v143'
             backend:                'openssl'
             use_cmake_prefix_path:  'off'
             shared_libs:            'off'
@@ -157,12 +157,12 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
-          cmake -B build   -G "Visual Studio 16 2019"  \
+          cmake -B build   -G "Visual Studio 17 2022"  \
                            -A ${{ matrix.arch.name }}  \
                            -T ${{ matrix.toolset }}    \
-                           -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}}            \
+                           -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}} \
                            -DENABLE_SANITIZERS=${{ matrix.sanitizers }} \
-                           -DCRYPTO_BACKEND=${{ matrix.backend }}                  \
+                           -DCRYPTO_BACKEND=${{ matrix.backend }}       \
                            -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DIR }}/scripts/buildsystems/vcpkg.cmake .
 
       - name: Configure using CMake prefix path
@@ -171,12 +171,12 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
-          cmake -B build   -G "Visual Studio 16 2019"  \
+          cmake -B build   -G "Visual Studio 17 2022"  \
                            -A ${{ matrix.arch.name }}  \
                            -T ${{ matrix.toolset }}    \
-                           -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}}            \
+                           -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}} \
                            -DENABLE_SANITIZERS=${{ matrix.sanitizers }} \
-                           -DCRYPTO_BACKEND=${{ matrix.backend }}                  \
+                           -DCRYPTO_BACKEND=${{ matrix.backend }}       \
                            -DCMAKE_PREFIX_PATH=${{ env.VCPKG_DIR }}/installed/${{ matrix.arch.triplet }} .
 
       - name: Build
@@ -193,6 +193,11 @@ jobs:
         # ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure
         run: |
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
+          if [[ "${{ matrix.sanitizers }}" == "on" ]]; then
+            # Since VS 2022 we need to add path to sanitizers lib to PATH to load it. Currently it is hardcoded for toolset v143.
+            lib_dir=$(cygpath -u "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\bin\Hostx64\x64")
+            export PATH=$lib_dir:$PATH
+          fi
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure


### PR DESCRIPTION
Due to update from Botan 3.3.0 to 3.5.0 windows-2019 runner started causing problems (https://github.com/microsoft/vcpkg/issues/40276).
So it's time to update to windows-2022, another point is that windows-2025 would become available soon.