### PR TITLE
Avoid returning enum in boolean context

### DIFF
--- a/src/lib/enc_material.cpp
+++ b/src/lib/enc_material.cpp
@@ -151,7 +151,7 @@ X25519EncMaterial::parse(pgp_packet_body_t &pkt) noexcept
         uint8_t bt = 0;
         if (!pkt.get(bt)) {
             RNP_LOG("failed to get salg");
-            return RNP_ERROR_BAD_FORMAT;
+            return false;
         }
         sess_len--;
         salg = (pgp_symm_alg_t) bt;
@@ -202,7 +202,7 @@ MlkemEcdhEncMaterial::parse(pgp_packet_body_t &pkt) noexcept
         uint8_t balg = 0;
         if (!pkt.get(balg)) {
             RNP_LOG("failed to get salg");
-            return RNP_ERROR_BAD_FORMAT;
+            return false;
         }
         salg = (pgp_symm_alg_t) balg;
         wrapped_key_len--;


### PR DESCRIPTION
Without this fix, when compiling with `ENABLE_CRYPTO_REFRESH`, we see:

```
…/src/lib/enc_material.cpp: In member function ‘virtual bool pgp::X25519EncMaterial::parse(pgp_packet_body_t&)’:
…/src/lib/enc_material.cpp:154:20: warning: enum constant in boolean context [-Wint-in-bool-context]
  154 |             return RNP_ERROR_BAD_FORMAT;
      |                    ^~~~~~~~~~~~~~~~~~~~
make[3]: Leaving directory '…/build'
```