### PR TITLE
tests: mask password values in run_proc debug logging

### DIFF
--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -99,13 +99,17 @@ def rnp_file_path(relpath, check = True):
 
     return fpath
 
+def _redact_sensitive_args(cmdline):
+    # Mask password values so they are not logged as clear text
+    return re.sub(r'(--(?:password|passphrase)(?:\s+|=))\S+', r'\1***', cmdline)
+
 def run_proc_windows(proc, params, stdin=None):
     exe = os.path.basename(proc)
     # test special quote cases 
     params = list(map(lambda st: st.replace('"', '\\"'), params))
     # We need to escape empty parameters/ones with spaces with quotes
     params = tuple(map(lambda st: st if (st and not any(x in st for x in [' ','\r','\t'])) else '"%s"' % st, [exe] + params))
-    logging.debug((proc + ' ' + ' '.join(params)).strip())
+    logging.debug(_redact_sensitive_args((proc + ' ' + ' '.join(params)).strip()))
     logging.debug('Working directory: ' + os.getcwd())
     sys.stdout.flush()
 
@@ -201,7 +205,7 @@ def run_proc(proc, params, stdin=None):
     if is_windows():
         return run_proc_windows(proc, params, stdin)
     paramline = u' '.join(map(_decode, params))
-    logging.debug((proc + ' ' + paramline).strip())
+    logging.debug(_redact_sensitive_args((proc + ' ' + paramline).strip()))
     param_bytes = list(map(lambda x: x.encode(CONSOLE_ENCODING), params))
     process = Popen([proc] + param_bytes, stdout=PIPE, stderr=PIPE,
                     stdin=PIPE if stdin else None, close_fds=False,

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -99,9 +99,28 @@ def rnp_file_path(relpath, check = True):
 
     return fpath
 
-def _redact_sensitive_args(cmdline):
-    # Mask password values so they are not logged as clear text
-    return re.sub(r'(--(?:password|passphrase)(?:\s+|=))\S+', r'\1***', cmdline)
+def _redact_sensitive_args(params):
+    # Return a copy of params with password values replaced by '***', so the
+    # sensitive values never enter the logged command line. Handles both
+    # '--password X' and '--password=X' forms (str and bytes elements).
+    redacted = []
+    hide_next = False
+    for param in params:
+        is_bytes = isinstance(param, bytes)
+        marker = b'***' if is_bytes else '***'
+        if hide_next:
+            redacted.append(marker)
+            hide_next = False
+            continue
+        opts = (b'--password', b'--passphrase') if is_bytes else ('--password', '--passphrase')
+        hide_next = param in opts
+        for opt in opts:
+            prefix = opt + b'=' if is_bytes else opt + '='
+            if param.startswith(prefix):
+                param = prefix + marker
+                break
+        redacted.append(param)
+    return redacted
 
 def run_proc_windows(proc, params, stdin=None):
     exe = os.path.basename(proc)
@@ -109,7 +128,7 @@ def run_proc_windows(proc, params, stdin=None):
     params = list(map(lambda st: st.replace('"', '\\"'), params))
     # We need to escape empty parameters/ones with spaces with quotes
     params = tuple(map(lambda st: st if (st and not any(x in st for x in [' ','\r','\t'])) else '"%s"' % st, [exe] + params))
-    logging.debug(_redact_sensitive_args((proc + ' ' + ' '.join(params)).strip()))
+    logging.debug((proc + ' ' + ' '.join(_redact_sensitive_args(params))).strip())
     logging.debug('Working directory: ' + os.getcwd())
     sys.stdout.flush()
 
@@ -204,8 +223,8 @@ def run_proc(proc, params, stdin=None):
     # On Windows we need to use spawnv() for handle inheritance in pswd_pipe()
     if is_windows():
         return run_proc_windows(proc, params, stdin)
-    paramline = u' '.join(map(_decode, params))
-    logging.debug(_redact_sensitive_args((proc + ' ' + paramline).strip()))
+    paramline = u' '.join(map(_decode, _redact_sensitive_args(params)))
+    logging.debug((proc + ' ' + paramline).strip())
     param_bytes = list(map(lambda x: x.encode(CONSOLE_ENCODING), params))
     process = Popen([proc] + param_bytes, stdout=PIPE, stderr=PIPE,
                     stdin=PIPE if stdin else None, close_fds=False,

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -122,6 +122,37 @@ def _redact_sensitive_args(params):
         redacted.append(param)
     return redacted
 
+def _extract_password_values(params):
+    # Collect password/passphrase values from params so they can be redacted
+    # from process output before logging. Returns a list of str values.
+    passwords = []
+    get_next = False
+    for param in params:
+        if isinstance(param, bytes):
+            param = param.decode('utf-8', errors='replace')
+        if get_next:
+            passwords.append(param)
+            get_next = False
+            continue
+        for opt in ('--password', '--passphrase'):
+            prefix = opt + '='
+            if param.startswith(prefix):
+                passwords.append(param[len(prefix):])
+                break
+        else:
+            if param in ('--password', '--passphrase'):
+                get_next = True
+    return passwords
+
+def _redact_output(text, params):
+    # Replace known password values in process output before logging.
+    if not text:
+        return text
+    for pw in _extract_password_values(params):
+        if pw and len(pw) > 0:
+            text = text.replace(pw, '***')
+    return text
+
 def run_proc_windows(proc, params, stdin=None):
     exe = os.path.basename(proc)
     # Redact on the raw params so values are masked before the Windows quoting
@@ -206,10 +237,10 @@ def run_proc_windows(proc, params, stdin=None):
     os.unlink(stderr_path)
     if stdin: 
         os.unlink(stdin_path)
-    if passfo: 
+    if passfo:
         os.unlink(pass_path)
-    logging.debug(err.strip())
-    logging.debug(out.strip())
+    logging.debug(_redact_output(err.strip(), params))
+    logging.debug(_redact_output(out.strip(), params))
     return (retcode, out, err)
 
 if sys.version_info >= (3,):
@@ -235,8 +266,8 @@ def run_proc(proc, params, stdin=None):
                     universal_newlines=True)
     output, errout = process.communicate(stdin)
     retcode = process.poll()
-    logging.debug(errout.strip())
-    logging.debug(output.strip())
+    logging.debug(_redact_output(errout.strip(), params))
+    logging.debug(_redact_output(output.strip(), params))
 
     return (retcode, output, errout)
 

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -124,11 +124,15 @@ def _redact_sensitive_args(params):
 
 def run_proc_windows(proc, params, stdin=None):
     exe = os.path.basename(proc)
-    # test special quote cases 
-    params = list(map(lambda st: st.replace('"', '\\"'), params))
-    # We need to escape empty parameters/ones with spaces with quotes
-    params = tuple(map(lambda st: st if (st and not any(x in st for x in [' ','\r','\t'])) else '"%s"' % st, [exe] + params))
-    logging.debug((proc + ' ' + ' '.join(_redact_sensitive_args(params))).strip())
+    # Redact on the raw params so values are masked before the Windows quoting
+    # below wraps whitespace-containing args (otherwise '"--password=x y"' leaks).
+    redacted = _redact_sensitive_args(list(params))
+    def _win_quote(items):
+        items = list(map(lambda st: st.replace('"', '\\"'), items))
+        # escape empty parameters/ones with spaces with quotes
+        return tuple(map(lambda st: st if (st and not any(x in st for x in [' ','\r','\t'])) else '"%s"' % st, items))
+    logging.debug((proc + ' ' + ' '.join(_win_quote([exe] + redacted))).strip())
+    params = _win_quote([exe] + list(params))
     logging.debug('Working directory: ' + os.getcwd())
     sys.stdout.flush()
 


### PR DESCRIPTION
## Summary

Fixes the open **error-level** CodeQL alert (`py/clear-text-logging-sensitive-data`, alert #454): `run_proc()`/`run_proc_windows()` in src/tests/cli_common.py log the full command line at debug level, which includes `--password` values used throughout the CLI tests.

Adds a small `_redact_sensitive_args()` helper masking `--password`/`--passphrase` values (both `--password X` and `--password=X` forms) in the logged line only — process execution is unchanged.

## Test plan

- Helper verified against separate/inline/non-matching cases (incl. `--passwords-plaintext` and `--pass-fd`, which must NOT be redacted)
- `python3 -m py_compile` clean; full CLI suite runs unchanged in CI (logging-only change)