### PR TITLE
Fix inverted rnp_key_25519_bits_tweaked() result documentation

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1335,10 +1335,11 @@ RNP_API rnp_result_t rnp_key_revoke(rnp_key_handle_t key,
  *        rnp_key_lock() afterwards.
  *
  * @param key key handle, cannot be NULL. Must be ECDH Curve25519 unlocked secret key.
- * @param result true will be stored here if secret key's low/high bits are not correctly set.
- *               In this case you may need to call `rnp_key_25519_bits_tweak()` on it to set
- *               bits to correct values so exported secret key will be compatible with
- *               implementations which do not tweak these bits automatically.
+ * @param result true will be stored here if secret key's low/high bits are correctly set
+ *               (tweaked). If false is stored here then you may need to call
+ *               `rnp_key_25519_bits_tweak()` on it to set bits to correct values, so
+ *               exported secret key will be compatible with implementations which do
+ *               not tweak these bits automatically.
  * @return RNP_SUCCESS or error code if failed.
  */
 RNP_API rnp_result_t rnp_key_25519_bits_tweaked(rnp_key_handle_t key, bool *result);


### PR DESCRIPTION
## Bug

The Doxygen for `rnp_key_25519_bits_tweaked()` stated that `true` is stored in `result` "if secret key's low/high bits are **not** correctly set", advising a call to `rnp_key_25519_bits_tweak()` in that case. This is inverted vs both the function name and the implementation:

- `x25519_bits_tweaked()` (`src/lib/crypto/ecdh_utils.cpp:150`) returns `!(key.x[31] & 7) && (key.x[0] < 128) && (key.x[0] >= 64)` — i.e. `true` when the bits **are** correctly clamped per RFC 7748 §5 (3 LSBs zeroed, high bit clear, bit 254 set);
- the FFI chain passes it straight through: `rnp_key_25519_bits_tweaked()` (`src/lib/rnp.cpp:4222`) → `ECDHKeyMaterial::x25519_bits_tweaked()` (`src/lib/key_material.cpp:1266`);
- the test suite agrees: a freshly imported *non-tweaked* secret key yields `tweaked == false`, and after `rnp_key_25519_bits_tweak()` it yields `true` (`src/tests/ffi-key-prop.cpp`, `test_ffi_key_25519_tweaked_bits`);
- `ECDHKeyMaterial::decrypt()` warns "bits of 25519 secret key are not tweaked" when `!x25519_bits_tweaked()` (`src/lib/key_material.cpp:1243`).

A consumer following the doc would call `rnp_key_25519_bits_tweak()` exactly when it is *not* needed and skip it when it is. Surfaced by downstream binding work: rnpgp/py-rnp#14.

## Fix

Comment-only: correct the `@param result` truth condition (true = bits are correctly set/tweaked; false = call `rnp_key_25519_bits_tweak()`), keeping the RFC 7748 context paragraph and the `rnp_key_lock()` note intact. `rnp_key_25519_bits_tweak()`'s own doc block was checked and is already consistent, so it is unchanged.
