### PR TITLE
Refactor key grip and signature packet.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -62,7 +62,7 @@ typedef std::unordered_map<pgp::Fingerprint, std::list<Key>::iterator> KeyFinger
 class KeyStore {
   private:
     Key *                   add_subkey(Key &srckey, Key *oldkey);
-    pgp_sig_import_status_t import_subkey_signature(Key &key, const pgp_signature_t &sig);
+    pgp_sig_import_status_t import_subkey_signature(Key &key, const pgp::pkt::Signature &sig);
     bool                    refresh_subkey_grips(Key &key);
 
   public:
@@ -166,7 +166,7 @@ class KeyStore {
      * @param prov key provider to request needed key.
      * @return pointer to the key or nullptr if signer's key was not found.
      */
-    Key *get_signer(const pgp_signature_t &sig, const KeyProvider *prov = nullptr);
+    Key *get_signer(const pgp::pkt::Signature &sig, const KeyProvider *prov = nullptr);
 
     /**
      * @brief Add key to the keystore, copying it.
@@ -187,10 +187,10 @@ class KeyStore {
      * @return pointer to the newly added signature or nullptr if error occurred (key not
      *         found, whatever else).
      */
-    Signature *add_key_sig(const pgp::Fingerprint &keyfp,
-                           const pgp_signature_t & sig,
-                           const pgp_userid_pkt_t *uid,
-                           bool                    front);
+    Signature *add_key_sig(const pgp::Fingerprint &   keyfp,
+                           const pgp::pkt::Signature &sig,
+                           const pgp_userid_pkt_t *   uid,
+                           bool                       front);
 
     /**
      * @brief Add transferable key to the keystore.
@@ -220,7 +220,7 @@ class KeyStore {
     /**
      * @brief Import signature for the specified key.
      */
-    pgp_sig_import_status_t import_signature(Key &key, const pgp_signature_t &sig);
+    pgp_sig_import_status_t import_signature(Key &key, const pgp::pkt::Signature &sig);
 
     /**
      * @brief Import revocation or direct-key signature to the keystore.
@@ -230,7 +230,7 @@ class KeyStore {
      * @return pointer to the key to which this signature belongs (or nullptr if key was not
      * found)
      */
-    Key *import_signature(const pgp_signature_t &sig, pgp_sig_import_status_t *status);
+    Key *import_signature(const pgp::pkt::Signature &sig, pgp_sig_import_status_t *status);
 
     /**
      * @brief Remove key from the keystore.

--- a/src/lib/crypto/signatures.cpp
+++ b/src/lib/crypto/signatures.cpp
@@ -44,9 +44,9 @@
  * @return RNP_SUCCESS on success or some error otherwise
  */
 static rnp::secure_bytes
-signature_hash_finish(const pgp_signature_t &  sig,
-                      rnp::Hash &              hash,
-                      const pgp_literal_hdr_t *hdr)
+signature_hash_finish(const pgp::pkt::Signature &sig,
+                      rnp::Hash &                hash,
+                      const pgp_literal_hdr_t *  hdr)
 {
     hash.add(sig.hashed_data);
     switch (sig.version) {
@@ -91,7 +91,7 @@ signature_hash_finish(const pgp_signature_t &  sig,
 }
 
 std::unique_ptr<rnp::Hash>
-signature_init(const pgp_key_pkt_t &key, const pgp_signature_t &sig)
+signature_init(const pgp_key_pkt_t &key, const pgp::pkt::Signature &sig)
 {
     auto hash = rnp::Hash::create(sig.halg);
 
@@ -109,7 +109,7 @@ signature_init(const pgp_key_pkt_t &key, const pgp_signature_t &sig)
 }
 
 void
-signature_calculate(pgp_signature_t &        sig,
+signature_calculate(pgp::pkt::Signature &    sig,
                     pgp::KeyMaterial &       seckey,
                     rnp::Hash &              hash,
                     rnp::SecurityContext &   ctx,
@@ -149,7 +149,7 @@ signature_calculate(pgp_signature_t &        sig,
 }
 
 rnp::SigValidity
-signature_validate(const pgp_signature_t &     sig,
+signature_validate(const pgp::pkt::Signature & sig,
                    const pgp::KeyMaterial &    key,
                    rnp::Hash &                 hash,
                    const rnp::SecurityContext &ctx,

--- a/src/lib/crypto/signatures.h
+++ b/src/lib/crypto/signatures.h
@@ -37,8 +37,8 @@
  * @param hash_alg the digest algo to be used
  * @param hash digest object that will be initialized
  */
-std::unique_ptr<rnp::Hash> signature_init(const pgp_key_pkt_t &  key,
-                                          const pgp_signature_t &sig);
+std::unique_ptr<rnp::Hash> signature_init(const pgp_key_pkt_t &      key,
+                                          const pgp::pkt::Signature &sig);
 
 /**
  * @brief Calculate signature with pre-populated hash
@@ -49,7 +49,7 @@ std::unique_ptr<rnp::Hash> signature_init(const pgp_key_pkt_t &  key,
  * @param ctx security context
  * @param hdr literal packet header for attached document signatures or NULL otherwise.
  */
-void signature_calculate(pgp_signature_t &        sig,
+void signature_calculate(pgp::pkt::Signature &    sig,
                          pgp::KeyMaterial &       seckey,
                          rnp::Hash &              hash,
                          rnp::SecurityContext &   ctx,
@@ -67,7 +67,7 @@ void signature_calculate(pgp_signature_t &        sig,
  * @param hdr literal packet header for attached document signatures or NULL otherwise.
  * @return RNP_SUCCESS if signature was successfully validated or error code otherwise.
  */
-rnp::SigValidity signature_validate(const pgp_signature_t &     sig,
+rnp::SigValidity signature_validate(const pgp::pkt::Signature & sig,
                                     const pgp::KeyMaterial &    key,
                                     rnp::Hash &                 hash,
                                     const rnp::SecurityContext &ctx,

--- a/src/lib/ffi-priv-types.h
+++ b/src/lib/ffi-priv-types.h
@@ -215,10 +215,10 @@ struct rnp_op_sign_st {
 };
 
 struct rnp_op_verify_signature_st {
-    rnp_ffi_t        ffi;
-    rnp_result_t     verify_status;
-    rnp::SigValidity validity;
-    pgp_signature_t  sig_pkt;
+    rnp_ffi_t           ffi;
+    rnp_result_t        verify_status;
+    rnp::SigValidity    validity;
+    pgp::pkt::Signature sig_pkt;
 };
 
 struct rnp_op_verify_st {

--- a/src/lib/fingerprint.hpp
+++ b/src/lib/fingerprint.hpp
@@ -55,7 +55,8 @@ static_assert(PGP_FINGERPRINT_V5_SIZE == PGP_FINGERPRINT_V6_SIZE, "FP size misma
 
 namespace pgp {
 
-typedef std::array<uint8_t, PGP_KEY_ID_SIZE> KeyID;
+using KeyID = std::array<uint8_t, PGP_KEY_ID_SIZE>;
+using KeyGrip = std::array<uint8_t, PGP_KEY_GRIP_SIZE>;
 
 class Fingerprint {
     std::vector<uint8_t> fp_;

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -64,7 +64,7 @@ KeySearch::create(const pgp::Fingerprint &fp)
 }
 
 std::unique_ptr<KeySearch>
-KeySearch::create(const pgp_key_grip_t &grip)
+KeySearch::create(const pgp::KeyGrip &grip)
 {
     return std::unique_ptr<KeySearch>(new KeyGripSearch(grip));
 }
@@ -111,7 +111,7 @@ KeySearch::create(const std::string &name, const std::string &value)
             RNP_LOG("Invalid grip: %s", value.c_str());
             return nullptr;
         }
-        pgp_key_grip_t grip{};
+        pgp::KeyGrip grip{};
         memcpy(grip.data(), binval.data(), grip.size());
         return create(grip);
     }
@@ -198,7 +198,7 @@ KeyGripSearch::value() const
     return bin_to_hex(grip_.data(), grip_.size());
 }
 
-KeyGripSearch::KeyGripSearch(const pgp_key_grip_t &grip)
+KeyGripSearch::KeyGripSearch(const pgp::KeyGrip &grip)
 {
     type_ = Type::Grip;
     grip_ = grip;

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -56,7 +56,7 @@ class KeySearch {
 
     static std::unique_ptr<KeySearch> create(const pgp::KeyID &keyid);
     static std::unique_ptr<KeySearch> create(const pgp::Fingerprint &fp);
-    static std::unique_ptr<KeySearch> create(const pgp_key_grip_t &grip);
+    static std::unique_ptr<KeySearch> create(const pgp::KeyGrip &grip);
     static std::unique_ptr<KeySearch> create(const std::string &uid);
     static std::unique_ptr<KeySearch> create(const std::string &name,
                                              const std::string &value);
@@ -90,14 +90,14 @@ class KeyFingerprintSearch : public KeySearch {
 };
 
 class KeyGripSearch : public KeySearch {
-    pgp_key_grip_t grip_;
+    pgp::KeyGrip grip_;
 
   public:
     bool              matches(const Key &key) const;
     const std::string name() const;
     std::string       value() const;
 
-    KeyGripSearch(const pgp_key_grip_t &grip);
+    KeyGripSearch(const pgp::KeyGrip &grip);
 };
 
 class KeyUIDSearch : public KeySearch {

--- a/src/lib/key.cpp
+++ b/src/lib/key.cpp
@@ -912,7 +912,7 @@ Key::has_secret() const noexcept
     if (!is_secret()) {
         return false;
     }
-    if ((format == KeyFormat::GPG) && !pkt_.sec_len) {
+    if ((format == KeyFormat::GPG) && pkt_.sec_data.empty()) {
         return false;
     }
     if (pkt_.sec_protection.s2k.usage == PGP_S2KU_NONE) {

--- a/src/lib/key.cpp
+++ b/src/lib/key.cpp
@@ -1123,7 +1123,7 @@ Key::fp() const noexcept
     return fingerprint_;
 }
 
-const pgp_key_grip_t &
+const pgp::KeyGrip &
 Key::grip() const noexcept
 {
     return grip_;

--- a/src/lib/key.hpp
+++ b/src/lib/key.hpp
@@ -94,35 +94,35 @@ class Key {
     Key &operator=(const Key &) = default;
     Key &operator=(Key &&) = default;
 
-    size_t                  sig_count() const;
-    Signature &             get_sig(size_t idx);
-    const Signature &       get_sig(size_t idx) const;
-    bool                    has_sig(const pgp::SigID &id) const;
-    Signature &             replace_sig(const pgp::SigID &id, const pgp_signature_t &newsig);
-    Signature &             get_sig(const pgp::SigID &id);
-    const Signature &       get_sig(const pgp::SigID &id) const;
-    Signature &             add_sig(const pgp_signature_t &sig,
-                                    size_t                 uid = UserID::None,
-                                    bool                   begin = false);
-    bool                    del_sig(const pgp::SigID &sigid);
-    size_t                  del_sigs(const pgp::SigIDs &sigs);
-    size_t                  keysig_count() const;
-    Signature &             get_keysig(size_t idx);
-    size_t                  uid_count() const;
-    UserID &                get_uid(size_t idx);
-    const UserID &          get_uid(size_t idx) const;
-    UserID &                add_uid(const pgp_transferable_userid_t &uid);
-    bool                    has_uid(const std::string &uid) const;
-    uint32_t                uid_idx(const pgp_userid_pkt_t &uid) const;
-    void                    del_uid(size_t idx);
-    bool                    has_primary_uid() const;
-    uint32_t                get_primary_uid() const;
-    bool                    revoked() const;
-    const Revocation &      revocation() const;
-    void                    clear_revokes();
-    void                    add_revoker(const pgp::Fingerprint &revoker);
-    bool                    has_revoker(const pgp::Fingerprint &revoker) const;
-    size_t                  revoker_count() const;
+    size_t            sig_count() const;
+    Signature &       get_sig(size_t idx);
+    const Signature & get_sig(size_t idx) const;
+    bool              has_sig(const pgp::SigID &id) const;
+    Signature &       replace_sig(const pgp::SigID &id, const pgp::pkt::Signature &newsig);
+    Signature &       get_sig(const pgp::SigID &id);
+    const Signature & get_sig(const pgp::SigID &id) const;
+    Signature &       add_sig(const pgp::pkt::Signature &sig,
+                              size_t                     uid = UserID::None,
+                              bool                       begin = false);
+    bool              del_sig(const pgp::SigID &sigid);
+    size_t            del_sigs(const pgp::SigIDs &sigs);
+    size_t            keysig_count() const;
+    Signature &       get_keysig(size_t idx);
+    size_t            uid_count() const;
+    UserID &          get_uid(size_t idx);
+    const UserID &    get_uid(size_t idx) const;
+    UserID &          add_uid(const pgp_transferable_userid_t &uid);
+    bool              has_uid(const std::string &uid) const;
+    uint32_t          uid_idx(const pgp_userid_pkt_t &uid) const;
+    void              del_uid(size_t idx);
+    bool              has_primary_uid() const;
+    uint32_t          get_primary_uid() const;
+    bool              revoked() const;
+    const Revocation &revocation() const;
+    void              clear_revokes();
+    void              add_revoker(const pgp::Fingerprint &revoker);
+    bool              has_revoker(const pgp::Fingerprint &revoker) const;
+    size_t            revoker_count() const;
     const pgp::Fingerprint &get_revoker(size_t idx) const;
 
     const pgp_key_pkt_t &   pkt() const noexcept;
@@ -406,11 +406,11 @@ class Key {
      * @param creation signature's creation time.
      * @param version signature version
      */
-    void sign_init(RNG &            rng,
-                   pgp_signature_t &sig,
-                   pgp_hash_alg_t   hash,
-                   uint64_t         creation,
-                   pgp_version_t    version) const;
+    void sign_init(RNG &                rng,
+                   pgp::pkt::Signature &sig,
+                   pgp_hash_alg_t       hash,
+                   uint64_t             creation,
+                   pgp_version_t        version) const;
 
     /**
      * @brief Calculate a certification and fill signature material.
@@ -424,7 +424,7 @@ class Key {
      */
     void sign_cert(const pgp_key_pkt_t &   key,
                    const pgp_userid_pkt_t &uid,
-                   pgp_signature_t &       sig,
+                   pgp::pkt::Signature &   sig,
                    SecurityContext &       ctx);
 
     /**
@@ -435,7 +435,7 @@ class Key {
      * @param sig signature, pre-populated with all of the required data, except the
      *            signature material.
      */
-    void sign_direct(const pgp_key_pkt_t &key, pgp_signature_t &sig, SecurityContext &ctx);
+    void sign_direct(const pgp_key_pkt_t &key, pgp::pkt::Signature &sig, SecurityContext &ctx);
 
     /**
      * @brief Calculate subkey or primary key binding.
@@ -446,7 +446,9 @@ class Key {
      * @param sig signature, pre-populated with all of the required data, except the
      *            signature material.
      */
-    void sign_binding(const pgp_key_pkt_t &key, pgp_signature_t &sig, SecurityContext &ctx);
+    void sign_binding(const pgp_key_pkt_t &key,
+                      pgp::pkt::Signature &sig,
+                      SecurityContext &    ctx);
 
     /**
      * @brief Calculate subkey binding.
@@ -459,10 +461,10 @@ class Key {
      * @param sig signature, pre-populated with all of the required data, except the
      *            signature material.
      */
-    void sign_subkey_binding(Key &            sub,
-                             pgp_signature_t &sig,
-                             SecurityContext &ctx,
-                             bool             subsign = false);
+    void sign_subkey_binding(Key &                sub,
+                             pgp::pkt::Signature &sig,
+                             SecurityContext &    ctx,
+                             bool                 subsign = false);
 
     /**
      * @brief Generate key or subkey revocation signature.
@@ -474,7 +476,7 @@ class Key {
     void gen_revocation(const Revocation &   rev,
                         pgp_hash_alg_t       hash,
                         const pgp_key_pkt_t &key,
-                        pgp_signature_t &    sig,
+                        pgp::pkt::Signature &sig,
                         SecurityContext &    ctx);
 
 #if defined(ENABLE_CRYPTO_REFRESH)

--- a/src/lib/key.hpp
+++ b/src/lib/key.hpp
@@ -60,7 +60,7 @@ class Key {
     uint8_t             flags_{};      /* key flags */
     uint32_t            expiration_{}; /* key expiration time, if available */
     pgp::Fingerprint    fingerprint_;
-    pgp_key_grip_t      grip_{};
+    pgp::KeyGrip        grip_{};
     pgp::Fingerprint    primary_fp_; /* fingerprint of the primary key (for subkeys) */
     bool                primary_fp_set_{};
     pgp::Fingerprints   subkey_fps_; /* array of subkey fingerprints (for primary keys) */
@@ -181,7 +181,7 @@ class Key {
     /** @brief Get key's fingerprint */
     const pgp::Fingerprint &fp() const noexcept;
     /** @brief Get key's grip */
-    const pgp_key_grip_t &grip() const noexcept;
+    const pgp::KeyGrip &grip() const noexcept;
     /** @brief Get primary key's fingerprint for the subkey, if it is available.
      *         Note: will throw if it is not available, use has_primary_fp() to check.
      */

--- a/src/lib/key_material.cpp
+++ b/src/lib/key_material.cpp
@@ -361,12 +361,12 @@ KeyMaterial::curve() const noexcept
     return PGP_CURVE_UNKNOWN;
 }
 
-pgp_key_grip_t
+KeyGrip
 KeyMaterial::grip() const
 {
     auto hash = rnp::Hash::create(PGP_HASH_SHA1);
     grip_update(*hash);
-    pgp_key_grip_t res{};
+    KeyGrip res{};
     hash->finish(res.data());
     return res;
 }

--- a/src/lib/key_material.hpp
+++ b/src/lib/key_material.hpp
@@ -31,6 +31,7 @@
 #include "defaults.h"
 #include "enc_material.hpp"
 #include "sig_material.hpp"
+#include "fingerprint.hpp"
 
 typedef struct pgp_packet_body_t pgp_packet_body_t;
 
@@ -224,7 +225,7 @@ class KeyMaterial {
     virtual bool           sig_hash_allowed(pgp_hash_alg_t hash) const;
     virtual size_t         bits() const noexcept = 0;
     virtual pgp_curve_t    curve() const noexcept;
-    pgp_key_grip_t         grip() const;
+    KeyGrip                grip() const;
 
     static std::unique_ptr<KeyMaterial> create(pgp_pubkey_alg_t alg);
     static std::unique_ptr<KeyMaterial> create(pgp_pubkey_alg_t alg, const rsa::Key &key);

--- a/src/lib/keygen.cpp
+++ b/src/lib/keygen.cpp
@@ -363,7 +363,7 @@ KeygenParams::generate(BindingParams &                binding,
            subkey_sec.refresh_data(&primary_sec, ctx());
 }
 
-UserPrefs::UserPrefs(const pgp_signature_t &sig)
+UserPrefs::UserPrefs(const pgp::pkt::Signature &sig)
 {
     symm_algs = sig.preferred_symm_algs();
     hash_algs = sig.preferred_hash_algs();
@@ -472,7 +472,7 @@ CertParams::populate(pgp_userid_pkt_t &uid) const
 }
 
 void
-CertParams::populate(pgp_signature_t &sig) const
+CertParams::populate(pgp::pkt::Signature &sig) const
 {
     if (key_expiration) {
         sig.set_key_expiration(key_expiration);
@@ -520,7 +520,7 @@ CertParams::populate(pgp_signature_t &sig) const
 }
 
 void
-CertParams::populate(pgp_userid_pkt_t &uid, pgp_signature_t &sig) const
+CertParams::populate(pgp_userid_pkt_t &uid, pgp::pkt::Signature &sig) const
 {
     sig.set_type(PGP_CERT_POSITIVE);
     populate(sig);

--- a/src/lib/keygen.hpp
+++ b/src/lib/keygen.hpp
@@ -140,7 +140,7 @@ class UserPrefs {
 #endif
 
     UserPrefs(){};
-    UserPrefs(const pgp_signature_t &sig);
+    UserPrefs(const pgp::pkt::Signature &sig);
 
     void add_symm_alg(pgp_symm_alg_t alg);
     void add_hash_alg(pgp_hash_alg_t alg);
@@ -166,8 +166,8 @@ class CertParams {
      * @brief Populate uid and sig packet with data stored in this struct.
      *        At some point we should get rid of it.
      */
-    void populate(pgp_userid_pkt_t &uid, pgp_signature_t &sig) const;
-    void populate(pgp_signature_t &sig) const;
+    void populate(pgp_userid_pkt_t &uid, pgp::pkt::Signature &sig) const;
+    void populate(pgp::pkt::Signature &sig) const;
     void populate(pgp_userid_pkt_t &uid) const;
 };
 

--- a/src/lib/rawpacket.cpp
+++ b/src/lib/rawpacket.cpp
@@ -37,7 +37,7 @@ RawPacket::RawPacket(const uint8_t *data, size_t len, pgp_pkt_type_t atag) : tag
     }
 }
 
-RawPacket::RawPacket(const pgp_signature_t &sig)
+RawPacket::RawPacket(const pgp::pkt::Signature &sig)
 {
     data_ = sig.write();
     tag_ = PGP_PKT_SIGNATURE;

--- a/src/lib/rawpacket.hpp
+++ b/src/lib/rawpacket.hpp
@@ -30,6 +30,9 @@
 #include "types.h"
 #include "librepgp/stream-common.h"
 
+typedef struct pgp_key_pkt_t    pgp_key_pkt_t;
+typedef struct pgp_userid_pkt_t pgp_userid_pkt_t;
+
 namespace rnp {
 class RawPacket {
     pgp_pkt_type_t       tag_;

--- a/src/lib/rawpacket.hpp
+++ b/src/lib/rawpacket.hpp
@@ -41,7 +41,7 @@ class RawPacket {
   public:
     RawPacket() : tag_(PGP_PKT_RESERVED){};
     RawPacket(const uint8_t *data, size_t len, pgp_pkt_type_t atag);
-    RawPacket(const pgp_signature_t &sig);
+    RawPacket(const pgp::pkt::Signature &sig);
     RawPacket(pgp_key_pkt_t &key);
     RawPacket(const pgp_userid_pkt_t &uid);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1841,7 +1841,7 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    pgp_signature_list_t sigs;
+    pgp::pkt::Signatures sigs;
     rnp_result_t         sigret = process_pgp_signatures(input->src, sigs);
     if (sigret) {
         FFI_LOG(ffi, "failed to parse signature(s)");
@@ -3722,7 +3722,7 @@ try {
 FFI_GUARD
 
 static rnp_key_handle_t
-get_signer_handle(rnp_ffi_t ffi, const pgp_signature_t &sig)
+get_signer_handle(rnp_ffi_t ffi, const pgp::pkt::Signature &sig)
 {
     // search the stores
     auto *pub = ffi->pubring->get_signer(sig);
@@ -4016,13 +4016,13 @@ fill_revocation_reason(rnp_ffi_t        ffi,
 }
 
 static rnp_result_t
-rnp_key_get_revocation(rnp_ffi_t        ffi,
-                       rnp::Key *       key,
-                       rnp::Key *       revoker,
-                       const char *     hash,
-                       const char *     code,
-                       const char *     reason,
-                       pgp_signature_t &sig)
+rnp_key_get_revocation(rnp_ffi_t            ffi,
+                       rnp::Key *           key,
+                       rnp::Key *           revoker,
+                       const char *         hash,
+                       const char *         code,
+                       const char *         reason,
+                       pgp::pkt::Signature &sig)
 {
     if (!hash) {
         hash = DEFAULT_HASH_ALG;
@@ -4077,8 +4077,8 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    pgp_signature_t sig;
-    rnp_result_t    ret =
+    pgp::pkt::Signature sig;
+    rnp_result_t        ret =
       rnp_key_get_revocation(key->ffi, exkey, revoker, hash, code, reason, sig);
     if (ret) {
         return ret;
@@ -4120,8 +4120,8 @@ try {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    pgp_signature_t sig;
-    rnp_result_t    ret =
+    pgp::pkt::Signature sig;
+    rnp_result_t        ret =
       rnp_key_get_revocation(key->ffi, exkey, revoker, hash, code, reason, sig);
     if (ret) {
         return ret;
@@ -5949,7 +5949,7 @@ create_key_signature(rnp_ffi_t               ffi,
     default:
         return RNP_ERROR_NOT_IMPLEMENTED;
     }
-    pgp_signature_t sigpkt;
+    pgp::pkt::Signature sigpkt;
     sigkey.sign_init(
       ffi->rng(), sigpkt, DEFAULT_PGP_HASH_ALG, ffi->context.time(), sigkey.version());
     sigpkt.set_type(type);
@@ -8171,7 +8171,7 @@ add_json_mpis(json_object *jso, rnp::Key *key, bool secret = false)
 }
 
 static rnp_result_t
-add_json_sig_mpis(json_object *jso, const pgp_signature_t *sig)
+add_json_sig_mpis(json_object *jso, const pgp::pkt::Signature *sig)
 {
     auto material = sig->parse_material();
     if (!material) {
@@ -8311,7 +8311,7 @@ add_json_subsig(json_object *jso, bool is_sub, uint32_t flags, const rnp::Signat
             return RNP_ERROR_OUT_OF_MEMORY;
         }
     }
-    const pgp_signature_t *sig = &subsig->sig;
+    const pgp::pkt::Signature *sig = &subsig->sig;
     // version
     if (!json_add(jso, "version", (int) sig->version)) {
         return RNP_ERROR_OUT_OF_MEMORY;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -570,7 +570,7 @@ ret_keyid(const pgp::KeyID &keyid, char **res)
 }
 
 static rnp_result_t
-ret_grip(const pgp_key_grip_t &grip, char **res)
+ret_grip(const pgp::KeyGrip &grip, char **res)
 {
     return hex_encode_value(grip.data(), grip.size(), res);
 }
@@ -7346,7 +7346,7 @@ try {
 }
 FFI_GUARD
 
-static const pgp_key_grip_t *
+static const pgp::KeyGrip *
 rnp_get_grip_by_fp(rnp_ffi_t ffi, const pgp::Fingerprint &fp)
 {
     auto *key = ffi->pubring->get_key(fp);
@@ -7371,7 +7371,7 @@ try {
         *grip = NULL;
         return RNP_SUCCESS;
     }
-    const pgp_key_grip_t *pgrip = rnp_get_grip_by_fp(handle->ffi, key->primary_fp());
+    const pgp::KeyGrip *pgrip = rnp_get_grip_by_fp(handle->ffi, key->primary_fp());
     if (!pgrip) {
         *grip = NULL;
         return RNP_SUCCESS;
@@ -8517,7 +8517,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
             return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
         }
         for (auto &subfp : key->subkey_fps()) {
-            const pgp_key_grip_t *subgrip = rnp_get_grip_by_fp(handle->ffi, subfp);
+            const pgp::KeyGrip *subgrip = rnp_get_grip_by_fp(handle->ffi, subfp);
             if (!subgrip) {
                 continue;
             }

--- a/src/lib/sig_subpacket.cpp
+++ b/src/lib/sig_subpacket.cpp
@@ -640,7 +640,7 @@ Features::clone() const
 /* Embedded signature signature subpacket */
 EmbeddedSignature::EmbeddedSignature(const EmbeddedSignature &src) : Raw(src)
 {
-    signature_ = std::unique_ptr<pgp_signature_t>(new pgp_signature_t(*src.signature_));
+    signature_ = std::unique_ptr<Signature>(new Signature(*src.signature_));
 }
 
 EmbeddedSignature::EmbeddedSignature(bool hashed, bool critical)
@@ -671,30 +671,30 @@ bool
 EmbeddedSignature::parse_data(const uint8_t *data, size_t size)
 {
     pgp_packet_body_t pkt(data, size);
-    pgp_signature_t   sig;
+    Signature         sig;
     if (sig.parse(pkt)) {
         return false;
     }
-    signature_ = std::unique_ptr<pgp_signature_t>(new pgp_signature_t(std::move(sig)));
+    signature_ = std::unique_ptr<Signature>(new Signature(std::move(sig)));
     return true;
 }
 
-const pgp_signature_t *
+const Signature *
 EmbeddedSignature::signature() const noexcept
 {
     return signature_.get();
 }
 
-pgp_signature_t *
+Signature *
 EmbeddedSignature::signature() noexcept
 {
     return signature_.get();
 }
 
 void
-EmbeddedSignature::set_signature(const pgp_signature_t &sig)
+EmbeddedSignature::set_signature(const Signature &sig)
 {
-    signature_ = std::unique_ptr<pgp_signature_t>(new pgp_signature_t(sig));
+    signature_ = std::unique_ptr<Signature>(new Signature(sig));
     data_.clear();
 }
 

--- a/src/lib/sig_subpacket.hpp
+++ b/src/lib/sig_subpacket.hpp
@@ -835,7 +835,7 @@ class Features : public Flags {
 /* Embedded signature signature subpacket */
 class EmbeddedSignature : public Raw {
   private:
-    std::unique_ptr<pgp_signature_t> signature_;
+    std::unique_ptr<Signature> signature_;
 
   protected:
     void write_data() override;
@@ -846,11 +846,11 @@ class EmbeddedSignature : public Raw {
     EmbeddedSignature(const EmbeddedSignature &src);
     EmbeddedSignature(bool hashed = true, bool critical = false);
 
-    const pgp_signature_t *signature() const noexcept;
+    const Signature *signature() const noexcept;
 
-    pgp_signature_t *signature() noexcept;
+    Signature *signature() noexcept;
 
-    void set_signature(const pgp_signature_t &sig);
+    void set_signature(const Signature &sig);
 
     RawPtr clone() const override;
 };

--- a/src/lib/signature.cpp
+++ b/src/lib/signature.cpp
@@ -28,7 +28,7 @@
 
 namespace rnp {
 
-Signature::Signature(const pgp_signature_t &sigpkt)
+Signature::Signature(const pgp::pkt::Signature &sigpkt)
     : sig(sigpkt), sigid(sig.get_id()), raw(sigpkt)
 {
 }

--- a/src/lib/signature.hpp
+++ b/src/lib/signature.hpp
@@ -110,23 +110,23 @@ class SigValidity {
 
 class SignatureInfo {
   public:
-    bool             signer_valid{};      /* assume that signing key is valid */
-    bool             ignore_expiry{};     /* ignore signer's key expiration time */
-    bool             ignore_sig_expiry{}; /* we ignore expiration for revocations */
-    pgp_signature_t *sig{};               /* signature, or NULL if there were parsing error */
-    SigValidity      validity;
+    bool                 signer_valid{};      /* assume that signing key is valid */
+    bool                 ignore_expiry{};     /* ignore signer's key expiration time */
+    bool                 ignore_sig_expiry{}; /* we ignore expiration for revocations */
+    pgp::pkt::Signature *sig{}; /* signature, or NULL if there were parsing error */
+    SigValidity          validity;
 };
 
 class Signature {
   public:
-    uint32_t        uid{};    /* index in userid array in key for certification sig */
-    pgp_signature_t sig{};    /* signature packet */
-    pgp::SigID      sigid{};  /* signature identifier */
-    RawPacket       raw;      /* signature's rawpacket */
-    SigValidity     validity; /* signature validity information */
+    uint32_t            uid{};    /* index in userid array in key for certification sig */
+    pgp::pkt::Signature sig{};    /* signature packet */
+    pgp::SigID          sigid{};  /* signature identifier */
+    RawPacket           raw;      /* signature's rawpacket */
+    SigValidity         validity; /* signature validity information */
 
     Signature() = delete;
-    Signature(const pgp_signature_t &sig);
+    Signature(const pgp::pkt::Signature &sig);
 
     /** @brief Returns true if signature is certification */
     bool is_cert() const;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -73,8 +73,6 @@ class id_str_pair {
                               int                         notfound = 0);
 };
 
-typedef std::array<uint8_t, PGP_KEY_GRIP_SIZE> pgp_key_grip_t;
-
 namespace pgp {
 using SigID = std::array<uint8_t, PGP_SHA1_HASH_SIZE>;
 using SigIDs = std::vector<SigID>;
@@ -148,7 +146,7 @@ typedef struct pgp_key_protection_t {
     uint8_t           iv[PGP_MAX_BLOCK_SIZE];
 } pgp_key_protection_t;
 
-typedef struct pgp_signature_t    pgp_signature_t;
+typedef struct pgp_signature_t pgp_signature_t;
 typedef enum {
     /* first octet */
     PGP_KEY_SERVER_NO_MODIFY = 0x80

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -148,11 +148,7 @@ typedef struct pgp_key_protection_t {
     uint8_t           iv[PGP_MAX_BLOCK_SIZE];
 } pgp_key_protection_t;
 
-typedef struct pgp_key_pkt_t      pgp_key_pkt_t;
-typedef struct pgp_userid_pkt_t   pgp_userid_pkt_t;
 typedef struct pgp_signature_t    pgp_signature_t;
-typedef struct pgp_one_pass_sig_t pgp_one_pass_sig_t;
-
 typedef enum {
     /* first octet */
     PGP_KEY_SERVER_NO_MODIFY = 0x80
@@ -196,10 +192,6 @@ typedef enum {
     PGP_LDT_LOCAL = 'l',
     PGP_LDT_LOCAL2 = '1'
 } pgp_litdata_enum;
-
-namespace rnp {
-class Signature;
-}
 
 typedef struct rnp_key_protection_params_t {
     pgp_symm_alg_t    symm_alg;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -146,7 +146,12 @@ typedef struct pgp_key_protection_t {
     uint8_t           iv[PGP_MAX_BLOCK_SIZE];
 } pgp_key_protection_t;
 
-typedef struct pgp_signature_t pgp_signature_t;
+namespace pgp {
+namespace pkt {
+class Signature;
+}
+} // namespace pgp
+
 typedef enum {
     /* first octet */
     PGP_KEY_SERVER_NO_MODIFY = 0x80

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -944,8 +944,8 @@ KeyStore::load_g10(pgp_source_t &src, const KeyProvider *key_provider)
         /* copy public key fields if any */
         Key key;
         if (key_provider) {
-            pgp_key_grip_t grip = seckey.material->grip();
-            auto           pubkey =
+            pgp::KeyGrip grip = seckey.material->grip();
+            auto         pubkey =
               key_provider->request_key(*KeySearch::create(grip), PGP_OP_MERGE_INFO);
             if (!pubkey) {
                 return false;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -389,10 +389,10 @@ KeyStore::add_key(Key &srckey)
 }
 
 Signature *
-KeyStore::add_key_sig(const pgp::Fingerprint &keyfp,
-                      const pgp_signature_t & sig,
-                      const pgp_userid_pkt_t *uid,
-                      bool                    front)
+KeyStore::add_key_sig(const pgp::Fingerprint &   keyfp,
+                      const pgp::pkt::Signature &sig,
+                      const pgp_userid_pkt_t *   uid,
+                      bool                       front)
 {
     auto *key = get_key(keyfp);
     if (!key) {
@@ -468,7 +468,7 @@ KeyStore::import_key(Key &srckey, bool pubkey, pgp_key_import_status_t *status)
 }
 
 pgp_sig_import_status_t
-KeyStore::import_subkey_signature(Key &key, const pgp_signature_t &sig)
+KeyStore::import_subkey_signature(Key &key, const pgp::pkt::Signature &sig)
 {
     if ((sig.type() != PGP_SIG_SUBKEY) && (sig.type() != PGP_SIG_REV_SUBKEY)) {
         return PGP_SIG_IMPORT_STATUS_UNKNOWN;
@@ -508,7 +508,7 @@ KeyStore::import_subkey_signature(Key &key, const pgp_signature_t &sig)
 }
 
 pgp_sig_import_status_t
-KeyStore::import_signature(Key &key, const pgp_signature_t &sig)
+KeyStore::import_signature(Key &key, const pgp::pkt::Signature &sig)
 {
     if (key.is_subkey()) {
         return import_subkey_signature(key, sig);
@@ -543,7 +543,7 @@ KeyStore::import_signature(Key &key, const pgp_signature_t &sig)
 }
 
 Key *
-KeyStore::import_signature(const pgp_signature_t &sig, pgp_sig_import_status_t *status)
+KeyStore::import_signature(const pgp::pkt::Signature &sig, pgp_sig_import_status_t *status)
 {
     pgp_sig_import_status_t tmp_status = PGP_SIG_IMPORT_STATUS_UNKNOWN;
     if (!status) {
@@ -688,7 +688,7 @@ KeyStore::search(const KeySearch &search, Key *after)
 }
 
 Key *
-KeyStore::get_signer(const pgp_signature_t &sig, const KeyProvider *prov)
+KeyStore::get_signer(const pgp::pkt::Signature &sig, const KeyProvider *prov)
 {
     /* if we have fingerprint let's check it */
     std::unique_ptr<KeySearch> ks;

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -573,9 +573,9 @@ dst_hexdump(pgp_dest_t *dst, const std::vector<uint8_t> &data)
 static rnp_result_t stream_dump_packets_raw(rnp_dump_ctx_t *ctx,
                                             pgp_source_t *  src,
                                             pgp_dest_t *    dst);
-static void         stream_dump_signature_pkt(rnp_dump_ctx_t *       ctx,
-                                              const pgp_signature_t &sig,
-                                              pgp_dest_t *           dst);
+static void         stream_dump_signature_pkt(rnp_dump_ctx_t *           ctx,
+                                              const pgp::pkt::Signature &sig,
+                                              pgp_dest_t *               dst);
 
 /* Todo: move dumper to pgp::pkt or pgp namespace */
 using namespace pgp;
@@ -734,7 +734,7 @@ signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, const pkt::sigsub
     case pkt::sigsub::Type::EmbeddedSignature: {
         auto &sub = dynamic_cast<const pkt::sigsub::EmbeddedSignature &>(subpkt);
         dst_printf(dst, "%s:\n", sname);
-        pgp_signature_t sig(*sub.signature());
+        pgp::pkt::Signature sig(*sub.signature());
         stream_dump_signature_pkt(ctx, sig, dst);
         break;
     }
@@ -758,10 +758,10 @@ signature_dump_subpacket(rnp_dump_ctx_t *ctx, pgp_dest_t *dst, const pkt::sigsub
 }
 
 static void
-signature_dump_subpackets(rnp_dump_ctx_t *       ctx,
-                          pgp_dest_t *           dst,
-                          const pgp_signature_t &sig,
-                          bool                   hashed)
+signature_dump_subpackets(rnp_dump_ctx_t *           ctx,
+                          pgp_dest_t *               dst,
+                          const pgp::pkt::Signature &sig,
+                          bool                       hashed)
 {
     bool empty = true;
 
@@ -788,7 +788,7 @@ signature_dump_subpackets(rnp_dump_ctx_t *       ctx,
 }
 
 static void
-stream_dump_signature_pkt(rnp_dump_ctx_t *ctx, const pgp_signature_t &sig, pgp_dest_t *dst)
+stream_dump_signature_pkt(rnp_dump_ctx_t *ctx, const pgp::pkt::Signature &sig, pgp_dest_t *dst)
 {
     indent_dest_increase(dst);
 
@@ -899,8 +899,8 @@ stream_dump_signature_pkt(rnp_dump_ctx_t *ctx, const pgp_signature_t &sig, pgp_d
 static rnp_result_t
 stream_dump_signature(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
 {
-    pgp_signature_t sig;
-    rnp_result_t    ret;
+    pgp::pkt::Signature sig;
+    rnp_result_t        ret;
 
     dst_printf(dst, "Signature packet\n");
     try {
@@ -1788,9 +1788,9 @@ obj_add_s2k_json(json_object *obj, pgp_s2k_t *s2k)
     return true;
 }
 
-static rnp_result_t stream_dump_signature_pkt_json(rnp_dump_ctx_t *       ctx,
-                                                   const pgp_signature_t &sig,
-                                                   json_object *          pkt);
+static rnp_result_t stream_dump_signature_pkt_json(rnp_dump_ctx_t *           ctx,
+                                                   const pgp::pkt::Signature &sig,
+                                                   json_object *              pkt);
 
 static bool
 signature_dump_subpacket_json(rnp_dump_ctx_t *        ctx,
@@ -1952,7 +1952,7 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *        ctx,
 }
 
 static json_object *
-signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp_signature_t &sig)
+signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp::pkt::Signature &sig)
 {
     json_object *res = json_object_new_array();
     if (!res) {
@@ -1993,9 +1993,9 @@ signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp_signature_t &sig)
 }
 
 static rnp_result_t
-stream_dump_signature_pkt_json(rnp_dump_ctx_t *       ctx,
-                               const pgp_signature_t &sig,
-                               json_object *          pkt)
+stream_dump_signature_pkt_json(rnp_dump_ctx_t *           ctx,
+                               const pgp::pkt::Signature &sig,
+                               json_object *              pkt)
 {
     json_object *material = NULL;
 
@@ -2115,8 +2115,8 @@ stream_dump_signature_pkt_json(rnp_dump_ctx_t *       ctx,
 static rnp_result_t
 stream_dump_signature_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
 {
-    pgp_signature_t sig;
-    rnp_result_t    ret;
+    pgp::pkt::Signature sig;
+    rnp_result_t        ret;
     try {
         ret = sig.parse(*src);
     } catch (const std::exception &e) {

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1094,9 +1094,9 @@ stream_dump_key(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
             dst_printf(dst, "v5 secret key data length: %" PRIu32 "\n", key.v5_sec_len);
         }
         if (!key.sec_protection.s2k.usage) {
-            dst_printf(dst, "cleartext secret key data: %d bytes\n", (int) key.sec_len);
+            dst_printf(dst, "cleartext secret key data: %zu bytes\n", key.sec_data.size());
         } else {
-            dst_printf(dst, "encrypted secret key data: %d bytes\n", (int) key.sec_len);
+            dst_printf(dst, "encrypted secret key data: %zu bytes\n", key.sec_data.size());
         }
         indent_dest_decrease(dst);
     }

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1114,7 +1114,7 @@ stream_dump_key(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst)
 
     if (ctx->dump_grips) {
         if (key.material) {
-            pgp_key_grip_t grip = key.material->grip();
+            pgp::KeyGrip grip = key.material->grip();
             dst_print_hex(dst, "grip", grip.data(), grip.size(), false);
         } else {
             dst_printf(dst, "grip: failed to calculate\n");
@@ -2321,7 +2321,7 @@ stream_dump_key_json(rnp_dump_ctx_t *ctx, pgp_source_t *src, json_object *pkt)
 
     if (ctx->dump_grips) {
         if (key.material) {
-            pgp_key_grip_t grip = key.material->grip();
+            pgp::KeyGrip grip = key.material->grip();
             if (!json_add_hex(pkt, "grip", grip.data(), grip.size())) {
                 return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
             }

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -78,14 +78,14 @@ skip_pgp_packets(pgp_source_t &src, const std::set<pgp_pkt_type_t> &pkts)
 }
 
 static rnp_result_t
-process_pgp_key_signatures(pgp_source_t &src, pgp_signature_list_t &sigs, bool skiperrors)
+process_pgp_key_signatures(pgp_source_t &src, pgp::pkt::Signatures &sigs, bool skiperrors)
 {
     int ptag;
     while ((ptag = stream_pkt_type(src)) == PGP_PKT_SIGNATURE) {
         uint64_t sigpos = src.readb;
         try {
-            pgp_signature_t sig;
-            rnp_result_t    ret = sig.parse(src);
+            pgp::pkt::Signature sig;
+            rnp_result_t        ret = sig.parse(src);
             if (ret) {
                 RNP_LOG("failed to parse signature at %" PRIu64, sigpos);
                 if (!skiperrors) {

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -45,22 +45,20 @@ typedef struct pgp_key_pkt_t {
     uint16_t         v3_days;    /* v2/v3 validity time */
     uint32_t         v5_pub_len; /* v5 public key material length */
 
-    uint8_t *hashed_data; /* key's hashed data used for signature calculation */
-    size_t   hashed_len;
+    std::vector<uint8_t> pub_data; /* key's hashed data used for signature calculation */
 
     std::unique_ptr<pgp::KeyMaterial> material;
 
     /* secret key data, if available. sec_len == 0, sec_data == NULL for public key/subkey */
     pgp_key_protection_t sec_protection;
-    uint8_t *            sec_data;
-    size_t               sec_len;
+    std::vector<uint8_t> sec_data;
     uint8_t              v5_s2k_len;
     uint32_t             v5_sec_len;
 
     pgp_key_pkt_t()
         : tag(PGP_PKT_RESERVED), version(PGP_VUNKNOWN), creation_time(0), alg(PGP_PKA_NOTHING),
-          v3_days(0), v5_pub_len(0), hashed_data(NULL), hashed_len(0), material(nullptr),
-          sec_protection({}), sec_data(NULL), sec_len(0), v5_s2k_len(0), v5_sec_len(0){};
+          v3_days(0), v5_pub_len(0), material(nullptr), sec_protection({}), v5_s2k_len(0),
+          v5_sec_len(0){};
     pgp_key_pkt_t(const pgp_key_pkt_t &src, bool pubonly = false);
     pgp_key_pkt_t(pgp_key_pkt_t &&src);
     pgp_key_pkt_t &operator=(pgp_key_pkt_t &&src);

--- a/src/librepgp/stream-key.h
+++ b/src/librepgp/stream-key.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2018-2025, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -82,13 +82,13 @@ typedef struct pgp_key_pkt_t {
 /* userid/userattr with all the corresponding signatures */
 typedef struct pgp_transferable_userid_t {
     pgp_userid_pkt_t     uid;
-    pgp_signature_list_t signatures;
+    pgp::pkt::Signatures signatures;
 } pgp_transferable_userid_t;
 
 /* subkey with all corresponding signatures */
 typedef struct pgp_transferable_subkey_t {
     pgp_key_pkt_t        subkey;
-    pgp_signature_list_t signatures;
+    pgp::pkt::Signatures signatures;
 
     pgp_transferable_subkey_t() = default;
     pgp_transferable_subkey_t(const pgp_transferable_subkey_t &src, bool pubonly = false);
@@ -100,7 +100,7 @@ typedef struct pgp_transferable_key_t {
     pgp_key_pkt_t                          key; /* main key packet */
     std::vector<pgp_transferable_userid_t> userids;
     std::vector<pgp_transferable_subkey_t> subkeys;
-    pgp_signature_list_t                   signatures;
+    pgp::pkt::Signatures                   signatures;
 
     pgp_transferable_key_t() = default;
     pgp_transferable_key_t(const pgp_transferable_key_t &src, bool pubonly = false);

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -768,7 +768,7 @@ pgp_packet_body_t::add(const pgp::mpi &val)
 }
 
 void
-pgp_packet_body_t::add_subpackets(const pgp_signature_t &sig, bool hashed)
+pgp_packet_body_t::add_subpackets(const pgp::pkt::Signature &sig, bool hashed)
 {
     pgp_packet_body_t spbody(PGP_PKT_RESERVED);
 

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -150,7 +150,7 @@ typedef struct pgp_packet_body_t {
      * @param sig signature, containing subpackets
      * @param hashed whether write hashed or not hashed subpackets
      */
-    void add_subpackets(const pgp_signature_t &sig, bool hashed);
+    void add_subpackets(const pgp::pkt::Signature &sig, bool hashed);
     /** @brief add ec curve description to the packet body */
     void add(const pgp_curve_t curve);
     /** @brief add s2k description to the packet body */

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -151,7 +151,7 @@ typedef struct pgp_source_signed_param_t {
     bool              has_lhdr = false;
 
     std::vector<pgp_one_pass_sig_t> onepasses;  /* list of one-pass signatures */
-    std::list<pgp_signature_t>      sigs;       /* list of signatures */
+    std::list<pgp::pkt::Signature>  sigs;       /* list of signatures */
     std::vector<rnp::SignatureInfo> siginfos;   /* signature validation info */
     rnp::HashList                   hashes;     /* hash contexts */
     rnp::HashList                   txt_hashes; /* hash contexts for text-mode sigs */
@@ -1047,7 +1047,7 @@ signed_src_close(pgp_source_t *src)
 static rnp_result_t
 signed_read_single_signature(pgp_source_signed_param_t *param,
                              pgp_source_t *             readsrc,
-                             pgp_signature_t **         sig)
+                             pgp::pkt::Signature **     sig)
 {
     uint8_t ptag;
     if (!readsrc->peek_eq(&ptag, 1)) {
@@ -1069,7 +1069,7 @@ signed_read_single_signature(pgp_source_signed_param_t *param,
     try {
         param->siginfos.emplace_back();
         rnp::SignatureInfo &siginfo = param->siginfos.back();
-        pgp_signature_t     readsig;
+        pgp::pkt::Signature readsig;
         if (readsig.parse(*readsrc)) {
             RNP_LOG("failed to parse signature");
             siginfo.validity.add_error(RNP_ERROR_SIG_PARSE_ERROR);
@@ -1124,8 +1124,8 @@ signed_read_signatures(pgp_source_t *src)
 
     /* reading signatures */
     for (auto op = param->onepasses.rbegin(); op != param->onepasses.rend(); op++) {
-        pgp_signature_t *sig = NULL;
-        rnp_result_t     ret = signed_read_single_signature(param, src, &sig);
+        pgp::pkt::Signature *sig = NULL;
+        rnp_result_t         ret = signed_read_single_signature(param, src, &sig);
         /* we have more onepasses then signatures */
         if (ret == RNP_ERROR_READ) {
             RNP_LOG("Warning: premature end of signatures");
@@ -2426,7 +2426,7 @@ init_signed_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *r
     pgp_source_signed_param_t *param;
     uint8_t                    ptag;
     int                        ptype;
-    pgp_signature_t *          sig = NULL;
+    pgp::pkt::Signature *      sig = nullptr;
     bool                       cleartext;
     size_t                     sigerrors = 0;
 

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -51,7 +51,7 @@
 void
 signature_hash_key(const pgp_key_pkt_t &key, rnp::Hash &hash, pgp_version_t pgpver)
 {
-    if (!key.hashed_data) {
+    if (key.pub_data.empty()) {
         /* call self recursively if hashed data is not filled, to overcome const restriction */
         pgp_key_pkt_t keycp(key, true);
         keycp.fill_hashed_data();
@@ -65,28 +65,28 @@ signature_hash_key(const pgp_key_pkt_t &key, rnp::Hash &hash, pgp_version_t pgpv
     case PGP_V3:
         FALLTHROUGH_STATEMENT;
     case PGP_V4: {
-        assert(key.hashed_len < ((size_t) 1 << 16));
+        assert(key.pub_data.size() < ((size_t) 1 << 16));
         uint8_t hdr[3] = {0x99, 0x00, 0x00};
-        write_uint16(hdr + 1, key.hashed_len);
+        write_uint16(hdr + 1, key.pub_data.size());
         hash.add(hdr, 3);
-        hash.add(key.hashed_data, key.hashed_len);
+        hash.add(key.pub_data);
         break;
     }
     case PGP_V5: {
-        assert(key.hashed_len < ((size_t) 1 << 32));
+        assert(key.pub_data.size() < ((size_t) 1 << 32));
         uint8_t hdr[5] = {0x9A, 0x00, 0x00, 0x00, 0x00};
-        write_uint32(hdr + 1, key.hashed_len);
+        write_uint32(hdr + 1, key.pub_data.size());
         hash.add(&hdr, 5);
-        hash.add(key.hashed_data, key.hashed_len);
+        hash.add(key.pub_data);
         break;
     }
 #if defined(ENABLE_CRYPTO_REFRESH)
     case PGP_V6: {
-        assert(key.hashed_len < ((size_t) 1 << 32));
+        assert(key.pub_data.size() < ((size_t) 1 << 32));
         uint8_t hdr[5] = {0x9b, 0x00, 0x00, 0x00, 0x00};
-        write_uint32(hdr + 1, key.hashed_len);
+        write_uint32(hdr + 1, key.pub_data.size());
         hash.add(hdr, sizeof(hdr));
-        hash.add(key.hashed_data, key.hashed_len);
+        hash.add(key.pub_data);
         break;
     }
 #endif

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1242,7 +1242,7 @@ cleartext_dst_write(pgp_dest_t *dst, const void *buf, size_t len)
 
 static void
 signed_fill_signature(pgp_dest_signed_param_t &param,
-                      pgp_signature_t &        sig,
+                      pgp::pkt::Signature &    sig,
                       pgp_dest_signer_info_t & signer)
 {
     /* fill signature fields, assuming sign_init was called on it */
@@ -1279,7 +1279,7 @@ signed_write_signature(pgp_dest_signed_param_t *param,
                        pgp_dest_t *             writedst)
 {
     try {
-        pgp_signature_t sig;
+        pgp::pkt::Signature sig;
         if (signer->onepass.version) {
             signer->key->sign_init(param->ctx->sec_ctx.rng,
                                    sig,

--- a/src/tests/data/test_key_validity/case5/generate.cpp
+++ b/src/tests/data/test_key_validity/case5/generate.cpp
@@ -44,7 +44,7 @@ load_transferable_key(pgp_transferable_key_t *key, const char *fname)
 bool calculate_primary_binding(const pgp_key_pkt_t &key,
                                const pgp_key_pkt_t &subkey,
                                pgp_hash_alg_t       halg,
-                               pgp_signature_t &    sig,
+                               pgp::pkt::Signature &sig,
                                rnp::Hash &          hash,
                                rnp::RNG &           rng);
 
@@ -72,7 +72,7 @@ main(int argc, char **argv)
 
     pgp_transferable_subkey_t *subkey =
       (pgp_transferable_subkey_t *) list_front(tpkey.subkeys);
-    pgp_signature_t *binding = (pgp_signature_t *) list_front(subkey->signatures);
+    pgp::pkt::Signature *binding = (pgp::pkt::Signature *) list_front(subkey->signatures);
 
     if (decrypt_secret_key(&tskey.key, "password")) {
         RNP_LOG("Failed to decrypt secret key");
@@ -120,8 +120,8 @@ main(int argc, char **argv)
         realkf = pgp_pk_alg_capabilities(subkey->subkey.alg);
     }
     if (realkf & PGP_KF_SIGN) {
-        pgp_signature_t embsig = {};
-        bool            embres;
+        pgp::pkt::Signature embsig;
+        bool                embres;
 
         if (!calculate_primary_binding(
               &tpkey.key, &subkey->subkey, binding->halg, &embsig, &hashcp, &rng)) {

--- a/src/tests/ffi-key-sig.cpp
+++ b/src/tests/ffi-key-sig.cpp
@@ -578,7 +578,7 @@ TEST_F(rnp_tests, test_ffi_export_revocation)
     /* check signature contents */
     pgp_source_t src = {};
     assert_rnp_success(init_file_src(&src, "alice-revocation.pgp"));
-    pgp_signature_t sig = {};
+    pgp::pkt::Signature sig;
     assert_rnp_success(sig.parse(src));
     src.close();
     assert_int_equal(sig.type(), PGP_SIG_REV_KEY);

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -1022,12 +1022,12 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
     // primary
     {
-        rnp::Key           pub;
-        rnp::Key           sec;
-        pgp_signature_t *  psig = NULL;
-        pgp_signature_t *  ssig = NULL;
-        rnp::SignatureInfo psiginfo;
-        rnp::SignatureInfo ssiginfo;
+        rnp::Key             pub;
+        rnp::Key             sec;
+        pgp::pkt::Signature *psig = nullptr;
+        pgp::pkt::Signature *ssig = nullptr;
+        rnp::SignatureInfo   psiginfo;
+        rnp::SignatureInfo   ssiginfo;
 
         rnp::KeygenParams keygen(PGP_PKA_RSA, global_ctx);
         auto &            rsa = dynamic_cast<pgp::RSAKeyParams &>(keygen.key_params());
@@ -1156,12 +1156,12 @@ TEST_F(rnp_tests, test_generated_key_sigs)
 
     // sub
     {
-        rnp::Key           pub;
-        rnp::Key           sec;
-        pgp_signature_t *  psig = NULL;
-        pgp_signature_t *  ssig = NULL;
-        rnp::SignatureInfo psiginfo;
-        rnp::SignatureInfo ssiginfo;
+        rnp::Key             pub;
+        rnp::Key             sec;
+        pgp::pkt::Signature *psig = nullptr;
+        pgp::pkt::Signature *ssig = nullptr;
+        rnp::SignatureInfo   psiginfo;
+        rnp::SignatureInfo   ssiginfo;
 
         rnp::KeygenParams keygen(PGP_PKA_RSA, global_ctx);
         auto &            rsa = dynamic_cast<pgp::RSAKeyParams &>(keygen.key_params());

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -62,7 +62,7 @@ TEST_F(rnp_tests, test_key_store_search)
             assert_true(rnp::hex_decode(
               testdata[i].keyid, (uint8_t *) key.keyid().data(), key.keyid().size()));
             // keys should have different grips otherwise store->add_key will fail here
-            pgp_key_grip_t &grip = (pgp_key_grip_t &) key.grip();
+            pgp::KeyGrip &grip = (pgp::KeyGrip &) key.grip();
             assert_true(rnp::hex_decode(testdata[i].keyid, grip.data(), grip.size()));
             grip[0] = (uint8_t) n;
             // and fingerprint

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -603,7 +603,7 @@ TEST_F(rnp_tests, test_key_expiry_direct_sig)
     assert_true(key->valid());
     assert_false(key->expired());
     /* create direct-key signature */
-    pgp_signature_t sig;
+    pgp::pkt::Signature sig;
 
     sig.version = PGP_V4;
     sig.halg = PGP_HASH_SHA256;

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -187,8 +187,8 @@ TEST_F(rnp_tests, test_load_keyring_and_count_pgp)
  */
 TEST_F(rnp_tests, test_load_check_bitfields_and_times)
 {
-    const rnp::Key *       key;
-    const pgp_signature_t *sig = NULL;
+    const rnp::Key *           key;
+    const pgp::pkt::Signature *sig = nullptr;
 
     // load keyring
     auto key_store = new rnp::KeyStore("data/keyrings/1/pubring.gpg", global_ctx);
@@ -329,9 +329,9 @@ TEST_F(rnp_tests, test_load_check_bitfields_and_times)
  */
 TEST_F(rnp_tests, test_load_check_bitfields_and_times_v3)
 {
-    pgp::KeyID             keyid = {};
-    const rnp::Key *       key;
-    const pgp_signature_t *sig = NULL;
+    pgp::KeyID                 keyid = {};
+    const rnp::Key *           key;
+    const pgp::pkt::Signature *sig = nullptr;
 
     // load keyring
     auto key_store = new rnp::KeyStore("data/keyrings/2/pubring.gpg", global_ctx);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -700,8 +700,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(check_subkey_fp(&keycp, skey2, 1));
     assert_true(keycp.grip() == key->grip());
     assert_int_equal(keycp.rawpkt().tag(), PGP_PKT_PUBLIC_KEY);
-    assert_null(keycp.pkt().sec_data);
-    assert_int_equal(keycp.pkt().sec_len, 0);
+    assert_true(keycp.pkt().sec_data.empty());
     assert_false(keycp.pkt().material->secret());
     pubstore->add_key(keycp);
     /* subkey 1 */
@@ -712,8 +711,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(keycp.grip() == skey1->grip());
     assert_true(cmp_keyid(keycp.keyid(), sub1id));
     assert_int_equal(keycp.rawpkt().tag(), PGP_PKT_PUBLIC_SUBKEY);
-    assert_null(keycp.pkt().sec_data);
-    assert_int_equal(keycp.pkt().sec_len, 0);
+    assert_true(keycp.pkt().sec_data.empty());
     assert_false(keycp.pkt().material->secret());
     pubstore->add_key(keycp);
     /* subkey 2 */
@@ -724,8 +722,7 @@ TEST_F(rnp_tests, test_load_public_from_secret)
     assert_true(keycp.grip() == skey2->grip());
     assert_true(cmp_keyid(keycp.keyid(), sub2id));
     assert_int_equal(keycp.rawpkt().tag(), PGP_PKT_PUBLIC_SUBKEY);
-    assert_null(keycp.pkt().sec_data);
-    assert_int_equal(keycp.pkt().sec_len, 0);
+    assert_true(keycp.pkt().sec_data.empty());
     assert_false(keycp.pkt().material->secret());
     pubstore->add_key(keycp);
     /* save pubring */

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -510,7 +510,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyfp(keyfp, "6BC04A5A3DDB35766B9A40D82FB9179118898E8B"));
     assert_true(cmp_keyid(keyfp.keyid(), "2FB9179118898E8B"));
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* rsa/rsa secret key */
@@ -522,7 +522,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_true(cmp_keyfp(keyfp, "6BC04A5A3DDB35766B9A40D82FB9179118898E8B"));
     assert_true(cmp_keyid(keyfp.keyid(), "2FB9179118898E8B"));
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* dsa/el-gamal public key */
@@ -544,7 +544,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* curve 25519 ecc public key */
@@ -583,7 +583,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* p-256 ecc public key */
@@ -604,7 +604,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* p-384 ecc public key */
@@ -625,7 +625,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* p-521 ecc public key */
@@ -646,7 +646,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* Brainpool P256 ecc public key */
@@ -667,7 +667,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* Brainpool P384 ecc public key */
@@ -688,7 +688,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* Brainpool P512 ecc public key */
@@ -709,7 +709,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 
     /* secp256k1 ecc public key, not supported now */
@@ -730,7 +730,7 @@ TEST_F(rnp_tests, test_stream_key_load)
     assert_int_equal(keyseq.keys.size(), 1);
     assert_non_null(key = &keyseq.keys.front());
     assert_int_equal(key->subkeys.size(), 1);
-    assert_non_null(key->subkeys[0].subkey.hashed_data);
+    assert_false(key->subkeys[0].subkey.pub_data.empty());
     keysrc.close();
 }
 

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -334,9 +334,9 @@ TEST_F(rnp_tests, test_stream_file)
 
 TEST_F(rnp_tests, test_stream_signatures)
 {
-    pgp_signature_t sig;
-    pgp_source_t    sigsrc;
-    rnp::Key *      key = nullptr;
+    pgp::pkt::Signature sig;
+    pgp_source_t        sigsrc;
+    rnp::Key *          key = nullptr;
 
     /* load keys */
     auto pubring = new rnp::KeyStore("data/test_stream_signatures/pub.asc", global_ctx);
@@ -416,8 +416,8 @@ TEST_F(rnp_tests, test_stream_signatures)
 
 TEST_F(rnp_tests, test_stream_signatures_revoked_key)
 {
-    pgp_signature_t sig = {};
-    pgp_source_t    sigsrc = {0};
+    pgp::pkt::Signature sig = {};
+    pgp_source_t        sigsrc = {0};
 
     /* load signature */
     assert_rnp_success(

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -759,8 +759,8 @@ rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const std::string &grip)
     if (!keyring || grip.empty() || !rnp::is_hex(grip)) {
         return NULL;
     }
-    pgp_key_grip_t grip_bin = {};
-    size_t         binlen = rnp::hex_decode(grip.c_str(), grip_bin.data(), grip_bin.size());
+    pgp::KeyGrip grip_bin{};
+    size_t       binlen = rnp::hex_decode(grip.c_str(), grip_bin.data(), grip_bin.size());
     if (binlen > PGP_KEY_GRIP_SIZE) {
         return NULL;
     }
@@ -768,7 +768,7 @@ rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const std::string &grip)
 }
 
 rnp::Key *
-rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const pgp_key_grip_t &grip)
+rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const pgp::KeyGrip &grip)
 {
     if (!keyring) {
         return NULL;

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -224,7 +224,7 @@ rnp::Key *rnp_tests_get_key_by_id(rnp::KeyStore *    keyring,
                                   rnp::Key *         after = NULL);
 rnp::Key *rnp_tests_get_key_by_fpr(rnp::KeyStore *keyring, const std::string &keyid);
 rnp::Key *rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const std::string &grip);
-rnp::Key *rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const pgp_key_grip_t &grip);
+rnp::Key *rnp_tests_get_key_by_grip(rnp::KeyStore *keyring, const pgp::KeyGrip &grip);
 rnp::Key *rnp_tests_key_search(rnp::KeyStore *keyring, const std::string &uid);
 
 /* key load/reload  shortcuts */


### PR DESCRIPTION
...and cleanup some things as well.

Don't like pgp::pkt::Signature in all upper-layer classes, but `using namespace pgp` in `rnp` namespace is not something ideal as well.