### PR TITLE
CI: Set codepage to utf-8 for msys2 tests run.

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -127,6 +127,14 @@ jobs:
 
       - name: Test
         run: |
+          # Add mt.exe (manifest tool) to the PATH
+          win_sdk=$(reg query "HKLM\SOFTWARE\Microsoft\Windows Kits\Installed Roots" | sort -r | head -n 1 | sed 's/.*\\//')
+          echo "Windows SDK: $win_sdk"
+          export PATH="/c/Program Files (x86)/Windows Kits/10/bin/$win_sdk/x64/":$PATH
+          # Add manifest which forces utf-8 encoding
+          for exe in "tests/rnp_tests" "rnp/rnp" "rnpkeys/rnpkeys"; do
+            mt.exe -manifest ./ci/utf8-manifest "-outputresource:./build/src/${exe}.exe;1" > /dev/null
+          done
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"

--- a/ci/utf8-manifest
+++ b/ci/utf8-manifest
@@ -1,0 +1,7 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings"> 
+      <activeCodePage>UTF-8</activeCodePage> 
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
Details on why this happened: https://github.com/msys2/MINGW-packages/issues/22462#issuecomment-2465927832
