### PR TITLE
Fixed conversion between utf-8 and utf-16 for Windows build

### DIFF
--- a/src/common/str-utils.cpp
+++ b/src/common/str-utils.cpp
@@ -185,14 +185,14 @@ is_slash(char c)
 std::wstring
 wstr_from_utf8(const char *s)
 {
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8conv;
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8conv;
     return utf8conv.from_bytes(s);
 }
 
 std::wstring
 wstr_from_utf8(const char *first, const char *last)
 {
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8conv;
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8conv;
     return utf8conv.from_bytes(first, last);
 }
 
@@ -205,7 +205,7 @@ wstr_from_utf8(const std::string &s)
 std::string
 wstr_to_utf8(const wchar_t *ws)
 {
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8conv;
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8conv;
     return utf8conv.to_bytes(ws);
 }
 


### PR DESCRIPTION
I need to use std::codecvt_utf8_utf16<wchar_t> instead of std::codecvt_utf8<wchar_t> for the conversion between utf-8 and utf-16 for Windows build.
Is there a flag or switch I need to set to make it work without this change?

I am using MinGW 8.1
gcc (x86_64-posix-seh-rev0, created by the MinGW-W64 project) 8.1.0