### PR TITLE
Fix cross-compilation with openssl backend

### DIFF
--- a/cmake/Modules/FindOpenSSLFeatures.cmake
+++ b/cmake/Modules/FindOpenSSLFeatures.cmake
@@ -106,7 +106,10 @@ if(CMAKE_GENERATOR_TOOLSET)
 endif(CMAKE_GENERATOR_TOOLSET)
 
 if(CMAKE_CROSSCOMPILING_EMULATOR)
-  set(MKF ${MKF} "-DCMAKE_CROSSCOMPILING_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}")
+  # Escape semicolons so list-style emulators (e.g. "qemu;-L;/sysroot")
+  # are forwarded to the nested configure as a single -D argument.
+  string(REPLACE ";" "\\;" _fossl_emulator "${CMAKE_CROSSCOMPILING_EMULATOR}")
+  set(MKF ${MKF} "-DCMAKE_CROSSCOMPILING_EMULATOR=${_fossl_emulator}")
 endif(CMAKE_CROSSCOMPILING_EMULATOR)
 
 execute_process(
@@ -157,7 +160,6 @@ foreach(feature "hashes" "ciphers" "curves" "publickey" "providers" "kdfs")
     OUTPUT_VARIABLE feature_val
     ERROR_VARIABLE error
     RESULT_VARIABLE result
-    COMMAND_ECHO STDOUT
   )
 
   if(NOT ${result} EQUAL 0)

--- a/cmake/Modules/FindOpenSSLFeatures.cmake
+++ b/cmake/Modules/FindOpenSSLFeatures.cmake
@@ -81,7 +81,10 @@ target_include_directories(findopensslfeatures PRIVATE ${OPENSSL_INCLUDE_DIR})\n
 target_link_libraries(findopensslfeatures PRIVATE OpenSSL::Crypto)\n\
 if (OpenSSL::applink)\n\
   target_link_libraries(findopensslfeatures PRIVATE OpenSSL::applink)\n\
-endif(OpenSSL::applink)\n"
+endif(OpenSSL::applink)\n\
+if(CMAKE_CROSSCOMPILING_EMULATOR)\n\
+  target_link_options(findopensslfeatures PRIVATE -static)\n\
+endif(CMAKE_CROSSCOMPILING_EMULATOR)\n"
 )
 
 set(MKF ${MKF} "-DCMAKE_BUILD_TYPE=Release" "-DOPENSSL_ROOT_DIR=${OPENSSL_INCLUDE_DIR}/..")
@@ -101,6 +104,10 @@ endif(CMAKE_GENERATOR_PLATFORM)
 if(CMAKE_GENERATOR_TOOLSET)
   set(MKF ${MKF} "-T" "${CMAKE_GENERATOR_TOOLSET}")
 endif(CMAKE_GENERATOR_TOOLSET)
+
+if(CMAKE_CROSSCOMPILING_EMULATOR)
+  set(MKF ${MKF} "-DCMAKE_CROSSCOMPILING_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}")
+endif(CMAKE_CROSSCOMPILING_EMULATOR)
 
 execute_process(
   COMMAND "${CMAKE_COMMAND}" "-Bbuild" ${MKF} "."
@@ -139,13 +146,18 @@ else(WIN32 AND NOT MINGW)
   set(FOF "build/findopensslfeatures")
 endif(WIN32 AND NOT MINGW)
 
+if(CMAKE_CROSSCOMPILING_EMULATOR)
+  set(FOF ${CMAKE_CROSSCOMPILING_EMULATOR} ${FOF})
+endif()
+
 foreach(feature "hashes" "ciphers" "curves" "publickey" "providers" "kdfs")
   execute_process(
-    COMMAND "${FOF}" "${feature}"
+    COMMAND ${FOF} "${feature}"
     WORKING_DIRECTORY "${_fossl_work_dir}"
     OUTPUT_VARIABLE feature_val
     ERROR_VARIABLE error
     RESULT_VARIABLE result
+    COMMAND_ECHO STDOUT
   )
 
   if(NOT ${result} EQUAL 0)

--- a/cmake/Modules/FindOpenSSLFeatures.cmake
+++ b/cmake/Modules/FindOpenSSLFeatures.cmake
@@ -83,6 +83,8 @@ if (OpenSSL::applink)\n\
   target_link_libraries(findopensslfeatures PRIVATE OpenSSL::applink)\n\
 endif(OpenSSL::applink)\n\
 if(CMAKE_CROSSCOMPILING_EMULATOR)\n\
+  # Static-link the helper so the emulator (e.g. qemu-user) doesn't need the\n\
+  # target's shared libs discoverable at its sysroot lookup paths.\n\
   target_link_options(findopensslfeatures PRIVATE -static)\n\
 endif(CMAKE_CROSSCOMPILING_EMULATOR)\n"
 )
@@ -150,6 +152,9 @@ else(WIN32 AND NOT MINGW)
 endif(WIN32 AND NOT MINGW)
 
 if(CMAKE_CROSSCOMPILING_EMULATOR)
+  # Prepend the emulator so execute_process expands ${FOF} as argv elements:
+  # COMMAND ${EMULATOR} ${FOF} "${feature}". Quotes around ${FOF} are intentionally
+  # dropped so the emulator + binary become separate argv entries.
   set(FOF ${CMAKE_CROSSCOMPILING_EMULATOR} ${FOF})
 endif()
 


### PR DESCRIPTION
FindOpenSSLFeatures.cmake uses execute_process() to run findopensslfeatures during configure, but execute_process() does not respect CMAKE_CROSSCOMPILING_EMULATOR (unlike try_run()). This causes configuration to fail when cross-compiling for Android, ARM, etc. because the target binary cannot execute on the host.

Prepend CMAKE_CROSSCOMPILING_EMULATOR to the FOF command if set, so the feature detection binary is run via the configured emulator (e.g. qemu-user) when cross-compiling.

Link findopensslfeatures statically when CMAKE_CROSSCOMPILING_EMULATOR is enabled to avoid linker not found errors when emulator attempt to run it