### PR TITLE
crypto/mem: include <cstring> for strlen

### DIFF
--- a/src/lib/crypto/mem.cpp
+++ b/src/lib/crypto/mem.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <cstdio>
+#include <cstring>
 #include "mem.h"
 #include "logging.h"
 #include <botan/ffi.h>


### PR DESCRIPTION
Fix a missing `<cstring>` include in `src/lib/crypto/mem.cpp`.

This is exposed by Botan 3.11 builds in Homebrew/homebrew-core#272485.

Full build log in here, https://github.com/Homebrew/homebrew-core/actions/runs/23126011126/job/67169369582
