### PR TITLE
ci: add missing Botan 3.6 modules for crypto-refresh/PQC

### DIFF
--- a/ci/botan3-pqc-modules
+++ b/ci/botan3-pqc-modules
@@ -1,8 +1,10 @@
 aead
 aes
+argon2
 auto_rng
 bigint
 blowfish
+blake2
 camellia
 cast128
 cbc
@@ -17,6 +19,7 @@ eax
 ecc_key
 ecdh
 ecdsa
+ed448
 ed25519
 elgamal
 eme_pkcs1
@@ -39,11 +42,14 @@ sha1
 sha2_32
 sha2_64
 sha3
+keccak_perm
+shake_xof
 sm2
 sm3
 sm4
 sp800_56a
 twofish
+x448
 kyber
 dilithium
 sphincsplus_sha2


### PR DESCRIPTION
The oss-fuzz build (google/oss-fuzz#15882) fails because rnp's minimized Botan module list is missing modules required for crypto-refresh:

- `ENABLE_CRYPTO_REFRESH` requires `HKDF`, `ED448` and `X448`.
- `ed448` depends on `shake_xof` (which depends on `keccak_perm`).
- `argon2` depends on `blake2`.

This PR adds all of them to `ci/botan3-pqc-modules`. The list is only consumed by the oss-fuzz build script, so it doesn't affect the rnp CI matrix (which uses full Botan builds).

Once merged, the oss-fuzz PR's build should pass.