### PR TITLE
Support use of botan-config.cmake

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -159,6 +159,28 @@ jobs:
           export PATH="$PWD/build/src/lib:$PATH"
           ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure
 
+      - name: Configure and build with botan-config.cmake
+        if:  matrix.backend == 'botan3'
+        run: |
+            rm -rf build
+            rm -rf ./cmake/Modules/FindBotan.cmake
+            shopt -s nullglob
+            files=(/opt/homebrew/lib/cmake/Botan-*/botan-config.cmake)
+            shopt -u nullglob
+
+            if [[ ${#files[@]} -eq 0 ]]; then
+              echo "Error: No botan-config.cmake found." >&2
+              exit 1
+            fi
+
+            brew install asciidoctor
+            cmake -B build -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }}   \
+                           -DCMAKE_BUILD_TYPE=Release                      \
+                           -DDOWNLOAD_GTEST=OFF                            \
+                           -DCRYPTO_BACKEND=botan3 .  
+            cmake --build build --config Release --parallel ${{ env.CORES }}
+            sudo cmake --install build
+
       - name: Checkout shell test framework
         if: matrix.shared_libs == 'on'
         uses: actions/checkout@v4

--- a/cmake/Modules/FindBotan.cmake
+++ b/cmake/Modules/FindBotan.cmake
@@ -46,7 +46,7 @@
 #   BOTAN_FOUND          - true if the headers and library were found
 #   BOTAN_INCLUDE_DIRS   - where to find headers
 #   BOTAN_LIBRARIES      - list of libraries to link
-#   BOTAN_VERSION        - library version that was found, if any
+#   Botan_VERSION        - library version that was found, if any
 #
 # Hints
 # ^^^^^
@@ -130,14 +130,14 @@ if(BOTAN_INCLUDE_DIR AND EXISTS "${BOTAN_INCLUDE_DIR}/botan/build.h")
            "\\1" _botan_version_minor "${botan_version_str}")
     string(REGEX REPLACE ".*#define[\t ]+BOTAN_VERSION_PATCH[\t ]+([0-9]+).*"
            "\\1" _botan_version_patch "${botan_version_str}")
-    set(BOTAN_VERSION "${_botan_version_major}.${_botan_version_minor}.${_botan_version_patch}"
+    set(Botan_VERSION "${_botan_version_major}.${_botan_version_minor}.${_botan_version_patch}"
                        CACHE INTERNAL "The version of Botan which was detected")
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Botan
   REQUIRED_VARS BOTAN_LIBRARY BOTAN_INCLUDE_DIR
-  VERSION_VAR BOTAN_VERSION
+  VERSION_VAR Botan_VERSION
 )
 
 if (BOTAN_FOUND)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -33,13 +33,19 @@ find_package(ZLIB REQUIRED)
 find_package(JSON-C 0.11 REQUIRED)
 if (CRYPTO_BACKEND_BOTAN3)
   find_package(Botan 3.0.0 REQUIRED)
-  set(CRYPTO_BACKEND_VERSION "${BOTAN_VERSION}")
 elseif (CRYPTO_BACKEND_BOTAN)
+  # botan-config.cmake from Botan distribution doesn't support version 2.x, 
+  # so use -DCRYPTO_BACKEND=botan3 to configure
   find_package(Botan 2.14.0 REQUIRED)
-  if(BOTAN_VERSION VERSION_GREATER_EQUAL 3.0.0)
+  if(Botan_VERSION VERSION_GREATER_EQUAL 3.0.0)
     set(CRYPTO_BACKEND_BOTAN3 1)
   endif()
-  set(CRYPTO_BACKEND_VERSION "${BOTAN_VERSION}")
+endif()
+if (CRYPTO_BACKEND_BOTAN)
+  # botan-config.cmake from Botan distribution sets Botan_VERSION instead of BOTAN_VERSION
+  # like we did and doesn't set BOTAN_INCLUDE_DIRS like our built-in did.
+  get_target_property(BOTAN_INCLUDE_DIRS Botan::Botan INTERFACE_INCLUDE_DIRECTORIES)
+  set(CRYPTO_BACKEND_VERSION "${Botan_VERSION}")
 endif()
 if (CRYPTO_BACKEND_OPENSSL)
   find_package(OpenSSL 1.1.1 REQUIRED)
@@ -168,12 +174,12 @@ if(CRYPTO_BACKEND_BOTAN)
       # public-key operations etc
       EME_PKCS1v15 EMSA_PKCS1 EMSA_RAW KDF_BASE RFC3394_KEYWRAP SP800_56A
   )
-  if(BOTAN_VERSION VERSION_LESS 3.0.0)
+  if(Botan_VERSION VERSION_LESS 3.0.0)
     set(_botan_required_features ${_botan_required_features} DL_PUBLIC_KEY_FAMILY)
   else()
     set(_botan_required_features ${_botan_required_features} DL_SCHEME RAW_HASH_FN)
   endif()
-  if(BOTAN_VERSION VERSION_GREATER_EQUAL 3.7.0)
+  if(Botan_VERSION VERSION_GREATER_EQUAL 3.7.0)
     set(_botan_required_features ${_botan_required_features}
         # Basic curves, see below for Brainpool/SM2
         PCURVES
@@ -186,7 +192,7 @@ if(CRYPTO_BACKEND_BOTAN)
     )
   endif()
   foreach(feature ${_botan_required_features})
-    check_cxx_symbol_exists("BOTAN_HAS_${feature}" botan/build.h _botan_has_${feature})
+    backend_has_feature("${feature}" _botan_has_${feature})
     if (NOT _botan_has_${feature})
       message(FATAL_ERROR "A required botan feature is missing: ${feature}")
     endif()
@@ -201,7 +207,7 @@ if(CRYPTO_BACKEND_BOTAN)
   resolve_feature_state(ENABLE_BLOWFISH "BLOWFISH")
   resolve_feature_state(ENABLE_CAST5 "CAST_128")
   resolve_feature_state(ENABLE_RIPEMD160 "RIPEMD_160")
-  if(BOTAN_VERSION VERSION_GREATER_EQUAL 3.7.0)
+  if(Botan_VERSION VERSION_GREATER_EQUAL 3.7.0)
     # Separate SM2 curve since 3.7.0
     resolve_feature_state(ENABLE_SM2 "PCURVES_SM2P256V1")
     # Botan supports Brainpool curves together with SECP via the ECC_GROUP define before the 3.7.0

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ if (CRYPTO_BACKEND_BOTAN3)
   find_package(Botan 3.0.0 REQUIRED)
 elseif (CRYPTO_BACKEND_BOTAN)
   find_package(Botan 2.14.0 REQUIRED)
-  if(BOTAN_VERSION VERSION_GREATER_EQUAL 3.0.0)
+  if(Botan_VERSION VERSION_GREATER_EQUAL 3.0.0)
     set(CRYPTO_BACKEND_BOTAN3 1)
   endif()
 endif()
@@ -192,6 +192,9 @@ if(MSVC)
       "${SHLWAPI_LIBRARY}"
       "${GETOPT_LIBRARY}"
     )
+endif()
+if (CRYPTO_BACKEND_BOTAN)
+  get_target_property(BOTAN_INCLUDE_DIRS Botan::Botan INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 target_include_directories(rnp_tests
   PRIVATE


### PR DESCRIPTION
It appears we didn't have best support for added via https://github.com/randombit/botan/pull/3722 botan-config.cmake, so this PR fixes that.
Since we still need to support Botan-2 I didn't delete builtin FindBotan.cmake
This should (or could) be a reason for issues @defnax experienced in #2307

Fixes #2121 
