### PR TITLE
tests: avoid ephemeral test suite failure on slow CI

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2080,7 +2080,7 @@ class Keystore(unittest.TestCase):
         # Expires in 60 seconds
         ret, out, _ = run_proc(RNPK, ['--homedir', RNPDIR, '--edit-key', '--set-expire', '60', 'primary_with_empty_password@rnp'])
         self.assertEqual(ret, 0)
-        self.assertRegex(out, r'(?s)^.*\[EXPIRES .*')
+        self.assertRegex(out, r'(?s)^.*\[EXPIRE[SD] .*')
 
         ret, out, _ = run_proc(RNP, ['--list-packets', kpath])
         self.assertEqual(ret, 0)


### PR DESCRIPTION
In debian's build daemon architecture, some machines are heavily congested (especially for more obscure ports with lower-resourced machines)), and a build can be delayed at any point.

If a build happens to be paused for more than a minute at the wrong time, this test can fail, as it did here, on the sparc64 architecture:

https://buildd.debian.org/status/fetch.php?pkg=rnp&arch=sparc64&ver=0.18.0-4&stamp=1760765792&raw=0

The failure was that the certificate showed as "EXPIRED" instead of "EXPIRES".

This fix isn't a complete fix -- test_set_expires will still fail on some extremely slow machines, for example if the build is delayed by 10 hours at the wrong moment, the subsequent test will fail.

But this should significantly reduce the frequency of build failures.