### PR TITLE
Generate 3072-bit RSA keys by default

### DIFF
--- a/docs/cli-usage.adoc
+++ b/docs/cli-usage.adoc
@@ -2,7 +2,7 @@
 
 == Generating an RSA private key
 
-By default, `rnpkeys  --generate-key` generates a 2048-bit RSA key.
+By default, `rnpkeys  --generate-key` generates a 3072-bit RSA key.
 
 [source,console]
 ----

--- a/src/lib/defaults.h
+++ b/src/lib/defaults.h
@@ -59,7 +59,7 @@
 #define DEFAULT_PK_ALG PGP_PKA_RSA
 
 /* Default RSA key length */
-#define DEFAULT_RSA_NUMBITS 2048
+#define DEFAULT_RSA_NUMBITS 3072
 
 /* Default ElGamal key length */
 #define DEFAULT_ELGAMAL_NUMBITS 2048

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -111,7 +111,7 @@ Without additional options, an RSA primary key pair with an RSA sub-key pair wil
 Additional options:
 
 *--numbits*:::
-Overrides the default RSA key size of *2048* bits.
+Overrides the default key size. For RSA it is *3072* bits.
 
 *--expiration* _TIME_:::
 Set key and subkey expiration time, counting from the creation time. +

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -10,7 +10,7 @@
 #include "../rnp/fficli.h"
 #include "logging.h"
 
-#define DEFAULT_RSA_NUMBITS 2048
+#define DEFAULT_RSA_NUMBITS 3072
 
 typedef enum {
     /* commands */

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1049,7 +1049,7 @@ class Keystore(unittest.TestCase):
             params = ['--numbits', str(bits)]
         else:
             params = []
-            bits = 2048
+            bits = 3072
 
         userid = str(bits) + '@rnptest'
         # Open pipe for password
@@ -4302,6 +4302,12 @@ class Misc(unittest.TestCase):
         self.assertRegex(err, r'(?s)^.*wrong armor trailer.*')
         self.assertRegex(err, r'(?s)^.*dearmoring failed.*')
 
+    def test_default_rsa_keygen(self):
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR2, '--generate', '--password', PASSWORD])
+        self.assertEqual(ret, 0)
+        self.assertRegex(out, r'(?s)^.*sec.*3072/RSA.*\[SC\].*ssb.*3072/RSA.*\[E\].*')
+        self.assertRegex(err, r'(?s)^.*Keyring directory.*is empty.*')
+
 class Encryption(unittest.TestCase):
     '''
         Things to try later:
@@ -5188,7 +5194,7 @@ class SignDefault(unittest.TestCase):
         # Make sure we can add subkey
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR2, '--password', PASSWORD, '--edit-key', 'dsa4096', '--add-subkey'], 'y\n')
         self.assertEqual(ret, 0)
-        self.assertRegex(out, r'(?s)^.*ssb.*2048/RSA.*EXPIRES.*')
+        self.assertRegex(out, r'(?s)^.*ssb.*3072/RSA.*EXPIRES.*')
 
     def test_verify_enconly_key(self):
         ret, _, err = run_proc(RNP, ['--keyfile', data_path('test_messages/key-rsas-rsae.asc'), '--verify', data_path('test_messages/message-signed-rsae.txt.pgp')])

--- a/src/tests/ffi-key.cpp
+++ b/src/tests/ffi-key.cpp
@@ -787,6 +787,16 @@ TEST_F(rnp_tests, test_ffi_key_generate_rsa)
     assert_int_equal(subkeys, 0);
     /* cleanup */
     assert_rnp_success(rnp_key_handle_destroy(key));
+    /* generate RSA keypair with default sizes */
+    assert_rnp_success(rnp_generate_key_ex(
+      ffi, RNP_ALGNAME_RSA, RNP_ALGNAME_RSA, 0, 0, NULL, NULL, "rsa_default", NULL, &key));
+    assert_rnp_success(rnp_key_get_bits(key, &bits));
+    assert_int_equal(bits, 3072);
+    assert_rnp_success(rnp_key_get_subkey_at(key, 0, &subkey));
+    assert_rnp_success(rnp_key_get_bits(subkey, &bits));
+    assert_int_equal(bits, 3072);
+    assert_rnp_success(rnp_key_handle_destroy(subkey));
+    assert_rnp_success(rnp_key_handle_destroy(key));
     assert_rnp_success(rnp_ffi_destroy(ffi));
 }
 


### PR DESCRIPTION
..instead of previously used 2048 bits.
Fixes #2337 