### PR TITLE
Define `__STDC_FORMAT_MACROS` before including inttypes

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -45,10 +45,13 @@
 #include <stdlib.h>
 #ifdef _MSC_VER
 #include "uniwin.h"
-#include <inttypes.h>
 #else
 #include <unistd.h>
 #endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
 #include <string.h>
 #include <sys/stat.h>
 #include <stdexcept>

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -33,7 +33,10 @@
 #include <string.h>
 #include <stdint.h>
 #include <time.h>
-#include <inttypes.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
 #include <cassert>
 
 #include "pgp-key.h"

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -35,7 +35,10 @@
 #endif
 #include <string.h>
 #include <time.h>
-#include <inttypes.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
 #include "stream-def.h"
 #include "stream-key.h"
 #include "stream-armor.h"

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -34,7 +34,10 @@
 #include "uniwin.h"
 #endif
 #include <string.h>
-#include <inttypes.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
 #include <rnp/rnp_def.h>
 #include "types.h"
 #include "crypto/mem.h"


### PR DESCRIPTION
Fix build errors on some platforms which need `__STDC_FORMAT_MACROS` before `inttypes` for PRI macros. Also use standard C++ header.