### PR TITLE
Fix rnp_op_verify_get_used_recipient to support hidden recipient

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3413,6 +3413,13 @@ try {
     handler.ctx = &op->rnpctx;
 
     rnp_result_t ret = process_pgp_source(&handler, op->input->src);
+    /* For hidden recipients, patch used_recipient with the actual key id that was used.
+     * kparam.last still points to the key that succeeded: the stream-parse loop breaks
+     * immediately after a successful encrypted_try_key(), so the key provider is not
+     * called again after that point. */
+    if (kparam.has_hidden && kparam.last && op->used_recipient) {
+        op->used_recipient->keyid = kparam.last->keyid();
+    }
     /* Allow to decrypt data ignoring the signatures check if requested */
     if (op->ignore_sigs && op->validated && (ret == RNP_ERROR_SIGNATURE_INVALID)) {
         ret = RNP_SUCCESS;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -84,9 +84,9 @@ static rnp::Key *get_key_prefer_public(rnp_key_handle_t handle);
 static rnp::Key *get_key_require_secret(rnp_key_handle_t handle);
 
 static bool rnp_password_cb_bounce(const pgp_password_ctx_t *ctx,
-                                   char *                    password,
+                                   char                     *password,
                                    size_t                    password_size,
-                                   void *                    userdata_void);
+                                   void                     *userdata_void);
 
 static rnp_result_t rnp_dump_src_to_json(pgp_source_t &src, uint32_t flags, char **result);
 
@@ -106,7 +106,7 @@ find_key(rnp_ffi_t             ffi,
          const rnp::KeySearch &search,
          bool                  secret,
          bool                  try_key_provider,
-         rnp::Key *            after = nullptr)
+         rnp::Key             *after = nullptr)
 {
     auto      ks = secret ? ffi->secring : ffi->pubring;
     rnp::Key *key = ks->search(search, after);
@@ -761,9 +761,9 @@ operation_description(uint8_t op)
 
 static bool
 rnp_password_cb_bounce(const pgp_password_ctx_t *ctx,
-                       char *                    password,
+                       char                     *password,
                        size_t                    password_size,
-                       void *                    userdata_void)
+                       void                     *userdata_void)
 {
     rnp_ffi_t ffi = (rnp_ffi_t) userdata_void;
 
@@ -1131,7 +1131,7 @@ try {
         ret = json_array_add_id_str(features, compress_alg_map, z_alg_supported);
     } else if (rnp::str_case_eq(type, RNP_FEATURE_CURVE)) {
         for (pgp_curve_t curve = PGP_CURVE_NIST_P_256; curve < PGP_CURVE_MAX;
-             curve = (pgp_curve_t)(curve + 1)) {
+             curve = (pgp_curve_t) (curve + 1)) {
             auto desc = pgp::ec::Curve::get(curve);
             if (!desc) {
                 return RNP_ERROR_BAD_STATE; // LCOV_EXCL_LINE
@@ -1280,9 +1280,9 @@ rnp_get_security_rule(rnp_ffi_t   ffi,
                       const char *type,
                       const char *name,
                       uint64_t    time,
-                      uint32_t *  flags,
-                      uint64_t *  from,
-                      uint32_t *  level)
+                      uint32_t   *flags,
+                      uint64_t   *from,
+                      uint32_t   *level)
 try {
     if (!ffi || !type || !name || !level) {
         return RNP_ERROR_NULL_POINTER;
@@ -1345,7 +1345,7 @@ rnp_remove_security_rule(rnp_ffi_t   ffi,
                          uint32_t    level,
                          uint32_t    flags,
                          uint64_t    from,
-                         size_t *    removed)
+                         size_t     *removed)
 try {
     if (!ffi) {
         return RNP_ERROR_NULL_POINTER;
@@ -1666,8 +1666,8 @@ key_status_to_str(pgp_key_import_status_t status)
 }
 
 static rnp_result_t
-add_key_status(json_object *           keys,
-               const rnp::Key *        key,
+add_key_status(json_object            *keys,
+               const rnp::Key         *key,
                pgp_key_import_status_t pub,
                pgp_key_import_status_t sec)
 {
@@ -1747,7 +1747,7 @@ try {
         return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp::JSONObject jsowrap(jsores);
-    json_object *   jsokeys = json_object_new_array();
+    json_object    *jsokeys = json_object_new_array();
     if (!json_add(jsores, "keys", jsokeys)) {
         return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
@@ -1798,8 +1798,8 @@ sig_status_to_str(pgp_sig_import_status_t status)
 }
 
 static rnp_result_t
-add_sig_status(json_object *           sigs,
-               const rnp::Key *        signer,
+add_sig_status(json_object            *sigs,
+               const rnp::Key         *signer,
                pgp_sig_import_status_t pub,
                pgp_sig_import_status_t sec)
 {
@@ -1856,7 +1856,7 @@ try {
         return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
     rnp::JSONObject jsowrap(jsores);
-    json_object *   jsosigs = json_object_new_array();
+    json_object    *jsosigs = json_object_new_array();
     if (!json_add(jsores, "sigs", jsosigs)) {
         return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
     }
@@ -1864,8 +1864,8 @@ try {
     for (auto &sig : sigs) {
         pgp_sig_import_status_t pub_status = PGP_SIG_IMPORT_STATUS_UNKNOWN;
         pgp_sig_import_status_t sec_status = PGP_SIG_IMPORT_STATUS_UNKNOWN;
-        auto *                  pkey = ffi->pubring->import_signature(sig, &pub_status);
-        auto *                  skey = ffi->secring->import_signature(sig, &sec_status);
+        auto                   *pkey = ffi->pubring->import_signature(sig, &pub_status);
+        auto                   *skey = ffi->secring->import_signature(sig, &sec_status);
         sigret = add_sig_status(jsosigs, pkey ? pkey : skey, pub_status, sec_status);
         if (sigret) {
             return sigret; // LCOV_EXCL_LINE
@@ -2131,10 +2131,10 @@ input_closer_bounce(pgp_source_t *src)
 }
 
 rnp_result_t
-rnp_input_from_callback(rnp_input_t *       input,
+rnp_input_from_callback(rnp_input_t        *input,
                         rnp_input_reader_t *reader,
                         rnp_input_closer_t *closer,
-                        void *              app_ctx)
+                        void               *app_ctx)
 try {
     // checks
     if (!input || !reader) {
@@ -2400,10 +2400,10 @@ try {
 FFI_GUARD
 
 rnp_result_t
-rnp_output_to_callback(rnp_output_t *       output,
+rnp_output_to_callback(rnp_output_t        *output,
                        rnp_output_writer_t *writer,
                        rnp_output_closer_t *closer,
-                       void *               app_ctx)
+                       void                *app_ctx)
 try {
     // checks
     if (!output || !writer) {
@@ -2458,8 +2458,8 @@ static rnp_result_t
 rnp_op_add_signature(rnp_ffi_t                 ffi,
                      rnp_op_sign_signatures_t &signatures,
                      rnp_key_handle_t          key,
-                     rnp_ctx_t &               ctx,
-                     rnp_op_sign_signature_t * sig)
+                     rnp_ctx_t                &ctx,
+                     rnp_op_sign_signature_t  *sig)
 {
     if (!key) {
         return RNP_ERROR_NULL_POINTER;
@@ -2695,10 +2695,10 @@ FFI_GUARD
 
 rnp_result_t
 rnp_op_encrypt_add_password(rnp_op_encrypt_t op,
-                            const char *     password,
-                            const char *     s2k_hash,
+                            const char      *password,
+                            const char      *s2k_hash,
                             size_t           iterations,
-                            const char *     s2k_cipher)
+                            const char      *s2k_cipher)
 try {
     // checks
     if (!op) {
@@ -3195,9 +3195,9 @@ rnp_verify_src_provider(pgp_parse_handler_t *handler, pgp_source_t *src)
 };
 
 static bool
-rnp_verify_dest_provider(pgp_parse_handler_t *    handler,
-                         pgp_dest_t **            dst,
-                         bool *                   closedst,
+rnp_verify_dest_provider(pgp_parse_handler_t     *handler,
+                         pgp_dest_t             **dst,
+                         bool                    *closedst,
                          const pgp_literal_hdr_t *lithdr)
 {
     rnp_op_verify_t op = (rnp_op_verify_t) handler->param;
@@ -3212,7 +3212,7 @@ rnp_verify_dest_provider(pgp_parse_handler_t *    handler,
 
 static void
 recipient_handle_from_pk_sesskey(rnp_recipient_handle_st &handle,
-                                 const pgp_pk_sesskey_t & sesskey)
+                                 const pgp_pk_sesskey_t  &sesskey)
 {
     handle.keyid = sesskey.key_id;
     handle.palg = sesskey.alg;
@@ -3235,7 +3235,7 @@ symenc_handle_from_sk_sesskey(rnp_symenc_handle_st &handle, const pgp_sk_sesskey
 static void
 rnp_verify_on_recipients(const std::vector<pgp_pk_sesskey_t> &recipients,
                          const std::vector<pgp_sk_sesskey_t> &passwords,
-                         void *                               param)
+                         void                                *param)
 {
     rnp_op_verify_t op = (rnp_op_verify_t) param;
     /* store only top-level encrypted stream recipients info for now */
@@ -3724,7 +3724,7 @@ FFI_GUARD
 
 rnp_result_t
 rnp_op_verify_signature_get_handle(rnp_op_verify_signature_t sig,
-                                   rnp_signature_handle_t *  handle)
+                                   rnp_signature_handle_t   *handle)
 try {
     if (!sig || !handle) {
         return RNP_ERROR_NULL_POINTER;
@@ -3774,8 +3774,8 @@ FFI_GUARD
 
 rnp_result_t
 rnp_op_verify_signature_get_times(rnp_op_verify_signature_t sig,
-                                  uint32_t *                create,
-                                  uint32_t *                expires)
+                                  uint32_t                 *create,
+                                  uint32_t                 *expires)
 try {
     if (create) {
         *create = sig->sig_pkt.creation();
@@ -3813,7 +3813,7 @@ FFI_GUARD
 static rnp_result_t
 rnp_locate_key_int(rnp_ffi_t             ffi,
                    const rnp::KeySearch &locator,
-                   rnp_key_handle_t *    handle,
+                   rnp_key_handle_t     *handle,
                    bool                  require_secret = false)
 {
     // search pubring
@@ -3836,8 +3836,8 @@ rnp_locate_key_int(rnp_ffi_t             ffi,
 
 rnp_result_t
 rnp_locate_key(rnp_ffi_t         ffi,
-               const char *      identifier_type,
-               const char *      identifier,
+               const char       *identifier_type,
+               const char       *identifier,
                rnp_key_handle_t *handle)
 try {
     // checks
@@ -3872,7 +3872,7 @@ try {
 
     // handle flags
     bool           armored = extract_flag(flags, RNP_KEY_EXPORT_ARMORED);
-    rnp::Key *     key = nullptr;
+    rnp::Key      *key = nullptr;
     rnp::KeyStore *store = nullptr;
     if (flags & RNP_KEY_EXPORT_PUBLIC) {
         extract_flag(flags, RNP_KEY_EXPORT_PUBLIC);
@@ -3949,7 +3949,7 @@ FFI_GUARD
 rnp_result_t
 rnp_key_export_autocrypt(rnp_key_handle_t key,
                          rnp_key_handle_t subkey,
-                         const char *     uid,
+                         const char      *uid,
                          rnp_output_t     output,
                          uint32_t         flags)
 try {
@@ -4025,8 +4025,8 @@ rnp_key_get_revoker(rnp_key_handle_t key)
 static bool
 fill_revocation_reason(rnp_ffi_t        ffi,
                        rnp::Revocation &revinfo,
-                       const char *     code,
-                       const char *     reason)
+                       const char      *code,
+                       const char      *reason)
 {
     revinfo = {};
     if (code && !str_to_revocation_type(code, &revinfo.code)) {
@@ -4045,11 +4045,11 @@ fill_revocation_reason(rnp_ffi_t        ffi,
 
 static rnp_result_t
 rnp_key_get_revocation(rnp_ffi_t            ffi,
-                       rnp::Key *           key,
-                       rnp::Key *           revoker,
-                       const char *         hash,
-                       const char *         code,
-                       const char *         reason,
+                       rnp::Key            *key,
+                       rnp::Key            *revoker,
+                       const char          *hash,
+                       const char          *code,
+                       const char          *reason,
                        pgp::pkt::Signature &sig)
 {
     if (!hash) {
@@ -4083,9 +4083,9 @@ rnp_result_t
 rnp_key_export_revocation(rnp_key_handle_t key,
                           rnp_output_t     output,
                           uint32_t         flags,
-                          const char *     hash,
-                          const char *     code,
-                          const char *     reason)
+                          const char      *hash,
+                          const char      *code,
+                          const char      *reason)
 try {
     if (!key || !key->ffi || !output) {
         return RNP_ERROR_NULL_POINTER;
@@ -4259,11 +4259,11 @@ FFI_GUARD
 
 static void
 report_signature_removal(rnp_ffi_t             ffi,
-                         const rnp::Key &      key,
+                         const rnp::Key       &key,
                          rnp_key_signatures_cb sigcb,
-                         void *                app_ctx,
-                         rnp::Signature &      keysig,
-                         bool &                remove)
+                         void                 *app_ctx,
+                         rnp::Signature       &keysig,
+                         bool                 &remove)
 {
     if (!sigcb) {
         return;
@@ -4333,11 +4333,11 @@ signature_needs_removal(rnp_ffi_t       ffi,
 
 static void
 remove_key_signatures(rnp_ffi_t             ffi,
-                      rnp::Key &            pub,
-                      rnp::Key *            sec,
+                      rnp::Key             &pub,
+                      rnp::Key             *sec,
                       uint32_t              flags,
                       rnp_key_signatures_cb sigcb,
-                      void *                app_ctx)
+                      void                 *app_ctx)
 {
     pgp::SigIDs sigs;
 
@@ -4363,7 +4363,7 @@ rnp_result_t
 rnp_key_remove_signatures(rnp_key_handle_t      handle,
                           uint32_t              flags,
                           rnp_key_signatures_cb sigcb,
-                          void *                app_ctx)
+                          void                 *app_ctx)
 try {
     if (!handle) {
         return RNP_ERROR_NULL_POINTER;
@@ -4539,9 +4539,9 @@ parse_protection(json_object *jso, rnp_key_protection_params_t &protection)
 }
 
 static bool
-parse_keygen_common_fields(json_object *                jso,
-                           uint8_t &                    usage,
-                           uint32_t &                   expiry,
+parse_keygen_common_fields(json_object                 *jso,
+                           uint8_t                     &usage,
+                           uint32_t                    &expiry,
                            rnp_key_protection_params_t &prot)
 {
     /* Key/subkey usage flags */
@@ -4577,8 +4577,8 @@ parse_keygen_common_fields(json_object *                jso,
 
 static std::unique_ptr<rnp::KeygenParams>
 parse_keygen_primary(rnp_ffi_t                    ffi,
-                     json_object *                jso,
-                     rnp::CertParams &            cert,
+                     json_object                 *jso,
+                     rnp::CertParams             &cert,
                      rnp_key_protection_params_t &prot)
 {
     /* Parse keygen params first */
@@ -4612,8 +4612,8 @@ parse_keygen_primary(rnp_ffi_t                    ffi,
 
 static std::unique_ptr<rnp::KeygenParams>
 parse_keygen_sub(rnp_ffi_t                    ffi,
-                 json_object *                jso,
-                 rnp::BindingParams &         binding,
+                 json_object                 *jso,
+                 rnp::BindingParams          &binding,
                  rnp_key_protection_params_t &prot)
 {
     /* Parse keygen params first */
@@ -4669,9 +4669,9 @@ gen_json_grips(char **result, const rnp::Key *primary, const rnp::Key *sub)
 
 static rnp_result_t
 gen_json_primary_key(rnp_ffi_t                    ffi,
-                     json_object *                jsoparams,
+                     json_object                 *jsoparams,
                      rnp_key_protection_params_t &prot,
-                     pgp::Fingerprint &           fp,
+                     pgp::Fingerprint            &fp,
                      bool                         protect)
 {
     rnp::CertParams cert;
@@ -4704,9 +4704,9 @@ gen_json_primary_key(rnp_ffi_t                    ffi,
 
 static rnp_result_t
 gen_json_subkey(rnp_ffi_t         ffi,
-                json_object *     jsoparams,
-                rnp::Key &        prim_pub,
-                rnp::Key &        prim_sec,
+                json_object      *jsoparams,
+                rnp::Key         &prim_pub,
+                rnp::Key         &prim_sec,
                 pgp::Fingerprint &fp)
 {
     rnp::BindingParams          binding;
@@ -4751,7 +4751,7 @@ try {
 
     // parse the JSON
     json_tokener_error error;
-    json_object *      jso = json_tokener_parse_verbose(json, &error);
+    json_object       *jso = json_tokener_parse_verbose(json, &error);
     if (!jso) {
         // syntax error or some other issue
         FFI_LOG(ffi, "Invalid JSON: %s", json_tokener_error_desc(error));
@@ -4791,8 +4791,8 @@ try {
     }
 
     // generate primary key
-    rnp::Key *                  prim_pub = nullptr;
-    rnp::Key *                  prim_sec = nullptr;
+    rnp::Key                   *prim_pub = nullptr;
+    rnp::Key                   *prim_sec = nullptr;
     rnp_key_protection_params_t prim_prot = {};
     pgp::Fingerprint            fp;
     if (jsoprimary) {
@@ -4868,14 +4868,14 @@ FFI_GUARD
 
 rnp_result_t
 rnp_generate_key_ex(rnp_ffi_t         ffi,
-                    const char *      key_alg,
-                    const char *      sub_alg,
+                    const char       *key_alg,
+                    const char       *sub_alg,
                     uint32_t          key_bits,
                     uint32_t          sub_bits,
-                    const char *      key_curve,
-                    const char *      sub_curve,
-                    const char *      userid,
-                    const char *      password,
+                    const char       *key_curve,
+                    const char       *sub_curve,
+                    const char       *userid,
+                    const char       *password,
                     rnp_key_handle_t *key)
 try {
     rnp_op_generate_t op = NULL;
@@ -4968,8 +4968,8 @@ rnp_result_t
 rnp_generate_key_rsa(rnp_ffi_t         ffi,
                      uint32_t          bits,
                      uint32_t          subbits,
-                     const char *      userid,
-                     const char *      password,
+                     const char       *userid,
+                     const char       *password,
                      rnp_key_handle_t *key)
 try {
     return rnp_generate_key_ex(ffi,
@@ -4989,8 +4989,8 @@ rnp_result_t
 rnp_generate_key_dsa_eg(rnp_ffi_t         ffi,
                         uint32_t          bits,
                         uint32_t          subbits,
-                        const char *      userid,
-                        const char *      password,
+                        const char       *userid,
+                        const char       *password,
                         rnp_key_handle_t *key)
 try {
     return rnp_generate_key_ex(ffi,
@@ -5008,9 +5008,9 @@ FFI_GUARD
 
 rnp_result_t
 rnp_generate_key_ec(rnp_ffi_t         ffi,
-                    const char *      curve,
-                    const char *      userid,
-                    const char *      password,
+                    const char       *curve,
+                    const char       *userid,
+                    const char       *password,
                     rnp_key_handle_t *key)
 try {
     return rnp_generate_key_ex(
@@ -5020,8 +5020,8 @@ FFI_GUARD
 
 rnp_result_t
 rnp_generate_key_25519(rnp_ffi_t         ffi,
-                       const char *      userid,
-                       const char *      password,
+                       const char       *userid,
+                       const char       *password,
                        rnp_key_handle_t *key)
 try {
     return rnp_generate_key_ex(ffi,
@@ -5039,8 +5039,8 @@ FFI_GUARD
 
 rnp_result_t
 rnp_generate_key_sm2(rnp_ffi_t         ffi,
-                     const char *      userid,
-                     const char *      password,
+                     const char       *userid,
+                     const char       *password,
                      rnp_key_handle_t *key)
 try {
     return rnp_generate_key_ex(
@@ -5142,7 +5142,7 @@ rnp_result_t
 rnp_op_generate_subkey_create(rnp_op_generate_t *op,
                               rnp_ffi_t          ffi,
                               rnp_key_handle_t   primary,
-                              const char *       alg)
+                              const char        *alg)
 try {
     if (!op || !ffi || !alg || !primary) {
         return RNP_ERROR_NULL_POINTER;
@@ -5666,8 +5666,8 @@ key_get_uid_at(rnp::Key *key, size_t idx, char **uid)
 
 rnp_result_t
 rnp_key_add_uid(rnp_key_handle_t handle,
-                const char *     uid,
-                const char *     hash,
+                const char      *uid,
+                const char      *hash,
                 uint32_t         expiration,
                 uint8_t          key_flags,
                 bool             primary)
@@ -5872,8 +5872,8 @@ FFI_GUARD
 
 static rnp_result_t
 rnp_key_return_signature(rnp_ffi_t               ffi,
-                         rnp::Key *              key,
-                         rnp::Signature *        subsig,
+                         rnp::Key               *key,
+                         rnp::Signature         *subsig,
                          rnp_signature_handle_t *sig)
 {
     try {
@@ -5919,8 +5919,8 @@ FFI_GUARD
 
 static rnp_result_t
 create_key_signature(rnp_ffi_t               ffi,
-                     rnp::Key &              sigkey,
-                     rnp::Key &              tgkey,
+                     rnp::Key               &sigkey,
+                     rnp::Key               &tgkey,
                      uint32_t                uid,
                      rnp_signature_handle_t &sig,
                      pgp_sig_type_t          type)
@@ -5993,7 +5993,7 @@ FFI_GUARD
 rnp_result_t
 rnp_key_certification_create(rnp_key_handle_t        signer,
                              rnp_uid_handle_t        uid,
-                             const char *            type,
+                             const char             *type,
                              rnp_signature_handle_t *sig)
 try {
     if (!signer || !uid || !sig) {
@@ -6229,8 +6229,8 @@ FFI_GUARD
 
 rnp_result_t
 rnp_key_signature_set_revocation_reason(rnp_signature_handle_t sig,
-                                        const char *           code,
-                                        const char *           reason)
+                                        const char            *code,
+                                        const char            *reason)
 try {
     if (!sig) {
         return RNP_ERROR_NULL_POINTER;
@@ -6510,7 +6510,7 @@ FFI_GUARD
 rnp_result_t
 rnp_signature_subpacket_at(rnp_signature_handle_t handle,
                            size_t                 idx,
-                           rnp_sig_subpacket_t *  subpkt)
+                           rnp_sig_subpacket_t   *subpkt)
 try {
     if (!handle || !subpkt) {
         return RNP_ERROR_NULL_POINTER;
@@ -6528,7 +6528,7 @@ rnp_signature_subpacket_find(rnp_signature_handle_t handle,
                              uint8_t                type,
                              bool                   hashed,
                              size_t                 skip,
-                             rnp_sig_subpacket_t *  subpkt)
+                             rnp_sig_subpacket_t   *subpkt)
 try {
     if (!handle || !subpkt) {
         return RNP_ERROR_NULL_POINTER;
@@ -6540,9 +6540,9 @@ FFI_GUARD
 
 rnp_result_t
 rnp_signature_subpacket_info(rnp_sig_subpacket_t subpkt,
-                             uint8_t *           type,
-                             bool *              hashed,
-                             bool *              critical)
+                             uint8_t            *type,
+                             bool               *hashed,
+                             bool               *critical)
 try {
     if (!subpkt) {
         return RNP_ERROR_NULL_POINTER;
@@ -7171,7 +7171,7 @@ FFI_GUARD
 
 rnp_result_t
 rnp_key_get_default_key(rnp_key_handle_t  primary_key,
-                        const char *      usage,
+                        const char       *usage,
                         uint32_t          flags,
                         rnp_key_handle_t *default_key)
 try {
@@ -7282,7 +7282,7 @@ try {
     if (!handle || !curve) {
         return RNP_ERROR_NULL_POINTER;
     }
-    auto *      key = get_key_prefer_public(handle);
+    auto       *key = get_key_prefer_public(handle);
     pgp_curve_t _curve = key->curve();
     if (_curve == PGP_CURVE_UNKNOWN) {
         return RNP_ERROR_BAD_PARAMETERS;
@@ -7562,7 +7562,7 @@ try {
     }
 
     rnp::KeyFingerprintSearch search(pkey->primary_fp());
-    auto *                    prim_sec = find_key(key->ffi, search, true, true);
+    auto                     *prim_sec = find_key(key->ffi, search, true, true);
     if (!prim_sec) {
         FFI_LOG(key->ffi, "Primary secret key not found.");
         return RNP_ERROR_KEY_NOT_FOUND;
@@ -7656,7 +7656,7 @@ try {
     }
 
     const pgp_s2k_t &s2k = key->sec->pkt().sec_protection.s2k;
-    const char *     res = "Unknown";
+    const char      *res = "Unknown";
     if (s2k.usage == PGP_S2KU_NONE) {
         res = "None";
     }
@@ -7844,10 +7844,10 @@ FFI_GUARD
 
 rnp_result_t
 rnp_key_protect(rnp_key_handle_t handle,
-                const char *     password,
-                const char *     cipher,
-                const char *     cipher_mode,
-                const char *     hash,
+                const char      *password,
+                const char      *cipher,
+                const char      *cipher_mode,
+                const char      *hash,
                 size_t           iterations)
 try {
     rnp_key_protection_params_t protection = {};
@@ -7876,7 +7876,7 @@ try {
     if (!key) {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    pgp_key_pkt_t *   decrypted_key = NULL;
+    pgp_key_pkt_t    *decrypted_key = NULL;
     const std::string pass = password;
     if (key->encrypted()) {
         pgp_password_ctx_t ctx(PGP_OP_PROTECT, key);
@@ -8051,7 +8051,7 @@ static rnp_result_t
 add_json_mpis(json_object *jso, ...)
 {
     va_list      ap;
-    const char * name;
+    const char  *name;
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
     va_start(ap, jso);
@@ -8229,10 +8229,10 @@ add_json_sig_mpis(json_object *jso, const pgp::pkt::Signature *sig)
 }
 
 static bool
-add_json_array_lookup(json_object *        jso,
+add_json_array_lookup(json_object         *jso,
                       std::vector<uint8_t> vals,
-                      const char *         name,
-                      const id_str_pair *  map)
+                      const char          *name,
+                      const id_str_pair   *map)
 {
     if (vals.empty()) {
         return true;
@@ -8653,7 +8653,7 @@ FFI_GUARD
 static rnp_result_t
 rnp_dump_src_to_json(pgp_source_t &src, uint32_t flags, char **result)
 {
-    json_object *        jso = NULL;
+    json_object         *jso = NULL;
     rnp::DumpContextJson dumpctx(src, &jso);
 
     dumpctx.set_dump_mpi(extract_flag(flags, RNP_JSON_DUMP_MPI));
@@ -8836,7 +8836,7 @@ key_iter_get_item(const rnp_identifier_iterator_t it)
 rnp_result_t
 rnp_identifier_iterator_create(rnp_ffi_t                  ffi,
                                rnp_identifier_iterator_t *it,
-                               const char *               identifier_type)
+                               const char                *identifier_type)
 try {
     // checks
     if (!ffi || !it || !identifier_type) {

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -2142,6 +2142,54 @@ TEST_F(rnp_tests, test_ffi_decrypt_small_eg)
     rnp_ffi_destroy(ffi);
 }
 
+/* Regression test for #1275 / PR #2391: rnp_op_verify_get_used_recipient must
+ * return the actual key that was used for decryption, even when the recipient
+ * was hidden in the PKESK packet (keyid all zeroes). The fix patches the
+ * used_recipient's keyid from the key that successfully decrypted. Without
+ * the fix, used_recipient is NULL because no embedded keyid matches a key. */
+TEST_F(rnp_tests, test_ffi_decrypt_hidden_recipient_used_recipient)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_true(import_sec_keys(ffi, "data/keyrings/1/secring.gpg"));
+    assert_rnp_success(
+      rnp_ffi_set_pass_provider(ffi, ffi_string_password_provider, (void *) "password"));
+
+    /* message.txt.enc-hidden-1 has a hidden first recipient. The seckey that
+     * decrypts it (per src/tests/cli_tests.py::test_hidden_recipient) is
+     * 0x326EF111425D14A5. */
+    rnp_input_t input = NULL;
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_messages/message.txt.enc-hidden-1"));
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_null(&output));
+
+    rnp_op_verify_t verify = NULL;
+    assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
+    assert_rnp_success(
+      rnp_op_verify_set_flags(verify, RNP_VERIFY_ALLOW_HIDDEN_RECIPIENT));
+    assert_rnp_success(rnp_op_verify_execute(verify));
+
+    /* Without the PR's patch, used_recipient->keyid would be all-zero
+     * (the hidden-recipient sentinel from RFC 4880 §5.1) because no real
+     * keyid is embedded in the PKESK packet. With the patch, used_recipient
+     * ->keyid is the actual key that succeeded. */
+    rnp_recipient_handle_t recipient = NULL;
+    assert_rnp_success(rnp_op_verify_get_used_recipient(verify, &recipient));
+    assert_non_null(recipient);
+    char *keyid = NULL;
+    assert_rnp_success(rnp_recipient_get_keyid(recipient, &keyid));
+    assert_non_null(keyid);
+    /* Must not be the all-zero hidden-recipient sentinel. */
+    EXPECT_STRNE(keyid, "0000000000000000");
+    rnp_buffer_destroy(keyid);
+
+    rnp_op_verify_destroy(verify);
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_ffi_encrypt_no_wrap)
 {
     rnp_ffi_t ffi = NULL;
@@ -2152,8 +2200,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_no_wrap)
     rnp_input_t input = NULL;
     assert_rnp_success(rnp_input_from_path(&input, "data/test_messages/message.txt.signed"));
     rnp_output_t output = NULL;
-    assert_rnp_success(rnp_output_to_path(&output, "encrypted"));
-    rnp_op_encrypt_t op = NULL;
+    assert_rnp_success(rnp_output_to_path(&output, "encrypted"));    rnp_op_encrypt_t op = NULL;
     assert_rnp_success(rnp_op_encrypt_create(&op, ffi, input, output));
     rnp_key_handle_t key = NULL;
     assert_rnp_success(rnp_locate_key(ffi, "userid", "key0-uid2", &key));

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -44,10 +44,10 @@
 
 static bool
 getpasscb_once(rnp_ffi_t        ffi,
-               void *           app_ctx,
+               void            *app_ctx,
                rnp_key_handle_t key,
-               const char *     pgp_context,
-               char *           buf,
+               const char      *pgp_context,
+               char            *buf,
                size_t           buf_len)
 {
     const char **pass = (const char **) app_ctx;
@@ -65,13 +65,13 @@ getpasscb_once(rnp_ffi_t        ffi,
 
 static bool
 getpasscb_inc(rnp_ffi_t        ffi,
-              void *           app_ctx,
+              void            *app_ctx,
               rnp_key_handle_t key,
-              const char *     pgp_context,
-              char *           buf,
+              const char      *pgp_context,
+              char            *buf,
               size_t           buf_len)
 {
-    int *       num = (int *) app_ctx;
+    int        *num = (int *) app_ctx;
     std::string pass = "pass" + std::to_string(*num);
     (*num)++;
     strncpy(buf, pass.c_str(), buf_len - 1);
@@ -83,14 +83,14 @@ typedef struct key_tbl_t {
     const uint8_t *key_data;
     size_t         key_data_size;
     bool           secret;
-    const char *   keyid;
-    const char *   grip;
-    const char *   userids[TBL_MAX_USERIDS + 1];
+    const char    *keyid;
+    const char    *grip;
+    const char    *userids[TBL_MAX_USERIDS + 1];
 } key_tbl_t;
 
 static void
 tbl_getkeycb(rnp_ffi_t   ffi,
-             void *      app_ctx,
+             void       *app_ctx,
              const char *identifier_type,
              const char *identifier,
              bool        secret)
@@ -138,7 +138,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_pass)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
+    const char      *plaintext = "data1";
 
     // setup FFI
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
@@ -603,7 +603,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_pk)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
+    const char      *plaintext = "data1";
 
     // setup FFI
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
@@ -712,7 +712,7 @@ TEST_F(rnp_tests, test_ffi_select_deprecated_ciphers)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
+    const char      *plaintext = "data1";
 
     // setup FFI
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
@@ -867,10 +867,10 @@ TEST_F(rnp_tests, test_ffi_select_deprecated_ciphers)
 
 static bool
 first_key_password_provider(rnp_ffi_t        ffi,
-                            void *           app_ctx,
+                            void            *app_ctx,
                             rnp_key_handle_t key,
-                            const char *     pgp_context,
-                            char *           buf,
+                            const char      *pgp_context,
+                            char            *buf,
                             size_t           buf_len)
 {
     if (!key) {
@@ -891,7 +891,7 @@ TEST_F(rnp_tests, test_ffi_decrypt_pk_unlocked)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
+    const char      *plaintext = "data1";
 
     // setup FFI
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
@@ -1022,7 +1022,7 @@ TEST_F(rnp_tests, test_ffi_pqc_gen_enc_sign)
         rnp_input_t      input = NULL;
         rnp_output_t     output = NULL;
         rnp_op_encrypt_t op = NULL;
-        const char *     plaintext = "data1";
+        const char      *plaintext = "data1";
         assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
         assert_rnp_success(rnp_generate_key_ex(ffi,
                                                pk_algs.first.c_str(),
@@ -1446,7 +1446,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_pk_with_v6_key)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
+    const char      *plaintext = "data1";
 
     // setup FFI
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
@@ -1562,10 +1562,10 @@ TEST_F(rnp_tests, test_ffi_encrypt_pk_key_provider)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
-    uint8_t *        primary_sec_key_data = NULL;
+    const char      *plaintext = "data1";
+    uint8_t         *primary_sec_key_data = NULL;
     size_t           primary_sec_size = 0;
-    uint8_t *        sub_sec_key_data = NULL;
+    uint8_t         *sub_sec_key_data = NULL;
     size_t           sub_sec_size = 0;
 
     /* first, let's generate some encrypted data */
@@ -1691,7 +1691,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_and_sign)
     rnp_output_t            output = NULL;
     rnp_op_encrypt_t        op = NULL;
     rnp_op_sign_signature_t signsig = NULL;
-    const char *            plaintext = "data1";
+    const char             *plaintext = "data1";
     rnp_key_handle_t        key = NULL;
     const uint32_t          issued = 1516211899;   // Unix epoch, nowish
     const uint32_t          expires = 1000000000;  // expires later
@@ -1880,7 +1880,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_and_sign)
     size_t                    sig_count;
     uint32_t                  sig_create;
     uint32_t                  sig_expires;
-    char *                    hname = NULL;
+    char                     *hname = NULL;
 
     assert_rnp_success(rnp_op_verify_get_signature_count(verify, &sig_count));
     assert_int_equal(sig_count, 2);
@@ -1953,7 +1953,7 @@ TEST_F(rnp_tests, test_ffi_encrypt_pk_subkey_selection)
     rnp_input_t      input = NULL;
     rnp_output_t     output = NULL;
     rnp_op_encrypt_t op = NULL;
-    const char *     plaintext = "data1";
+    const char      *plaintext = "data1";
 
     /* check whether a latest subkey is selected for encryption */
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
@@ -2166,8 +2166,7 @@ TEST_F(rnp_tests, test_ffi_decrypt_hidden_recipient_used_recipient)
 
     rnp_op_verify_t verify = NULL;
     assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
-    assert_rnp_success(
-      rnp_op_verify_set_flags(verify, RNP_VERIFY_ALLOW_HIDDEN_RECIPIENT));
+    assert_rnp_success(rnp_op_verify_set_flags(verify, RNP_VERIFY_ALLOW_HIDDEN_RECIPIENT));
     assert_rnp_success(rnp_op_verify_execute(verify));
 
     /* Without the PR's patch, used_recipient->keyid would be all-zero
@@ -2200,7 +2199,8 @@ TEST_F(rnp_tests, test_ffi_encrypt_no_wrap)
     rnp_input_t input = NULL;
     assert_rnp_success(rnp_input_from_path(&input, "data/test_messages/message.txt.signed"));
     rnp_output_t output = NULL;
-    assert_rnp_success(rnp_output_to_path(&output, "encrypted"));    rnp_op_encrypt_t op = NULL;
+    assert_rnp_success(rnp_output_to_path(&output, "encrypted"));
+    rnp_op_encrypt_t op = NULL;
     assert_rnp_success(rnp_op_encrypt_create(&op, ffi, input, output));
     rnp_key_handle_t key = NULL;
     assert_rnp_success(rnp_locate_key(ffi, "userid", "key0-uid2", &key));


### PR DESCRIPTION
Fix rnp_op_verify_get_used_recipient to support hidden recipient
Related to Issue #1275
