### PR TITLE
Tests support: use POSIX syntax for cp

### DIFF
--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -290,7 +290,7 @@ copy_recursively(const char *src, const char *dst)
     // TODO: maybe use fts or something less hacky
     char buf[2048];
 #ifndef _WIN32
-    snprintf(buf, sizeof(buf), "cp -a '%s' '%s'", src, dst);
+    snprintf(buf, sizeof(buf), "cp -pRP '%s' '%s'", src, dst);
 #else
     snprintf(buf, sizeof(buf), "xcopy \"%s\" \"%s\" /I /Q /E /Y", src, dst);
 #endif // _WIN32


### PR DESCRIPTION
Using gnuism here was breaking tests when `cp` did not support it. Use POSIX instead.