### PR TITLE
Refactor pgp::mpi to use std::vector instead of fixed-size buffer.

### DIFF
--- a/src/lib/crypto/botan_utils.hpp
+++ b/src/lib/crypto/botan_utils.hpp
@@ -28,7 +28,7 @@
 #define RNP_BOTAN_UTILS_HPP_
 
 #include <botan/ffi.h>
-#include "mpi.h"
+#include "mpi.hpp"
 #include "utils.h"
 
 /* Self-destructing wrappers around the Botan's FFI objects */
@@ -53,7 +53,7 @@ class bn {
         }
     }
 
-    bn(const pgp::mpi &val) : bn(val.mpi, val.len){};
+    bn(const pgp::mpi &val) : bn(val.data(), val.size()){};
 
     bn(const bn &) = delete;
 
@@ -76,13 +76,14 @@ class bn {
     bool
     mpi(pgp::mpi &val) const noexcept
     {
-        val.len = bytes();
-        if (val.len > PGP_MPINT_SIZE) {
+        auto len = bytes();
+        if (len > PGP_MPINT_SIZE) {
             RNP_LOG("Too large MPI.");
-            val.len = 0;
+            val.resize(0);
             return false;
         }
-        return !botan_mp_to_bin(bn_, val.mpi);
+        val.resize(len);
+        return !botan_mp_to_bin(bn_, val.data());
     }
 
     bool

--- a/src/lib/crypto/common.h
+++ b/src/lib/crypto/common.h
@@ -28,7 +28,7 @@
 #define RNP_CRYPTO_COMMON_H_
 
 /* base */
-#include "mpi.h"
+#include "mpi.hpp"
 #include "rng.h"
 /* asymmetric crypto */
 #include "rsa.h"

--- a/src/lib/crypto/dl_ossl.h
+++ b/src/lib/crypto/dl_ossl.h
@@ -27,7 +27,7 @@
 #ifndef DL_OSSL_H_
 #define DL_OSSL_H_
 
-#include "mpi.h"
+#include "mpi.hpp"
 #include <rnp/rnp_def.h>
 #include "ossl_utils.hpp"
 

--- a/src/lib/crypto/dsa.h
+++ b/src/lib/crypto/dsa.h
@@ -30,7 +30,7 @@
 #include <rnp/rnp_def.h>
 #include <repgp/repgp_def.h>
 #include "crypto/rng.h"
-#include "crypto/mpi.h"
+#include "crypto/mpi.hpp"
 #include "crypto/mem.h"
 
 namespace pgp {

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -69,20 +69,20 @@ Key::generate_x25519(rnp::RNG &rng)
     if (botan_privkey_x25519_get_privkey(pr_key.get(), keyle.data())) {
         return RNP_ERROR_KEY_GENERATION;
     }
+    x.resize(32);
     for (int i = 0; i < 32; i++) {
-        x.mpi[31 - i] = keyle[i];
+        x[31 - i] = keyle[i];
     }
-    x.len = 32;
     /* botan doesn't tweak secret key bits, so we should do that here */
     if (!x25519_tweak_bits(*this)) {
         return RNP_ERROR_KEY_GENERATION;
     }
 
-    if (botan_pubkey_x25519_get_pubkey(pu_key.get(), &p.mpi[1])) {
+    p.resize(33);
+    if (botan_pubkey_x25519_get_pubkey(pu_key.get(), &p[1])) {
         return RNP_ERROR_KEY_GENERATION;
     }
-    p.len = 33;
-    p.mpi[0] = 0x40;
+    p[0] = 0x40;
     return RNP_SUCCESS;
 }
 
@@ -148,11 +148,10 @@ Key::generate(rnp::RNG &rng, const pgp_pubkey_alg_t alg_id, const pgp_curve_t cu
      * Note: Generated pk/sk may not always have exact number of bytes
      *       which is important when converting to octet-string
      */
-    memset(p.mpi, 0, sizeof(p.mpi));
-    p.mpi[0] = 0x04;
-    px.bin(&p.mpi[1 + field_size - px.bytes()]);
-    py.bin(&p.mpi[1 + 2 * field_size - py.bytes()]);
-    p.len = 2 * field_size + 1;
+    p.resize(2 * field_size + 1);
+    p[0] = 0x04;
+    px.bin(&p[1 + field_size - px.bytes()]);
+    py.bin(&p[1 + 2 * field_size - py.bytes()]);
     /* secret key value */
     bx.mpi(x);
     return RNP_SUCCESS;

--- a/src/lib/crypto/ec.h
+++ b/src/lib/crypto/ec.h
@@ -30,7 +30,7 @@
 #include <rnp/rnp_def.h>
 #include <repgp/repgp_def.h>
 #include "crypto/rng.h"
-#include "crypto/mpi.h"
+#include "crypto/mpi.hpp"
 #include "crypto/mem.h"
 #include "utils.h"
 #include <vector>

--- a/src/lib/crypto/ecdh_ossl.cpp
+++ b/src/lib/crypto/ecdh_ossl.cpp
@@ -327,7 +327,7 @@ encrypt_pkcs5(rnp::RNG &rng, Encrypted &out, const rnp::secure_bytes &in, const 
 rnp_result_t
 decrypt_pkcs5(rnp::secure_bytes &out, const Encrypted &in, const ec::Key &key)
 {
-    if (!key.x.bytes()) {
+    if (!key.x.size()) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 

--- a/src/lib/crypto/ecdh_utils.cpp
+++ b/src/lib/crypto/ecdh_utils.cpp
@@ -136,21 +136,21 @@ set_params(ec::Key &key, pgp_curve_t curve_id)
 bool
 x25519_tweak_bits(pgp::ec::Key &key)
 {
-    if (key.x.len != 32) {
+    if (key.x.size() != 32) {
         return false;
     }
     /* MPI is big-endian, while raw x25519 key is little-endian */
-    key.x.mpi[31] &= 248; // zero 3 low bits
-    key.x.mpi[0] &= 127;  // zero high bit
-    key.x.mpi[0] |= 64;   // set high - 1 bit
+    key.x[31] &= 248; // zero 3 low bits
+    key.x[0] &= 127;  // zero high bit
+    key.x[0] |= 64;   // set high - 1 bit
     return true;
 }
 
 bool
 x25519_bits_tweaked(const pgp::ec::Key &key)
 {
-    if (key.x.len != 32) {
+    if (key.x.size() != 32) {
         return false;
     }
-    return !(key.x.mpi[31] & 7) && (key.x.mpi[0] < 128) && (key.x.mpi[0] >= 64);
+    return !(key.x[31] & 7) && (key.x[0] < 128) && (key.x[0] >= 64);
 }

--- a/src/lib/crypto/elgamal.h
+++ b/src/lib/crypto/elgamal.h
@@ -29,7 +29,7 @@
 
 #include <stdint.h>
 #include "crypto/rng.h"
-#include "crypto/mpi.h"
+#include "crypto/mpi.hpp"
 #include "mem.h"
 
 namespace pgp {

--- a/src/lib/crypto/hash_common.cpp
+++ b/src/lib/crypto/hash_common.cpp
@@ -117,9 +117,9 @@ Hash::add(uint32_t val)
 void
 Hash::add(const pgp::mpi &val)
 {
-    size_t len = val.bytes();
+    size_t len = val.size();
     size_t idx = 0;
-    while ((idx < len) && (!val.mpi[idx])) {
+    while ((idx < len) && (!val[idx])) {
         idx++;
     }
 
@@ -129,11 +129,11 @@ Hash::add(const pgp::mpi &val)
     }
 
     add(len - idx);
-    if (val.mpi[idx] & 0x80) {
+    if (val[idx] & 0x80) {
         uint8_t padbyte = 0;
         add(&padbyte, 1);
     }
-    add(val.mpi + idx, len - idx);
+    add(val.data() + idx, len - idx);
 }
 
 std::vector<uint8_t>

--- a/src/lib/crypto/mpi.hpp
+++ b/src/lib/crypto/mpi.hpp
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018, 2024 Ribose Inc.
+ * Copyright (c) 2018-2025 Ribose Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,12 +24,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef RNP_MPI_H_
-#define RNP_MPI_H_
+#ifndef RNP_MPI_HPP_
+#define RNP_MPI_HPP_
 
 #include <cstdint>
 #include <cstdbool>
 #include <cstddef>
+#include <vector>
 
 /* 16384 bits should be pretty enough for now */
 #define PGP_MPINT_BITS (16384)
@@ -38,20 +39,26 @@
 /** multi-precision integer, used in signatures and public/secret keys */
 namespace pgp {
 
-typedef struct mpi {
-    /* Change this to vector once opaqueness is not required anymore */
-    uint8_t mpi[PGP_MPINT_SIZE];
-    size_t  len;
+class mpi {
+    std::vector<uint8_t> data_;
 
-    bool operator==(const struct mpi &src) const;
+  public:
+    bool           operator==(const mpi &src) const;
+    bool           operator!=(const mpi &src) const;
+    uint8_t &      operator[](size_t idx);
+    const uint8_t &operator[](size_t idx) const;
 
-    bool   from_mem(const void *mem, size_t len) noexcept;
-    void   to_mem(void *mem) const noexcept;
-    size_t bits() const noexcept;
-    size_t bytes() const noexcept;
-    void   forget() noexcept;
-} mpi;
+    void assign(const uint8_t *val, size_t size);
+    void copy(uint8_t *dst) const noexcept;
+    void resize(size_t size, uint8_t fill = 0);
+    void forget() noexcept;
+
+    uint8_t *      data() noexcept;
+    const uint8_t *data() const noexcept;
+    size_t         size() const noexcept;
+    size_t         bits() const noexcept;
+};
 
 } // namespace pgp
 
-#endif // MPI_H_
+#endif // MPI_HPP_

--- a/src/lib/crypto/ossl_utils.hpp
+++ b/src/lib/crypto/ossl_utils.hpp
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <cstdint>
 #include "config.h"
-#include "mpi.h"
+#include "mpi.hpp"
 #include <cassert>
 #include <memory>
 #include <openssl/bn.h>
@@ -72,7 +72,7 @@ class bn {
         }
 
         _bn = BN_new();
-        if (_bn && !BN_bin2bn(val->mpi, val->len, _bn)) {
+        if (_bn && !BN_bin2bn(val->data(), val->size(), _bn)) {
             BN_free(_bn);
             _bn = NULL;
         }
@@ -159,11 +159,12 @@ class bn {
     static bool
     mpi(const BIGNUM *num, pgp::mpi &mpi) noexcept
     {
-        assert((size_t) BN_num_bytes(num) <= sizeof(mpi.mpi));
-        if (BN_bn2bin(num, mpi.mpi) < 0) {
+        size_t bytes = (size_t) BN_num_bytes(num);
+        assert(bytes <= PGP_MPINT_SIZE);
+        mpi.resize(bytes);
+        if (BN_bn2bin(num, mpi.data()) < 0) {
             return false;
         }
-        mpi.len = BN_num_bytes(num);
         return true;
     }
 

--- a/src/lib/crypto/rsa.h
+++ b/src/lib/crypto/rsa.h
@@ -30,7 +30,7 @@
 #include <rnp/rnp_def.h>
 #include <repgp/repgp_def.h>
 #include "crypto/rng.h"
-#include "crypto/mpi.h"
+#include "crypto/mpi.hpp"
 #include "mem.h"
 
 namespace pgp {

--- a/src/lib/fingerprint.cpp
+++ b/src/lib/fingerprint.cpp
@@ -60,8 +60,9 @@ Fingerprint::Fingerprint(const pgp_key_pkt_t &key)
         hash->add(rsa.e());
         fp_ = hash->finish();
         /* keyid just low bytes of RSA n */
-        size_t n = rsa.n().bytes();
-        std::memcpy(keyid_.data(), rsa.n().mpi + n - keyid_.size(), keyid_.size());
+        size_t n = rsa.n().size();
+        size_t sz = std::min(rsa.n().size(), keyid_.size());
+        std::memcpy(keyid_.data(), rsa.n().data() + n - sz, sz);
         return;
     }
     case PGP_V4:

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -8076,7 +8076,7 @@ add_json_mpis(json_object *jso, ...)
             ret = RNP_ERROR_BAD_PARAMETERS;
             goto done;
         }
-        if (!json_add_hex(jso, name, val->mpi, val->len)) {
+        if (!json_add_hex(jso, name, val->data(), val->size())) {
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto done;
         }

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -296,9 +296,11 @@ read_mpi(const sexp_list_t *list, const std::string &name, pgp::mpi &val) noexce
     /* strip leading zero */
     const auto &bytes = data->get_string();
     if ((bytes.size() > 1) && !bytes[0] && (bytes[1] & 0x80)) {
-        return val.from_mem(bytes.data() + 1, bytes.size() - 1);
+        val.assign(bytes.data() + 1, bytes.size() - 1);
+    } else {
+        val.assign(bytes.data(), bytes.size());
     }
-    return val.from_mem(bytes.data(), bytes.size());
+    return true;
 }
 
 static bool
@@ -329,18 +331,18 @@ gnupg_sexp_t::add_mpi(const std::string &name, const pgp::mpi &mpi)
     sub_s_exp->push_back(value_block);
 
     sexp_simple_string_t data;
-    size_t               len = mpi.bytes();
+    size_t               len = mpi.size();
     size_t               idx;
 
-    for (idx = 0; (idx < len) && !mpi.mpi[idx]; idx++)
+    for (idx = 0; (idx < len) && !mpi[idx]; idx++)
         ;
 
     if (idx < len) {
-        if (mpi.mpi[idx] & 0x80) {
+        if (mpi[idx] & 0x80) {
             data.append(0);
-            data.std::basic_string<uint8_t>::append(mpi.mpi + idx, len - idx);
+            data.std::basic_string<uint8_t>::append(mpi.data() + idx, len - idx);
         } else {
-            data.assign(mpi.mpi + idx, mpi.mpi + len);
+            data.assign(mpi.data() + idx, mpi.data() + len);
         }
         value_block->set_string(data);
     }

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -335,7 +335,7 @@ dst_print_mpi(pgp_dest_t *dst, const char *name, const pgp::mpi &mpi, bool dumpb
         dst_printf(dst, "%s: %zu bits\n", name, mpi.bits());
     } else {
         char hex[5000];
-        vsnprinthex(hex, sizeof(hex), mpi.mpi, mpi.len);
+        vsnprinthex(hex, sizeof(hex), mpi.data(), mpi.size());
         dst_printf(dst, "%s: %zu bits, %s\n", name, mpi.bits(), hex);
     }
 }
@@ -1710,7 +1710,7 @@ obj_add_mpi_json(json_object *obj, const char *name, const pgp::mpi &mpi, bool c
         return true;
     }
     snprintf(strname, sizeof(strname), "%s.raw", name);
-    return json_add_hex(obj, strname, mpi.mpi, mpi.len);
+    return json_add_hex(obj, strname, mpi.data(), mpi.size());
 }
 
 static bool

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -593,12 +593,12 @@ pgp_packet_body_t::get(pgp::mpi &val) noexcept
         RNP_LOG("0 mpi");
         return false;
     }
-    if (!get(val.mpi, len)) {
+    val.resize(len);
+    if (!get(val.data(), len)) {
         RNP_LOG("failed to read mpi body");
         return false;
     }
     /* check the mpi bit count */
-    val.len = len;
     size_t mbits = val.bits();
     if (mbits != bits) {
         RNP_LOG(
@@ -746,17 +746,17 @@ pgp_packet_body_t::add(const pgp::KeyID &val)
 void
 pgp_packet_body_t::add(const pgp::mpi &val)
 {
-    if (!val.len) {
+    if (!val.size()) {
         throw rnp::rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
 
-    unsigned idx = 0;
-    while ((idx < val.len - 1) && (!val.mpi[idx])) {
+    size_t idx = 0;
+    while ((idx < val.size() - 1) && (!val[idx])) {
         idx++;
     }
 
-    unsigned bits = (val.len - idx - 1) << 3;
-    unsigned hibyte = val.mpi[idx];
+    size_t  bits = (val.size() - idx - 1) << 3;
+    uint8_t hibyte = val[idx];
     while (hibyte) {
         bits++;
         hibyte = hibyte >> 1;
@@ -764,7 +764,7 @@ pgp_packet_body_t::add(const pgp::mpi &val)
 
     uint8_t hdr[2] = {(uint8_t)(bits >> 8), (uint8_t)(bits & 0xff)};
     add(hdr, 2);
-    add(val.mpi + idx, val.len - idx);
+    add(val.data() + idx, val.size() - idx);
 }
 
 void

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -369,7 +369,8 @@ bool
 hex2mpi(pgp::mpi *val, const char *hex)
 {
     auto hexbin = rnp::hex_to_bin(hex);
-    return val->from_mem(hexbin.data(), hexbin.size());
+    val->assign(hexbin.data(), hexbin.size());
+    return true;
 }
 
 bool
@@ -397,8 +398,7 @@ test_ffi_init(rnp_ffi_t *ffi)
 bool
 mpi_empty(const pgp::mpi &val)
 {
-    pgp::mpi zero{};
-    return (val.len == 0) && !memcmp(val.mpi, zero.mpi, PGP_MPINT_SIZE);
+    return val.size() == 0;
 }
 
 bool


### PR DESCRIPTION
Less memory usage, more robust, cleaner code.