### PR TITLE
ci: add automated release workflow and streamline release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.18.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || github.event.inputs.tag }}
+
+jobs:
+  tarball:
+    name: Build source tarball
+    runs-on: ubuntu-latest
+    container: ghcr.io/rnpgp/ci-rnp-fedora-40-amd64
+    steps:
+      - name: Checkout release scripts
+        uses: actions/checkout@v4
+
+      - name: Build source tarball
+        run: |
+          mkdir -p /opt/artifacts
+          bash ci/build_tarball.sh "${RELEASE_TAG}"
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+
+      - name: Stage artifacts
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/artifacts"
+          cp /opt/artifacts/rnp-* "${GITHUB_WORKSPACE}/artifacts/"
+          ls -la "${GITHUB_WORKSPACE}/artifacts/"
+
+      - name: Upload tarball artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-tarball
+          path: artifacts/
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub release
+    needs: tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download tarball artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-tarball
+          path: artifacts/
+
+      - name: Prepare release notes
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          awk "/^### ${VERSION}/{flag=1; next} /^### /{flag=0} flag" CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "Release ${RELEASE_TAG}" > release-notes.md
+          fi
+          cat release-notes.md
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          gh release create "${RELEASE_TAG}" \
+            artifacts/rnp-*.tar.gz artifacts/rnp-*.sha256 \
+            --title "${RELEASE_TAG}" \
+            --notes-file release-notes.md

--- a/docs/develop/release-workflow.adoc
+++ b/docs/develop/release-workflow.adoc
@@ -3,9 +3,13 @@
 == General notes
 
 * Avoid tagging commits in the `main` branch.
-* Release branches should have annotated tags and a CHANGELOG.md.
-* The steps below detail creation of a brand new 1.0.0 release.
-  Some steps would be omitted for minor releases.
+* Release branches should have annotated tags and a `CHANGELOG.md`.
+* Release branches have names of the form `release/N.x`, where N is the major
+  version (and `x` is a literal -- not a placeholder).
+* Pushing an annotated tag `vX.Y.Z` triggers the
+  link:.github/workflows/release.yml[`release` GitHub Actions workflow],
+  which builds the source tarball and publishes the GitHub release
+  automatically.
 
 == Creating an initial release
 
@@ -19,14 +23,11 @@ version you intend to release.
 git checkout main
 vim docs/installation.adoc
 git add docs/installation.adoc
-git commit
+git commit -m "docs: update version references for X.Y.Z"
 git push
 ----
 
 === Create branch
-
-Release branches have names of the form `release/N.x`, where N is the major
-version (and `x` is a literal -- not a placeholder).
 
 [source,console]
 ----
@@ -45,40 +46,41 @@ git add CHANGELOG.md
 echo 1.0.0 > version.txt
 git add -f version.txt
 
-git commit
+git commit -m "release: prepare v1.0.0"
 ----
 
-=== Create tag
+=== Tag and push
 
-An initial release would be tagged as follows:
+Create and push an annotated tag. The `release` workflow will build the
+source tarball (`rnp-vX.Y.Z.tar.gz` plus `rnp-vX.Y.Z.sha256`) and create the
+GitHub release using the matching `CHANGELOG.md` section.
 
 [source,console]
 ----
-git tag -a v1.0.0 -m ''
-----
+git tag -a v1.0.0 -m 'Release v1.0.0'
 
-=== Push branch and tag
-
-[source,console]
-----
 # push the branch
 git push origin release/1.x
 
-# push the tag
+# push the tag (triggers the release workflow)
 git push origin v1.0.0
 ----
 
-=== Edit tagged release description on GitHub
+=== Verify the GitHub release
 
-. Navigate to the link:#https://github.com/rnpgp/rnp/releases[Releases] page;
+Wait for the `release` workflow to finish, then check the release assets:
 
-. Edit the tag that was just pushed;
+[source,console]
+----
+gh run list --workflow=release --branch release/1.x
+gh release view v1.0.0
+----
 
-. Fill the tag's description with data from the corresponding `CHANGELOG`
-  entries of the same tag version;
+The release should contain:
 
-. Publish the release.
-
+* `rnp-v1.0.0.tar.gz`
+* `rnp-v1.0.0.sha256`
+* Release notes extracted from `CHANGELOG.md`
 
 == Creating a new release
 
@@ -86,7 +88,8 @@ Maintaining a release branch involves cherry-picking hotfixes and
 similar commits from the `main` branch, while following the rules for
 Semantic Versioning.
 
-The steps below will show the release of version 1.0.1.
+The steps below show the release of version `1.0.1` on the `release/1.x`
+branch.
 
 === Add desired changes
 
@@ -118,5 +121,30 @@ git cherry release/0.x main | grep '^+ ' | cut -c 3-9 | \
   while read commit; do git cherry-pick $commit; done
 ----
 
-From here, you can follow the steps for an initial release,
+From here, follow the steps for an initial release,
 starting with <<update-changelog-and-version>>.
+
+== Post-release: downstream channels
+
+After the GitHub release is published, update the distribution channels.
+The canonical source for all package recipes is the release tarball built by
+`ci/build_tarball.sh`.
+
+* **Source tarball** -- published automatically by the `release` workflow.
+* **Homebrew** -- open a bump PR, e.g.
+  `brew bump-formula-pr rnp --version=1.0.1`.
+* **Chocolatey** -- update `rnpgp/chocolatey-rnp` (bump the nuspec version
+  and merge; the package is built and pushed to chocolatey.org on `main`).
+* **vcpkg** -- open a version-bump PR in `microsoft/vcpkg` for
+  `ports/rnp`.
+* **Linux distros / Conan** -- coordinate with downstream maintainers.
+
+== Release checklist
+
+* [ ] Version numbers updated in docs.
+* [ ] `CHANGELOG.md` updated for the release.
+* [ ] `version.txt` updated on the release branch.
+* [ ] Annotated tag `vX.Y.Z` pushed.
+* [ ] `release` workflow completed successfully.
+* [ ] GitHub release contains the tarball and SHA256 checksum.
+* [ ] Downstream channels (Homebrew, Chocolatey, vcpkg, ...) updated.

--- a/src/tests/ffi-key.cpp
+++ b/src/tests/ffi-key.cpp
@@ -3236,7 +3236,7 @@ TEST_F(rnp_tests, test_ffi_v6_cert_import)
 
     /* check that fingerprint is correct by checking the fingerprint in the signature (coming
       from the correct input data) vs the computed fingerprint value of the primary key.
-      Issuer fingerprint is the priamry's key fingerprint for the primary and its subkeys */
+      Issuer fingerprint is the primary's key fingerprint for the primary and its subkeys */
     pgp::Fingerprint primary_fp;
     for (rnp::Key key : ffi->pubring->keys) {
         if (key.is_primary()) {


### PR DESCRIPTION
Adds a tag-triggered GitHub Actions workflow that builds the source tarball using the existing "ci/build_tarball.sh" script and creates the GitHub release with the tarball, SHA256 checksum, and the matching CHANGELOG section as release notes.

Also rewrites docs/develop/release-workflow.adoc to describe the streamlined flow and adds a post-release checklist for downstream channels (Homebrew, Chocolatey, vcpkg).

This is a CI/docs change only; no functional library code is changed.