### PR TITLE
fix build with Botan 3.11

### DIFF
--- a/src/lib/crypto/mem.cpp
+++ b/src/lib/crypto/mem.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <cstdio>
+#include <cstring>
 #include "mem.h"
 #include "logging.h"
 #include <botan/ffi.h>


### PR DESCRIPTION
Fixes:

```
[ 40%] Building CXX object src/lib/CMakeFiles/librnp-obj.dir/sig_material.cpp.o
[ 40%] Building CXX object src/lib/CMakeFiles/librnp-obj.dir/pass-provider.cpp.o
[ 40%] Building CXX object src/lib/CMakeFiles/librnp-obj.dir/keygen.cpp.o
[ 41%] Building CXX object src/lib/CMakeFiles/librnp-obj.dir/key.cpp.o
[ 41%] Built target man_librnp
[ 41%] Built target man_rnpkeys
/build/source/src/lib/crypto/mem.cpp: In function 'size_t rnp::hex_decode(const char*, uint8_t*, size_t)':
/build/source/src/lib/crypto/mem.cpp:55:21: error: 'strlen' was not declared in this scope
   55 |     size_t hexlen = strlen(hex);
      |                     ^~~~~~
/build/source/src/lib/crypto/mem.cpp:30:1: note: 'strlen' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
   29 | #include "logging.h"
  +++ |+#include <cstring>
   30 | #include <botan/ffi.h>
```