### PR TITLE
Refactor rnp::Hash and pgp_key_store_format_t.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -55,9 +55,10 @@ typedef enum pgp_sig_import_status_t {
     PGP_SIG_IMPORT_STATUS_NEW
 } pgp_sig_import_status_t;
 
-typedef std::unordered_map<pgp_fingerprint_t, std::list<rnp::Key>::iterator> pgp_key_fp_map_t;
-
 namespace rnp {
+
+typedef std::unordered_map<pgp_fingerprint_t, std::list<Key>::iterator> pgp_key_fp_map_t;
+
 class KeyStore {
   private:
     Key *                   add_subkey(Key &srckey, Key *oldkey);
@@ -65,10 +66,10 @@ class KeyStore {
     bool                    refresh_subkey_grips(Key &key);
 
   public:
-    std::string            path;
-    pgp_key_store_format_t format;
-    rnp::SecurityContext & secctx;
-    bool                   disable_validation =
+    std::string      path;
+    KeyFormat        format;
+    SecurityContext &secctx;
+    bool             disable_validation =
       false; /* do not automatically validate keys, added to this key store */
 
     std::list<Key>                           keys;
@@ -76,11 +77,8 @@ class KeyStore {
     std::vector<std::unique_ptr<kbx_blob_t>> blobs;
 
     ~KeyStore();
-    KeyStore(rnp::SecurityContext &ctx)
-        : path(""), format(PGP_KEY_STORE_UNKNOWN), secctx(ctx){};
-    KeyStore(pgp_key_store_format_t format,
-             const std::string &    path,
-             rnp::SecurityContext & ctx);
+    KeyStore(SecurityContext &ctx) : path(""), format(KeyFormat::Unknown), secctx(ctx){};
+    KeyStore(const std::string &path, SecurityContext &ctx, KeyFormat format = KeyFormat::GPG);
     /* make sure we use only empty constructor */
     KeyStore(KeyStore &&src) = delete;
     KeyStore &operator=(KeyStore &&) = delete;
@@ -189,10 +187,10 @@ class KeyStore {
      * @return pointer to the newly added signature or nullptr if error occurred (key not
      *         found, whatever else).
      */
-    rnp::Signature *add_key_sig(const pgp_fingerprint_t &keyfp,
-                                const pgp_signature_t &  sig,
-                                const pgp_userid_pkt_t * uid,
-                                bool                     front);
+    Signature *add_key_sig(const pgp_fingerprint_t &keyfp,
+                           const pgp_signature_t &  sig,
+                           const pgp_userid_pkt_t * uid,
+                           bool                     front);
 
     /**
      * @brief Add transferable key to the keystore.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -568,13 +568,6 @@ typedef enum : uint8_t {
     PGP_HASH_SM3 = 105,
 } pgp_hash_alg_t;
 
-typedef enum pgp_key_store_format_t {
-    PGP_KEY_STORE_UNKNOWN = 0,
-    PGP_KEY_STORE_GPG,
-    PGP_KEY_STORE_KBX,
-    PGP_KEY_STORE_G10,
-} pgp_key_store_format_t;
-
 namespace rnp {
 enum class AuthType {
     None,

--- a/src/lib/crypto/dsa_common.cpp
+++ b/src/lib/crypto/dsa_common.cpp
@@ -28,6 +28,7 @@
 #include "defaults.h"
 #include "repgp/repgp_def.h"
 #include "dsa.h"
+#include "ecdsa.h"
 #include <cstddef>
 
 namespace pgp {

--- a/src/lib/crypto/elgamal_ossl.cpp
+++ b/src/lib/crypto/elgamal_ossl.cpp
@@ -414,7 +414,7 @@ Key::generate(rnp::RNG &rng, size_t keybits)
             return RNP_ERROR_GENERIC;
             /* LCOV_EXCL_END */
         }
-        if (BITS_TO_BYTES(BN_num_bits(DH_get0_pub_key(dh))) != BITS_TO_BYTES(keybits)) {
+        if (BITS_TO_BYTES(BN_num_bits(DH_get0_pub_key(dh))) != BITS_TO_BYTES((int) keybits)) {
             /* This code chunk is rarely hit, so ignoring it for the coverage report */
             continue; // LCOV_EXCL_LINE
         }

--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -95,19 +95,17 @@ Hash_Botan::add(const void *buf, size_t len)
     fn_->update(static_cast<const uint8_t *>(buf), len);
 }
 
-size_t
+void
 Hash_Botan::finish(uint8_t *digest)
 {
     if (!fn_) {
-        return 0;
+        return;
     }
-    size_t outlen = size_;
     if (digest) {
         fn_->final(digest);
     }
     fn_ = nullptr;
     size_ = 0;
-    return outlen;
 }
 
 const char *

--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -98,6 +98,7 @@ Hash_Botan::add(const void *buf, size_t len)
 void
 Hash_Botan::finish(uint8_t *digest)
 {
+    assert(fn_);
     if (!fn_) {
         return;
     }

--- a/src/lib/crypto/hash.hpp
+++ b/src/lib/crypto/hash.hpp
@@ -30,6 +30,7 @@
 #include <repgp/repgp_def.h>
 #include "types.h"
 #include "config.h"
+#include "mem.h"
 #include <memory>
 #include <vector>
 #include <array>
@@ -56,11 +57,14 @@ class Hash {
     static std::unique_ptr<Hash>  create(pgp_hash_alg_t alg);
     virtual std::unique_ptr<Hash> clone() const = 0;
 
-    virtual void   add(const void *buf, size_t len) = 0;
-    virtual void   add(const std::vector<uint8_t> &val);
-    virtual void   add(uint32_t val);
-    virtual void   add(const pgp::mpi &mpi);
-    virtual size_t finish(uint8_t *digest = NULL) = 0;
+    virtual void add(const void *buf, size_t len) = 0;
+    virtual void add(const std::vector<uint8_t> &val);
+    virtual void add(uint32_t val);
+    virtual void add(const pgp::mpi &mpi);
+    virtual void finish(uint8_t *digest) = 0;
+
+    std::vector<uint8_t> finish();
+    rnp::secure_bytes    sec_finish();
 
     virtual ~Hash();
 

--- a/src/lib/crypto/hash_botan.hpp
+++ b/src/lib/crypto/hash_botan.hpp
@@ -44,8 +44,8 @@ class Hash_Botan : public Hash {
     static std::unique_ptr<Hash_Botan> create(pgp_hash_alg_t alg);
     std::unique_ptr<Hash>              clone() const override;
 
-    void   add(const void *buf, size_t len) override;
-    size_t finish(uint8_t *digest = NULL) override;
+    void add(const void *buf, size_t len) override;
+    void finish(uint8_t *digest) override;
 
     static const char *name_backend(pgp_hash_alg_t alg);
 };

--- a/src/lib/crypto/hash_common.cpp
+++ b/src/lib/crypto/hash_common.cpp
@@ -136,6 +136,22 @@ Hash::add(const pgp::mpi &val)
     add(val.mpi + idx, len - idx);
 }
 
+std::vector<uint8_t>
+Hash::finish()
+{
+    std::vector<uint8_t> res(size_, 0);
+    finish(res.data());
+    return res;
+}
+
+rnp::secure_bytes
+Hash::sec_finish()
+{
+    rnp::secure_bytes res(size_, 0);
+    finish(res.data());
+    return res;
+}
+
 Hash::~Hash()
 {
 }

--- a/src/lib/crypto/hash_ossl.cpp
+++ b/src/lib/crypto/hash_ossl.cpp
@@ -120,6 +120,7 @@ Hash_OpenSSL::add(const void *buf, size_t len)
 void
 Hash_OpenSSL::finish(uint8_t *digest)
 {
+    assert(fn_);
     if (!fn_) {
         return;
     }

--- a/src/lib/crypto/hash_ossl.cpp
+++ b/src/lib/crypto/hash_ossl.cpp
@@ -117,23 +117,20 @@ Hash_OpenSSL::add(const void *buf, size_t len)
     }
 }
 
-size_t
+void
 Hash_OpenSSL::finish(uint8_t *digest)
 {
     if (!fn_) {
-        return 0;
+        return;
     }
     int res = digest ? EVP_DigestFinal_ex(fn_, digest, NULL) : 1;
     EVP_MD_CTX_free(fn_);
     fn_ = NULL;
     if (res != 1) {
         RNP_LOG("Digest finalization error %d: %lu", res, ERR_peek_last_error());
-        return 0;
+        return;
     }
-
-    size_t outsz = size_;
     size_ = 0;
-    return outsz;
 }
 
 Hash_OpenSSL::~Hash_OpenSSL()

--- a/src/lib/crypto/hash_ossl.hpp
+++ b/src/lib/crypto/hash_ossl.hpp
@@ -44,8 +44,8 @@ class Hash_OpenSSL : public Hash {
     static std::unique_ptr<Hash_OpenSSL> create(pgp_hash_alg_t alg);
     std::unique_ptr<Hash>                clone() const override;
 
-    void   add(const void *buf, size_t len) override;
-    size_t finish(uint8_t *digest = NULL) override;
+    void add(const void *buf, size_t len) override;
+    void finish(uint8_t *digest) override;
 
     static const char *name_backend(pgp_hash_alg_t alg);
 };

--- a/src/lib/crypto/hash_sha1cd.cpp
+++ b/src/lib/crypto/hash_sha1cd.cpp
@@ -73,7 +73,7 @@ Hash_SHA1CD::add(const void *buf, size_t len)
 #if defined(__clang__)
 __attribute__((no_sanitize("undefined")))
 #endif
-size_t
+void
 Hash_SHA1CD::finish(uint8_t *digest)
 {
     unsigned char fixed_digest[20];
@@ -83,12 +83,11 @@ Hash_SHA1CD::finish(uint8_t *digest)
         RNP_LOG("Warning! SHA1 collision detected and mitigated.");
     }
     if (res) {
-        return 0;
+        return;
     }
     if (digest) {
         memcpy(digest, fixed_digest, 20);
     }
-    return 20;
 }
 
 } // namespace rnp

--- a/src/lib/crypto/hash_sha1cd.hpp
+++ b/src/lib/crypto/hash_sha1cd.hpp
@@ -44,8 +44,8 @@ class Hash_SHA1CD : public Hash {
     static std::unique_ptr<Hash_SHA1CD> create();
     std::unique_ptr<Hash>               clone() const override;
 
-    void   add(const void *buf, size_t len) override;
-    size_t finish(uint8_t *digest = NULL) override;
+    void add(const void *buf, size_t len) override;
+    void finish(uint8_t *digest) override;
 };
 
 } // namespace rnp

--- a/src/lib/crypto/s2k_ossl.cpp
+++ b/src/lib/crypto/s2k_ossl.cpp
@@ -65,10 +65,7 @@ pgp_s2k_iterated(pgp_hash_alg_t alg,
             /* create hash context */
             auto hash = rnp::Hash::create(alg);
             /* add leading zeroes */
-            for (size_t z = 0; z < zeroes; z++) {
-                uint8_t zero = 0;
-                hash->add(&zero, 1);
-            }
+            hash->add(std::vector<uint8_t>(zeroes, 0));
             if (!data.empty()) {
                 /* if iteration is 1 then still hash the whole data chunk */
                 size_t left = std::max(data.size(), iterations);
@@ -78,12 +75,8 @@ pgp_s2k_iterated(pgp_hash_alg_t alg,
                     left -= to_hash;
                 }
             }
-            rnp::secure_bytes dgst(hash_len);
-            size_t            out_cpy = std::min(dgst.size(), output_len);
-            if (hash->finish(dgst.data()) != dgst.size()) {
-                RNP_LOG("Unexpected digest size.");
-                return 1;
-            }
+            auto dgst = hash->sec_finish();
+            size_t out_cpy = std::min(dgst.size(), output_len);
             memcpy(out, dgst.data(), out_cpy);
             output_len -= out_cpy;
             out += out_cpy;

--- a/src/lib/crypto/s2k_ossl.cpp
+++ b/src/lib/crypto/s2k_ossl.cpp
@@ -75,7 +75,7 @@ pgp_s2k_iterated(pgp_hash_alg_t alg,
                     left -= to_hash;
                 }
             }
-            auto dgst = hash->sec_finish();
+            auto   dgst = hash->sec_finish();
             size_t out_cpy = std::min(dgst.size(), output_len);
             memcpy(out, dgst.data(), out_cpy);
             output_len -= out_cpy;

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -120,7 +120,7 @@ struct rnp_ffi_st {
     pgp_password_provider_t pass_provider;
     rnp::SecurityContext    context;
 
-    rnp_ffi_st(pgp_key_store_format_t pub_fmt, pgp_key_store_format_t sec_fmt);
+    rnp_ffi_st(rnp::KeyFormat pub_fmt, rnp::KeyFormat sec_fmt);
     ~rnp_ffi_st();
 
     rnp::RNG &            rng() noexcept;

--- a/src/lib/fingerprint.cpp
+++ b/src/lib/fingerprint.cpp
@@ -52,7 +52,8 @@ try {
         auto  hash = rnp::Hash::create(PGP_HASH_MD5);
         hash->add(rsa.n());
         hash->add(rsa.e());
-        fp.length = hash->finish(fp.fingerprint);
+        fp.length = hash->size();
+        hash->finish(fp.fingerprint);
         return RNP_SUCCESS;
     }
     case PGP_V4:
@@ -64,7 +65,8 @@ try {
         auto halg = key.version == PGP_V4 ? PGP_HASH_SHA1 : PGP_HASH_SHA256;
         auto hash = rnp::Hash::create(halg);
         signature_hash_key(key, *hash, key.version);
-        fp.length = hash->finish(fp.fingerprint);
+        fp.length = hash->size();
+        hash->finish(fp.fingerprint);
         return RNP_SUCCESS;
     }
     default:

--- a/src/lib/key.cpp
+++ b/src/lib/key.cpp
@@ -111,7 +111,7 @@ pgp_decrypt_seckey(const Key &                    key,
     case KeyFormat::G10:
         return g10_decrypt_seckey(key.rawpkt(), key.pkt(), password.data());
     default:
-        RNP_LOG("unexpected format: %d", key.format);
+        RNP_LOG("unexpected format: %d", static_cast<int>(key.format));
         return NULL;
     }
 }

--- a/src/lib/key.hpp
+++ b/src/lib/key.hpp
@@ -47,6 +47,8 @@ class KeyStore;
 class CertParams;
 class BindingParams;
 
+enum class KeyFormat { Unknown, GPG, KBX, G10 };
+
 /* describes a user's key */
 class Key {
   private:
@@ -83,7 +85,7 @@ class Key {
                              RNG &              rng);
 
   public:
-    pgp_key_store_format_t format{}; /* the format of the key in packets[0] */
+    KeyFormat format = KeyFormat::Unknown; /* the format of the key in packets[0] */
 
     Key() = default;
     Key(const pgp_key_pkt_t &pkt);

--- a/src/lib/key.hpp
+++ b/src/lib/key.hpp
@@ -47,7 +47,7 @@ class KeyStore;
 class CertParams;
 class BindingParams;
 
-enum class KeyFormat { Unknown, GPG, KBX, G10 };
+enum class KeyFormat : int { Unknown, GPG, KBX, G10 };
 
 /* describes a user's key */
 class Key {

--- a/src/lib/keygen.cpp
+++ b/src/lib/keygen.cpp
@@ -239,10 +239,10 @@ load_generated_g10_key(
 }
 
 bool
-KeygenParams::generate(CertParams &           cert,
-                       Key &                  primary_sec,
-                       Key &                  primary_pub,
-                       pgp_key_store_format_t secformat)
+KeygenParams::generate(CertParams &cert,
+                       Key &       primary_sec,
+                       Key &       primary_pub,
+                       KeyFormat   secformat)
 {
     primary_sec = {};
     primary_pub = {};
@@ -272,12 +272,12 @@ KeygenParams::generate(CertParams &           cert,
     sec.add_uid_cert(cert, hash(), ctx(), &pub);
 
     switch (secformat) {
-    case PGP_KEY_STORE_GPG:
-    case PGP_KEY_STORE_KBX:
+    case KeyFormat::GPG:
+    case KeyFormat::KBX:
         primary_sec = std::move(sec);
         primary_pub = std::move(pub);
         break;
-    case PGP_KEY_STORE_G10:
+    case KeyFormat::G10:
         primary_pub = std::move(pub);
         if (!load_generated_g10_key(&primary_sec, &secpkt, NULL, &primary_pub, ctx())) {
             RNP_LOG("failed to load generated key");
@@ -303,7 +303,7 @@ KeygenParams::generate(BindingParams &                binding,
                        Key &                          subkey_sec,
                        Key &                          subkey_pub,
                        const pgp_password_provider_t &password_provider,
-                       pgp_key_store_format_t         secformat)
+                       KeyFormat                      secformat)
 {
     // validate args
     if (!primary_sec.is_primary() || !primary_pub.is_primary() || !primary_sec.is_secret() ||
@@ -342,11 +342,11 @@ KeygenParams::generate(BindingParams &                binding,
     /* copy to the result */
     subkey_pub = std::move(pub);
     switch (secformat) {
-    case PGP_KEY_STORE_GPG:
-    case PGP_KEY_STORE_KBX:
+    case KeyFormat::GPG:
+    case KeyFormat::KBX:
         subkey_sec = std::move(sec);
         break;
-    case PGP_KEY_STORE_G10:
+    case KeyFormat::G10:
         if (!load_generated_g10_key(&subkey_sec, &secpkt, &primary_sec, &subkey_pub, ctx())) {
             RNP_LOG("failed to load generated key");
             return false;

--- a/src/lib/keygen.hpp
+++ b/src/lib/keygen.hpp
@@ -106,10 +106,10 @@ class KeygenParams {
     bool generate(pgp_key_pkt_t &seckey, bool primary);
 
     /* Generate primary key with self-certification */
-    bool generate(CertParams &           cert,
-                  Key &                  primary_sec,
-                  Key &                  primary_pub,
-                  pgp_key_store_format_t secformat);
+    bool generate(CertParams &cert,
+                  Key &       primary_sec,
+                  Key &       primary_pub,
+                  KeyFormat   secformat = KeyFormat::GPG);
 
     /* Generate a subkey for already existing primary key*/
     bool generate(BindingParams &                binding,
@@ -118,7 +118,7 @@ class KeygenParams {
                   Key &                          subkey_sec,
                   Key &                          subkey_pub,
                   const pgp_password_provider_t &password_provider,
-                  pgp_key_store_format_t         secformat);
+                  KeyFormat                      secformat = KeyFormat::GPG);
 };
 
 class UserPrefs {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -492,14 +492,14 @@ str_to_key_flag(const char *str, uint8_t *flag)
 }
 
 static bool
-parse_ks_format(pgp_key_store_format_t *key_store_format, const char *format)
+parse_ks_format(rnp::KeyFormat *key_store_format, const char *format)
 {
     if (!strcmp(format, RNP_KEYSTORE_GPG)) {
-        *key_store_format = PGP_KEY_STORE_GPG;
+        *key_store_format = rnp::KeyFormat::GPG;
     } else if (!strcmp(format, RNP_KEYSTORE_KBX)) {
-        *key_store_format = PGP_KEY_STORE_KBX;
+        *key_store_format = rnp::KeyFormat::KBX;
     } else if (!strcmp(format, RNP_KEYSTORE_G10)) {
-        *key_store_format = PGP_KEY_STORE_G10;
+        *key_store_format = rnp::KeyFormat::G10;
     } else {
         return false;
     }
@@ -605,11 +605,11 @@ ffi_exception(FILE *fp, const char *func, const char *msg, uint32_t ret = RNP_ER
 
 #define FFI_GUARD FFI_GUARD_FP((stderr))
 
-rnp_ffi_st::rnp_ffi_st(pgp_key_store_format_t pub_fmt, pgp_key_store_format_t sec_fmt)
+rnp_ffi_st::rnp_ffi_st(rnp::KeyFormat pub_fmt, rnp::KeyFormat sec_fmt)
 {
     errs = stderr;
-    pubring = new rnp::KeyStore(pub_fmt, "", context);
-    secring = new rnp::KeyStore(sec_fmt, "", context);
+    pubring = new rnp::KeyStore("", context, pub_fmt);
+    secring = new rnp::KeyStore("", context, sec_fmt);
     getkeycb = NULL;
     getkeycb_ctx = NULL;
     getpasscb = NULL;
@@ -640,8 +640,8 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    pgp_key_store_format_t pub_ks_format = PGP_KEY_STORE_UNKNOWN;
-    pgp_key_store_format_t sec_ks_format = PGP_KEY_STORE_UNKNOWN;
+    auto pub_ks_format = rnp::KeyFormat::Unknown;
+    auto sec_ks_format = rnp::KeyFormat::Unknown;
     if (!parse_ks_format(&pub_ks_format, pub_format) ||
         !parse_ks_format(&sec_ks_format, sec_format)) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -1451,8 +1451,8 @@ load_keys_from_input(rnp_ffi_t ffi, rnp_input_t input, rnp::KeyStore *store)
 static bool
 key_needs_conversion(const rnp::Key *key, const rnp::KeyStore *store)
 {
-    pgp_key_store_format_t key_format = key->format;
-    pgp_key_store_format_t store_format = store->format;
+    auto key_format = key->format;
+    auto store_format = store->format;
     /* rnp::Key->format is only ever GPG or G10.
      *
      * The key store, however, could have a format of KBX, GPG, or G10.
@@ -1460,26 +1460,23 @@ key_needs_conversion(const rnp::Key *key, const rnp::KeyStore *store)
      * A G10 key store can only handle a rnp::Key with a format of G10.
      */
     // should never be the case
-    assert(key_format != PGP_KEY_STORE_KBX);
+    assert(key_format != rnp::KeyFormat::KBX);
     // normalize the store format
-    if (store_format == PGP_KEY_STORE_KBX) {
-        store_format = PGP_KEY_STORE_GPG;
+    if (store_format == rnp::KeyFormat::KBX) {
+        store_format = rnp::KeyFormat::GPG;
     }
     // from here, both the key and store formats can only be GPG or G10
     return key_format != store_format;
 }
 
 static rnp_result_t
-do_load_keys(rnp_ffi_t              ffi,
-             rnp_input_t            input,
-             pgp_key_store_format_t format,
-             key_type_t             key_type)
+do_load_keys(rnp_ffi_t ffi, rnp_input_t input, rnp::KeyFormat format, key_type_t key_type)
 {
     // create a temporary key store to hold the keys
     std::unique_ptr<rnp::KeyStore> tmp_store;
     try {
         tmp_store =
-          std::unique_ptr<rnp::KeyStore>(new rnp::KeyStore(format, "", ffi->context));
+          std::unique_ptr<rnp::KeyStore>(new rnp::KeyStore("", ffi->context, format));
     } catch (const std::invalid_argument &e) {
         FFI_LOG(ffi, "Failed to create key store of format: %d", (int) format);
         return RNP_ERROR_BAD_PARAMETERS;
@@ -1507,7 +1504,7 @@ do_load_keys(rnp_ffi_t              ffi,
         }
 
         // add public key part if needed
-        if ((key.format == PGP_KEY_STORE_G10) ||
+        if ((key.format == rnp::KeyFormat::G10) ||
             ((key_type != KEY_TYPE_ANY) && (key_type != KEY_TYPE_PUBLIC))) {
             continue;
         }
@@ -1570,7 +1567,7 @@ try {
         FFI_LOG(ffi, "invalid flags - must have public and/or secret keys");
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    pgp_key_store_format_t ks_format = PGP_KEY_STORE_UNKNOWN;
+    auto ks_format = rnp::KeyFormat::Unknown;
     if (!parse_ks_format(&ks_format, format)) {
         FFI_LOG(ffi, "invalid key store format: %s", format);
         return RNP_ERROR_BAD_PARAMETERS;
@@ -1709,7 +1706,7 @@ try {
     }
 
     rnp_result_t  ret = RNP_ERROR_GENERIC;
-    rnp::KeyStore tmp_store(PGP_KEY_STORE_GPG, "", ffi->context);
+    rnp::KeyStore tmp_store("", ffi->context);
 
     /* check whether input is base64 */
     if (base64 && input->src.is_base64()) {
@@ -1895,15 +1892,12 @@ copy_store_keys(rnp_ffi_t ffi, rnp::KeyStore *dest, rnp::KeyStore *src)
 }
 
 static rnp_result_t
-do_save_keys(rnp_ffi_t              ffi,
-             rnp_output_t           output,
-             pgp_key_store_format_t format,
-             key_type_t             key_type)
+do_save_keys(rnp_ffi_t ffi, rnp_output_t output, rnp::KeyFormat format, key_type_t key_type)
 {
     // create a temporary key store to hold the keys
     rnp::KeyStore *tmp_store = nullptr;
     try {
-        tmp_store = new rnp::KeyStore(format, "", ffi->context);
+        tmp_store = new rnp::KeyStore("", ffi->context, format);
     } catch (const std::invalid_argument &e) {
         /* LCOV_EXCL_START */
         FFI_LOG(ffi, "Failed to create key store of format: %d", (int) format);
@@ -1969,7 +1963,7 @@ try {
         FFI_LOG(ffi, "unexpected flags remaining: 0x%X", flags);
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    pgp_key_store_format_t ks_format = PGP_KEY_STORE_UNKNOWN;
+    auto ks_format = rnp::KeyFormat::Unknown;
     if (!parse_ks_format(&ks_format, format)) {
         FFI_LOG(ffi, "unknown key store format: %s", format);
         return RNP_ERROR_BAD_PARAMETERS;
@@ -3884,7 +3878,7 @@ try {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
     // only PGP packets supported for now
-    if (key->format != PGP_KEY_STORE_GPG && key->format != PGP_KEY_STORE_KBX) {
+    if (key->format != rnp::KeyFormat::GPG && key->format != rnp::KeyFormat::KBX) {
         return RNP_ERROR_NOT_IMPLEMENTED;
     }
     if (armored) {
@@ -5714,7 +5708,7 @@ try {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
     auto *public_key = get_key_prefer_public(handle);
-    if (!public_key && secret_key->format == PGP_KEY_STORE_G10) {
+    if (!public_key && secret_key->format == rnp::KeyFormat::G10) {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
     rnp::KeyLocker seclock(*secret_key);
@@ -7965,7 +7959,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
 
     auto *key = get_key_prefer_public(handle);
-    if (key->format == PGP_KEY_STORE_G10) {
+    if (key->format == rnp::KeyFormat::G10) {
         // we can't currently determine this for a G10 secret key
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
@@ -7981,7 +7975,7 @@ try {
         return RNP_ERROR_NULL_POINTER;
 
     auto *key = get_key_prefer_public(handle);
-    if (key->format == PGP_KEY_STORE_G10) {
+    if (key->format == rnp::KeyFormat::G10) {
         // we can't currently determine this for a G10 secret key
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
@@ -8693,7 +8687,7 @@ try {
     }
 
     rnp::Key *key = secret ? handle->sec : handle->pub;
-    if (!key || (key->format == PGP_KEY_STORE_G10)) {
+    if (!key || (key->format == rnp::KeyFormat::G10)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 

--- a/src/lib/sig_subpacket.cpp
+++ b/src/lib/sig_subpacket.cpp
@@ -492,8 +492,8 @@ NotationData::check_size(size_t size) const noexcept
 bool
 NotationData::parse_data(const uint8_t *data, size_t size)
 {
-    uint16_t nlen = read_uint16(data + 4);
-    uint16_t vlen = read_uint16(data + 6);
+    size_t nlen = read_uint16(data + 4);
+    size_t vlen = read_uint16(data + 6);
     if (size != nlen + vlen + 8) {
         return false;
     }

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -944,7 +944,7 @@ KeyStore::load_g10(pgp_source_t &src, const KeyProvider *key_provider)
         if (key_provider) {
             pgp_key_grip_t grip = seckey.material->grip();
             auto           pubkey =
-              key_provider->request_key(*rnp::KeySearch::create(grip), PGP_OP_MERGE_INFO);
+              key_provider->request_key(*KeySearch::create(grip), PGP_OP_MERGE_INFO);
             if (!pubkey) {
                 return false;
             }
@@ -959,8 +959,8 @@ KeyStore::load_g10(pgp_source_t &src, const KeyProvider *key_provider)
         }
         /* set rawpkt */
         key.set_rawpkt(
-          rnp::RawPacket((uint8_t *) memsrc.memory(), memsrc.size(), PGP_PKT_RESERVED));
-        key.format = PGP_KEY_STORE_G10;
+          RawPacket((uint8_t *) memsrc.memory(), memsrc.size(), PGP_PKT_RESERVED));
+        key.format = KeyFormat::G10;
         if (!add_key(key)) {
             return false;
         }
@@ -1280,7 +1280,7 @@ g10_calculated_hash(const pgp_key_pkt_t &key, const char *protected_at, uint8_t 
 bool
 rnp_key_store_gnupg_sexp_to_dst(rnp::Key &key, pgp_dest_t &dest)
 {
-    if (key.format != PGP_KEY_STORE_G10) {
+    if (key.format != rnp::KeyFormat::G10) {
         RNP_LOG("incorrect format: %d", key.format);
         return false;
     }

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1281,7 +1281,7 @@ bool
 rnp_key_store_gnupg_sexp_to_dst(rnp::Key &key, pgp_dest_t &dest)
 {
     if (key.format != rnp::KeyFormat::G10) {
-        RNP_LOG("incorrect format: %d", key.format);
+        RNP_LOG("incorrect format: %d", static_cast<int>(key.format));
         return false;
     }
     dst_write(dest, key.rawpkt().data());

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -169,7 +169,8 @@ do_write(rnp::KeyStore &key_store, pgp_dest_t &dst, bool secret)
         }
 
         if (key.format != rnp::KeyFormat::GPG) {
-            RNP_LOG("incorrect format (conversions not supported): %d", key.format);
+            RNP_LOG("incorrect format (conversions not supported): %d",
+                    static_cast<int>(key.format));
             return false;
         }
         key.write(dst);

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -168,7 +168,7 @@ do_write(rnp::KeyStore &key_store, pgp_dest_t &dst, bool secret)
             continue;
         }
 
-        if (key.format != PGP_KEY_STORE_GPG) {
+        if (key.format != rnp::KeyFormat::GPG) {
             RNP_LOG("incorrect format (conversions not supported): %d", key.format);
             return false;
         }

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -111,7 +111,8 @@ KeyStore::load(pgp_source_t &src, const KeyProvider *key_provider)
     case KeyFormat::G10:
         return load_g10(src, key_provider);
     default:
-        RNP_LOG("Unsupported load from memory for key-store format: %d", format);
+        RNP_LOG("Unsupported load from memory for key-store format: %d",
+                static_cast<int>(format));
     }
 
     return false;
@@ -196,7 +197,8 @@ KeyStore::write(pgp_dest_t &dst)
     case KeyFormat::KBX:
         return write_kbx(dst);
     default:
-        RNP_LOG("Unsupported write to memory for key-store format: %d", format);
+        RNP_LOG("Unsupported write to memory for key-store format: %d",
+                static_cast<int>(format));
     }
 
     return false;

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -424,9 +424,7 @@ parse_secret_key_mpis(pgp_key_pkt_t &key, const uint8_t *mpis, size_t len)
             assert(hash->size() == sizeof(hval));
             len -= PGP_SHA1_HASH_SIZE;
             hash->add(mpis, len);
-            if (hash->finish(hval) != PGP_SHA1_HASH_SIZE) {
-                return RNP_ERROR_BAD_STATE;
-            }
+            hash->finish(hval);
         } catch (const std::exception &e) {
             RNP_LOG("hash calculation failed: %s", e.what());
             return RNP_ERROR_BAD_STATE;
@@ -574,13 +572,8 @@ write_secret_key_mpis(pgp_packet_body_t &body, pgp_key_pkt_t &key)
     /* add sha1 hash */
     auto hash = rnp::Hash::create(PGP_HASH_SHA1);
     hash->add(body.data(), body.size());
-    uint8_t hval[PGP_SHA1_HASH_SIZE];
-    assert(sizeof(hval) == hash->size());
-    if (hash->finish(hval) != PGP_SHA1_HASH_SIZE) {
-        RNP_LOG("failed to finish hash");
-        throw rnp::rnp_exception(RNP_ERROR_BAD_STATE);
-    }
-    body.add(hval, PGP_SHA1_HASH_SIZE);
+    assert(hash->size() == PGP_SHA1_HASH_SIZE);
+    body.add(hash->finish());
 }
 
 rnp_result_t

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -482,8 +482,8 @@ TEST_F(rnp_tests, sm2_sm3_signature_test)
 
     assert_rnp_success(pgp::sm2::compute_za(sm2_key, *hash, "sm2_p256_test@example.com"));
     hash->add(msg, strlen(msg));
-    rnp::secure_bytes digest(hash_len, 0);
-    assert_int_equal(hash->finish(digest.data()), hash_len);
+    rnp::secure_bytes digest = hash->sec_finish();
+    assert_int_equal(digest.size(), hash_len);
 
     // First generate a signature, then verify it
     assert_rnp_success(pgp::sm2::sign(global_ctx.rng, sig, hash_alg, digest, sm2_key));
@@ -523,8 +523,8 @@ TEST_F(rnp_tests, sm2_sha256_signature_test)
     auto hash = rnp::Hash::create(hash_alg);
     assert_rnp_success(pgp::sm2::compute_za(sm2_key, *hash, "sm2test@example.com"));
     hash->add(msg, strlen(msg));
-    rnp::secure_bytes digest(hash_len, 0);
-    assert_int_equal(hash->finish(digest.data()), hash_len);
+    rnp::secure_bytes digest = hash->sec_finish();
+    assert_int_equal(digest.size(), hash_len);
 
     // First generate a signature, then verify it
     assert_rnp_success(pgp::sm2::sign(global_ctx.rng, sig, hash_alg, digest, sm2_key));

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -768,7 +768,7 @@ TEST_F(rnp_tests, test_cli_rnpkeys_genkey)
     assert_int_equal(key_generate(GENKEYS, "expiration_2months@rnp", "2m"), 0);
     assert_int_equal(key_generate(GENKEYS, "expiration_2years@rnp", "2y"), 0);
 
-    auto         keystore = new rnp::KeyStore(PGP_KEY_STORE_GPG, "", global_ctx);
+    auto         keystore = new rnp::KeyStore("", global_ctx);
     pgp_source_t src = {};
     assert_rnp_success(init_file_src(&src, GENKEYS "/pubring.gpg"));
     assert_true(keystore->load(src));

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1037,7 +1037,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         cert.userid = "test";
 
         // generate
-        assert_true(keygen.generate(cert, sec, pub, PGP_KEY_STORE_GPG));
+        assert_true(keygen.generate(cert, sec, pub));
 
         // add to our rings
         assert_true(pubring->add_key(pub));
@@ -1170,8 +1170,7 @@ TEST_F(rnp_tests, test_generated_key_sigs)
         // generate
         pgp_password_provider_t prov = {};
         rnp::BindingParams      binding;
-        assert_true(keygen.generate(
-          binding, *primary_sec, *primary_pub, sec, pub, prov, PGP_KEY_STORE_GPG));
+        assert_true(keygen.generate(binding, *primary_sec, *primary_pub, sec, pub, prov));
         assert_true(pub.valid());
         assert_true(pub.validated());
         assert_false(pub.expired());

--- a/src/tests/key-grip.cpp
+++ b/src/tests/key-grip.cpp
@@ -34,11 +34,11 @@
 TEST_F(rnp_tests, key_grip)
 {
     auto pub_store = new rnp::KeyStore(
-      PGP_KEY_STORE_KBX, "data/test_stream_key_load/g10/pubring.kbx", global_ctx);
+      "data/test_stream_key_load/g10/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pub_store->load());
 
     auto sec_store = new rnp::KeyStore(
-      PGP_KEY_STORE_G10, "data/test_stream_key_load/g10/private-keys-v1.d", global_ctx);
+      "data/test_stream_key_load/g10/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     rnp::KeyProvider key_provider(rnp_key_provider_store, pub_store);
     assert_true(sec_store->load(&key_provider));
 

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -239,8 +239,8 @@ TEST_F(rnp_tests, test_key_protect_sec_data)
     /* generate raw unprotected keypair */
     rnp::Key                skey, pkey, ssub, psub;
     pgp_password_provider_t prov = {};
-    assert_true(keygen.generate(cert, skey, pkey, PGP_KEY_STORE_GPG));
-    assert_true(keygen.generate(binding, skey, pkey, ssub, psub, prov, PGP_KEY_STORE_GPG));
+    assert_true(keygen.generate(cert, skey, pkey));
+    assert_true(keygen.generate(binding, skey, pkey, ssub, psub, prov));
     assert_non_null(skey.pkt().sec_data);
     assert_non_null(ssub.pkt().sec_data);
     assert_null(pkey.pkt().sec_data);

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -37,7 +37,7 @@
 TEST_F(rnp_tests, test_key_store_search)
 {
     // create our store
-    auto store = new rnp::KeyStore(PGP_KEY_STORE_GPG, "", global_ctx);
+    auto store = new rnp::KeyStore("", global_ctx);
     store->disable_validation = true;
 
     // some fake key data
@@ -163,11 +163,11 @@ TEST_F(rnp_tests, test_key_store_search_by_name)
 
     // load pubring
     auto pub_store =
-      new rnp::KeyStore(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx", global_ctx);
+      new rnp::KeyStore("data/keyrings/3/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pub_store->load());
     // load secring
     auto sec_store =
-      new rnp::KeyStore(PGP_KEY_STORE_G10, "data/keyrings/3/private-keys-v1.d", global_ctx);
+      new rnp::KeyStore("data/keyrings/3/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     rnp::KeyProvider key_provider(rnp_key_provider_store, pub_store);
     assert_true(sec_store->load(&key_provider));
 

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -57,8 +57,7 @@ TEST_F(rnp_tests, test_key_validate)
 {
     rnp::Key *key = nullptr;
 
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg", global_ctx);
+    auto pubring = new rnp::KeyStore("data/keyrings/1/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     /* this keyring has one expired subkey */
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "1d7e8a5393c997a8"));
@@ -68,8 +67,7 @@ TEST_F(rnp_tests, test_key_validate)
     delete pubring;
 
     /* secret key is marked is expired as well */
-    auto secring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/1/secring.gpg", global_ctx);
+    auto secring = new rnp::KeyStore("data/keyrings/1/secring.gpg", global_ctx);
     assert_true(secring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(secring, "1d7e8a5393c997a8"));
     assert_false(key->valid());
@@ -77,12 +75,12 @@ TEST_F(rnp_tests, test_key_validate)
     assert_true(all_keys_valid(secring, key));
     delete secring;
 
-    pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/2/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore("data/keyrings/2/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_true(all_keys_valid(pubring));
 
     /* secret keyring doesn't have signatures - so keys are marked as invalid */
-    secring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/2/secring.gpg", global_ctx);
+    secring = new rnp::KeyStore("data/keyrings/2/secring.gpg", global_ctx);
     assert_true(secring->load());
     assert_false(all_keys_valid(secring));
     /* but after adding signatures from public it is marked as valid */
@@ -92,19 +90,20 @@ TEST_F(rnp_tests, test_key_validate)
     delete pubring;
     delete secring;
 
-    pubring = new rnp::KeyStore(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx", global_ctx);
+    pubring =
+      new rnp::KeyStore("data/keyrings/3/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pubring->load());
     assert_true(all_keys_valid(pubring));
 
     secring =
-      new rnp::KeyStore(PGP_KEY_STORE_G10, "data/keyrings/3/private-keys-v1.d", global_ctx);
+      new rnp::KeyStore("data/keyrings/3/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     rnp::KeyProvider key_provider(rnp_key_provider_store, pubring);
     assert_true(secring->load(&key_provider));
     assert_true(all_keys_valid(secring));
     delete pubring;
     delete secring;
 
-    pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/4/pubring.pgp", global_ctx);
+    pubring = new rnp::KeyStore("data/keyrings/4/pubring.pgp", global_ctx);
     assert_true(pubring->load());
     /* certification has signature with MD5 hash algorithm */
     assert_false(all_keys_valid(pubring));
@@ -125,17 +124,17 @@ TEST_F(rnp_tests, test_key_validate)
     delete pubring;
 
     /* secret keyring doesn't have certifications - so marked as invalid */
-    secring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/4/secring.pgp", global_ctx);
+    secring = new rnp::KeyStore("data/keyrings/4/secring.pgp", global_ctx);
     assert_true(secring->load());
     assert_false(all_keys_valid(secring));
     delete secring;
 
-    pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/5/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore("data/keyrings/5/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_true(all_keys_valid(pubring));
     delete pubring;
 
-    secring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/5/secring.gpg", global_ctx);
+    secring = new rnp::KeyStore("data/keyrings/5/secring.gpg", global_ctx);
     assert_true(secring->load());
     assert_true(all_keys_valid(secring));
     delete secring;
@@ -164,7 +163,7 @@ key_check(rnp::KeyStore *keyring, const std::string &keyid, bool valid, bool exp
 
 TEST_F(rnp_tests, test_forged_key_validate)
 {
-    auto pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "", global_ctx);
+    auto pubring = new rnp::KeyStore("", global_ctx);
 
     /* load valid dsa-eg key */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub.pgp");
@@ -342,8 +341,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice is signed by Basil, but without the Basil's key.
      * Result: Alice [valid]
      */
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case1/pubring.gpg", global_ctx);
+    auto pubring = new rnp::KeyStore(KEYSIG_PATH "case1/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     rnp::Key *key = nullptr;
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -357,8 +355,7 @@ TEST_F(rnp_tests, test_key_validity)
      * corrupted.
      * Result: Alice [invalid], Basil [valid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case2/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case2/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
     assert_false(key->valid());
@@ -373,8 +370,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice is signed by Basil, but doesn't have self-signature
      * Result: Alice [invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case3/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case3/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
     assert_false(key->valid());
@@ -389,8 +385,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice subkey has invalid binding signature
      * Result: Alice [valid], Alice sub [invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case4/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case4/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_true(key->valid());
@@ -410,8 +405,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Note: to re-generate keyring file, use generate.cpp from case5 folder.
      *       To build it, feed -DBUILD_TESTING_GENERATORS=On to the cmake.
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case5/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case5/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_true(key->valid());
@@ -427,8 +421,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Key Alice has revocation signature by Alice, and subkey doesn't
      * Result: Alice [invalid], Alice sub [invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case6/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case6/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_false(key->valid());
@@ -446,8 +439,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice subkey has revocation signature by Alice
      * Result: Alice [valid], Alice sub [invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case7/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case7/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_true(key->valid());
@@ -465,8 +457,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Userid is stripped from the key, but it still has valid subkey binding
      * Result: Alice [valid], Alice sub[valid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case8/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case8/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
     assert_true(key->valid());
@@ -481,8 +472,7 @@ TEST_F(rnp_tests, test_key_validity)
      * expiration.
      * Result: Alice [valid], Alice sub[valid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case9/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case9/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
@@ -499,8 +489,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice key has expiring direct-key signature and non-expiring self-certification.
      * Result: Alice [invalid], Alice sub[invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case10/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case10/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
@@ -517,8 +506,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice key has expiring direct-key signature, non-expiring self-certification and
      * expiring primary userid certification. Result: Alice [invalid], Alice sub[invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case11/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case11/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
@@ -536,8 +524,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice key has non-expiring direct-key signature, non-expiring self-certification and
      * expiring primary userid certification. Result: Alice [invalid], Alice sub[invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case12/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case12/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
@@ -555,8 +542,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Alice key has expiring direct-key signature, non-expiring self-certification and
      * non-expiring primary userid certification. Result: Alice [invalid], Alice sub[invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case13/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case13/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
@@ -575,8 +561,7 @@ TEST_F(rnp_tests, test_key_validity)
      * non-expiring primary userid certification (with 0 key expiration subpacket). Result:
      * Alice [invalid], Alice sub[invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case14/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case14/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "0451409669FFDE3C"));
@@ -594,8 +579,7 @@ TEST_F(rnp_tests, test_key_validity)
      * Signing subkey has expired primary-key signature embedded into the subkey binding.
      * Result: primary [valid], sub[invalid]
      */
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "case15/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "case15/pubring.gpg", global_ctx);
     assert_non_null(pubring);
     assert_true(pubring->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubring, "E863072D3E9042EE"));
@@ -612,8 +596,7 @@ TEST_F(rnp_tests, test_key_validity)
 TEST_F(rnp_tests, test_key_expiry_direct_sig)
 {
     /* this test was mainly used to generate test data for cases 10-12 in test_key_validity */
-    auto secring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "alice-sub-sec.pgp", global_ctx);
+    auto secring = new rnp::KeyStore(KEYSIG_PATH "alice-sub-sec.pgp", global_ctx);
     assert_true(secring->load());
     rnp::Key *key = nullptr;
     assert_non_null(key = rnp_tests_key_search(secring, "Alice <alice@rnp>"));
@@ -642,8 +625,7 @@ TEST_F(rnp_tests, test_key_expiry_direct_sig)
     assert_false(key->valid());
     assert_true(key->expired());
 
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "alice-sub-pub.pgp", global_ctx);
+    auto pubring = new rnp::KeyStore(KEYSIG_PATH "alice-sub-pub.pgp", global_ctx);
     assert_true(pubring->load());
     rnp::Key *pubkey = nullptr;
     assert_non_null(pubkey = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
@@ -681,8 +663,7 @@ TEST_F(rnp_tests, test_key_expiry_direct_sig)
     delete secring;
     delete pubring;
 
-    secring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "alice-sub-sec.pgp", global_ctx);
+    secring = new rnp::KeyStore(KEYSIG_PATH "alice-sub-sec.pgp", global_ctx);
     assert_true(secring->load());
     assert_non_null(key = rnp_tests_key_search(secring, "Alice <alice@rnp>"));
     /* create direct-key signature */
@@ -710,8 +691,7 @@ TEST_F(rnp_tests, test_key_expiry_direct_sig)
     key->revalidate(*secring);
     assert_int_equal(key->expiration(), 6);
 
-    pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, KEYSIG_PATH "alice-sub-pub.pgp", global_ctx);
+    pubring = new rnp::KeyStore(KEYSIG_PATH "alice-sub-pub.pgp", global_ctx);
     assert_true(pubring->load());
     assert_non_null(pubkey = rnp_tests_key_search(pubring, "Alice <alice@rnp>"));
     assert_non_null(subpub = rnp_tests_get_key_by_id(pubring, "dd23ceb7febeff17"));

--- a/src/tests/load-g10.cpp
+++ b/src/tests/load-g10.cpp
@@ -34,11 +34,11 @@ TEST_F(rnp_tests, test_invalid_g10)
     rnp::KeyProvider key_provider(rnp_key_provider_store);
     // load pubring
     auto pub_store =
-      new rnp::KeyStore(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx", global_ctx);
+      new rnp::KeyStore("data/keyrings/3/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pub_store->load());
     // trigger "Unsupported public key algorithm:" error message
     auto sec_store = new rnp::KeyStore(
-      PGP_KEY_STORE_G10, "data/test_invalid_g10/private-keys-v1.d", global_ctx);
+      "data/test_invalid_g10/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     key_provider.userdata = pub_store;
     assert_true(sec_store->load(&key_provider));
     // NULL key_provider
@@ -57,11 +57,11 @@ TEST_F(rnp_tests, test_load_g10)
 
     // load pubring
     auto pub_store =
-      new rnp::KeyStore(PGP_KEY_STORE_KBX, "data/keyrings/3/pubring.kbx", global_ctx);
+      new rnp::KeyStore("data/keyrings/3/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pub_store->load());
     // load secring
     auto sec_store =
-      new rnp::KeyStore(PGP_KEY_STORE_G10, "data/keyrings/3/private-keys-v1.d", global_ctx);
+      new rnp::KeyStore("data/keyrings/3/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     key_provider.userdata = pub_store;
     assert_true(sec_store->load(&key_provider));
 
@@ -75,10 +75,10 @@ TEST_F(rnp_tests, test_load_g10)
 
     /* another store */
     pub_store = new rnp::KeyStore(
-      PGP_KEY_STORE_KBX, "data/test_stream_key_load/g10/pubring.kbx", global_ctx);
+      "data/test_stream_key_load/g10/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pub_store->load());
     sec_store = new rnp::KeyStore(
-      PGP_KEY_STORE_G10, "data/test_stream_key_load/g10/private-keys-v1.d", global_ctx);
+      "data/test_stream_key_load/g10/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     key_provider.userdata = pub_store;
     assert_true(sec_store->load(&key_provider));
 

--- a/src/tests/load-g23.cpp
+++ b/src/tests/load-g23.cpp
@@ -38,10 +38,10 @@ TEST_F(rnp_tests, test_load_g23)
 
     /* another store */
     auto pub_store = new rnp::KeyStore(
-      PGP_KEY_STORE_KBX, "data/test_stream_key_load/g23/pubring.kbx", global_ctx);
+      "data/test_stream_key_load/g23/pubring.kbx", global_ctx, rnp::KeyFormat::KBX);
     assert_true(pub_store->load());
     auto sec_store = new rnp::KeyStore(
-      PGP_KEY_STORE_G10, "data/test_stream_key_load/g23/private-keys-v1.d", global_ctx);
+      "data/test_stream_key_load/g23/private-keys-v1.d", global_ctx, rnp::KeyFormat::G10);
     key_provider.userdata = pub_store;
     assert_true(sec_store->load(&key_provider));
 

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -191,8 +191,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
     const pgp_signature_t *sig = NULL;
 
     // load keyring
-    auto key_store =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg", global_ctx);
+    auto key_store = new rnp::KeyStore("data/keyrings/1/pubring.gpg", global_ctx);
     assert_true(key_store->load());
 
     // find
@@ -335,8 +334,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
     const pgp_signature_t *sig = NULL;
 
     // load keyring
-    auto key_store =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/2/pubring.gpg", global_ctx);
+    auto key_store = new rnp::KeyStore("data/keyrings/2/pubring.gpg", global_ctx);
     assert_true(key_store->load());
 
     // find
@@ -371,8 +369,7 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
 
 TEST_F(rnp_tests, test_load_armored_pub_sec)
 {
-    auto key_store =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, MERGE_PATH "key-both.asc", global_ctx);
+    auto key_store = new rnp::KeyStore(MERGE_PATH "key-both.asc", global_ctx);
     assert_true(key_store->load());
 
     /* we must have 1 main key and 2 subkeys */
@@ -466,7 +463,7 @@ TEST_F(rnp_tests, test_load_merge)
     provider.callback = string_copy_password_callback;
     provider.userdata = (void *) "password";
 
-    auto        key_store = new rnp::KeyStore(PGP_KEY_STORE_GPG, "", global_ctx);
+    auto        key_store = new rnp::KeyStore("", global_ctx);
     std::string keyid = "9747D2A6B3A63124";
     std::string sub1id = "AF1114A47F5F5B28";
     std::string sub2id = "16CD16F267CCDD4F";
@@ -673,9 +670,9 @@ TEST_F(rnp_tests, test_load_merge)
 
 TEST_F(rnp_tests, test_load_public_from_secret)
 {
-    auto secstore = new rnp::KeyStore(PGP_KEY_STORE_GPG, MERGE_PATH "key-sec.asc", global_ctx);
+    auto secstore = new rnp::KeyStore(MERGE_PATH "key-sec.asc", global_ctx);
     assert_true(secstore->load());
-    auto pubstore = new rnp::KeyStore(PGP_KEY_STORE_GPG, "pubring.gpg", global_ctx);
+    auto pubstore = new rnp::KeyStore("pubring.gpg", global_ctx);
 
     std::string keyid = "9747D2A6B3A63124";
     std::string sub1id = "AF1114A47F5F5B28";
@@ -735,7 +732,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(pubstore->write());
     delete pubstore;
     /* reload */
-    pubstore = new rnp::KeyStore(PGP_KEY_STORE_GPG, "pubring.gpg", global_ctx);
+    pubstore = new rnp::KeyStore("pubring.gpg", global_ctx);
     assert_true(pubstore->load());
     assert_non_null(key = rnp_tests_get_key_by_id(pubstore, keyid));
     assert_non_null(skey1 = rnp_tests_get_key_by_id(pubstore, sub1id));
@@ -926,7 +923,7 @@ TEST_F(rnp_tests, test_key_import)
 
 TEST_F(rnp_tests, test_load_subkey)
 {
-    auto        key_store = new rnp::KeyStore(PGP_KEY_STORE_GPG, "", global_ctx);
+    auto        key_store = new rnp::KeyStore("", global_ctx);
     std::string keyid = "9747D2A6B3A63124";
     std::string sub1id = "AF1114A47F5F5B28";
     std::string sub2id = "16CD16F267CCDD4F";

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -339,8 +339,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     rnp::Key *      key = nullptr;
 
     /* load keys */
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/test_stream_signatures/pub.asc", global_ctx);
+    auto pubring = new rnp::KeyStore("data/test_stream_signatures/pub.asc", global_ctx);
     assert_true(pubring->load());
     /* load signature */
     assert_rnp_success(init_file_src(&sigsrc, "data/test_stream_signatures/source.txt.sig"));
@@ -367,8 +366,7 @@ TEST_F(rnp_tests, test_stream_signatures)
     /* now let's create signature and sign file */
 
     /* load secret key */
-    auto secring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/test_stream_signatures/sec.asc", global_ctx);
+    auto secring = new rnp::KeyStore("data/test_stream_signatures/sec.asc", global_ctx);
     assert_true(secring->load());
     assert_non_null(key = secring->get_signer(sig));
     assert_true(key->is_secret());
@@ -998,8 +996,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     rnp::SignatureInfo sinfo;
 
     /* v3 public key */
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/4/rsav3-p.asc", global_ctx);
+    auto pubring = new rnp::KeyStore("data/keyrings/4/rsav3-p.asc", global_ctx);
     assert_true(pubring->load());
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/4/rsav3-p.asc"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
@@ -1033,7 +1030,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
     delete pubring;
 
     /* keyring */
-    pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore("data/keyrings/1/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_rnp_success(init_file_src(&keysrc, "data/keyrings/1/pubring.gpg"));
     assert_rnp_success(process_pgp_keys(keysrc, keyseq, false));
@@ -1094,7 +1091,7 @@ TEST_F(rnp_tests, test_stream_key_signatures)
 static bool
 validate_key_sigs(const char *path, rnp::SecurityContext &global_ctx)
 {
-    auto pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, path, global_ctx);
+    auto pubring = new rnp::KeyStore(path, global_ctx);
     bool valid = pubring->load();
     for (auto &key : pubring->keys) {
         key.validate(*pubring);
@@ -1107,8 +1104,7 @@ validate_key_sigs(const char *path, rnp::SecurityContext &global_ctx)
 TEST_F(rnp_tests, test_stream_key_signature_validate)
 {
     /* v3 public key */
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/4/rsav3-p.asc", global_ctx);
+    auto pubring = new rnp::KeyStore("data/keyrings/4/rsav3-p.asc", global_ctx);
     assert_true(pubring->load());
     assert_int_equal(pubring->key_count(), 1);
     rnp::Key &pkey = pubring->keys.front();
@@ -1132,7 +1128,7 @@ TEST_F(rnp_tests, test_stream_key_signature_validate)
     delete pubring;
 
     /* keyring */
-    pubring = new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg", global_ctx);
+    pubring = new rnp::KeyStore("data/keyrings/1/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_true(pubring->key_count() > 0);
     int i = 0;
@@ -1482,7 +1478,7 @@ TEST_F(rnp_tests, test_stream_825_dearmor_blank_line)
 {
     pgp_source_t src = {};
 
-    auto keystore = new rnp::KeyStore(PGP_KEY_STORE_GPG, "", global_ctx);
+    auto keystore = new rnp::KeyStore("", global_ctx);
     assert_rnp_success(
       init_file_src(&src, "data/test_stream_armor/extra_line_before_trailer.asc"));
     assert_true(keystore->load(src));

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -57,8 +57,7 @@ find_subsig(const rnp::Key *key, const char *userid)
 
 TEST_F(rnp_tests, test_load_user_prefs)
 {
-    auto pubring =
-      new rnp::KeyStore(PGP_KEY_STORE_GPG, "data/keyrings/1/pubring.gpg", global_ctx);
+    auto pubring = new rnp::KeyStore("data/keyrings/1/pubring.gpg", global_ctx);
     assert_true(pubring->load());
     assert_int_equal(pubring->key_count(), 7);
 


### PR DESCRIPTION
Came accross these changes while refactoring pgp_fingerprint_t, so for better clarity and easier review moved them to separate PR.