### PR TITLE
Fix macOS OpenSSL 1.1.1 tests failure.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,6 +94,8 @@ jobs:
           echo "brew \"openssl@1.1\"" >> Brewfile
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
           echo "CRYPTO_BACKEND=openssl" >> $GITHUB_ENV
+          # Harsh workaround against CLang adding /usr/local/include path, where OpenSSL 3.0 headers are
+          rm -r /usr/local/include/openssl
 
       - name: Configure openssl 3 backend
         if: matrix.backend == 'openssl@3'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -74,8 +74,8 @@ jobs:
           - { CC: gcc,    CXX: g++     }
           - { CC: clang,  CXX: clang++ }
         include:
-        # This implies openssl 1.1.1 as opposed to ubuntu-latest which is openssl 3
-          - os: ubuntu-20.04
+        # Since ubuntu-20.04 runner is deprecated we do not test OpenSSL 1.1.1 here.
+          - os: ubuntu-22.04
             shared_libs: 'on'
             backend: { name: 'openssl',  package: 'libssl-dev' }
             env: { CC: gcc, CXX: g++ }


### PR DESCRIPTION
A bit weird but seems to work.
The issue is that macOS clang adds /usr/local/include to search path with higher priority then OpenSSL 1.1.1 headers, causing FindOpenSSLFeatures malfunction (compiling with 3.0 headers from /usr/local/include, but attempting to link with 1.1.1. libraries).