### PR TITLE
fix key hashing for v5 / v6 signatures

### DIFF
--- a/src/lib/fingerprint.cpp
+++ b/src/lib/fingerprint.cpp
@@ -63,7 +63,7 @@ try {
     {
         auto halg = key.version == PGP_V4 ? PGP_HASH_SHA1 : PGP_HASH_SHA256;
         auto hash = rnp::Hash::create(halg);
-        signature_hash_key(key, *hash);
+        signature_hash_key(key, *hash, key.version);
         fp.length = hash->finish(fp.fingerprint);
         return RNP_SUCCESS;
     }

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -452,8 +452,10 @@ typedef struct pgp_signature_info_t {
  *        Throws exception on error.
  * @param key key packet, must be populated
  * @param hash initialized hash context
+ * @param pgpver for fingerprint calculation, the key version is required,
+ * otherwise the signature version is required
  */
-void signature_hash_key(const pgp_key_pkt_t &key, rnp::Hash &hash);
+void signature_hash_key(const pgp_key_pkt_t &key, rnp::Hash &hash, pgp_version_t pgpver);
 
 void signature_hash_userid(const pgp_userid_pkt_t &uid, rnp::Hash &hash, pgp_version_t sigver);
 


### PR DESCRIPTION
Justus pointed out that the hashing of keys is implemented incorrectly for RNP and some other implementations, see https://mailarchive.ietf.org/arch/msg/openpgp/PyP-XDv0VM5bYPX1Iq41-Oyytds/
This concerns computing v5 and v6 signatures over keys.

This PR fixes that. I separated signature and fingerprint computation logically, but the same code is used in the background. I also added a check that we don't accidently hash too large a key.