### PR TITLE
tests: split output handles in test_ffi_export_revocation (Coverity CID 1428747)

### DIFF
--- a/src/tests/ffi-key-sig.cpp
+++ b/src/tests/ffi-key-sig.cpp
@@ -491,31 +491,32 @@ TEST_F(rnp_tests, test_ffi_export_revocation)
 
     rnp_key_handle_t key_handle = NULL;
     assert_rnp_success(rnp_locate_key(ffi, "userid", "Alice <alice@rnp>", &key_handle));
-    rnp_output_t output = NULL;
-    assert_rnp_success(rnp_output_to_null(&output));
+    /* null-sink output for failure-path tests */
+    rnp_output_t null_output = NULL;
+    assert_rnp_success(rnp_output_to_null(&null_output));
     /* check for failure with wrong parameters */
     assert_rnp_failure(rnp_key_export_revocation(
-      NULL, output, 0, "SHA256", "superseded", "test key revocation"));
+      NULL, null_output, 0, "SHA256", "superseded", "test key revocation"));
     assert_rnp_failure(rnp_key_export_revocation(key_handle, NULL, 0, "SHA256", NULL, NULL));
     assert_rnp_failure(
-      rnp_key_export_revocation(key_handle, output, 0x17, "SHA256", NULL, NULL));
+      rnp_key_export_revocation(key_handle, null_output, 0x17, "SHA256", NULL, NULL));
     assert_rnp_failure(
-      rnp_key_export_revocation(key_handle, output, 0, "Wrong hash", NULL, NULL));
-    assert_rnp_failure(
-      rnp_key_export_revocation(key_handle, output, 0, "SHA256", "Wrong reason code", NULL));
+      rnp_key_export_revocation(key_handle, null_output, 0, "Wrong hash", NULL, NULL));
+    assert_rnp_failure(rnp_key_export_revocation(
+      key_handle, null_output, 0, "SHA256", "Wrong reason code", NULL));
     assert_rnp_success(rnp_key_handle_destroy(key_handle));
     /* check for failure with subkey */
     assert_true(import_sec_keys(ffi, "data/test_key_validity/alice-sub-sec.pgp"));
     assert_rnp_success(rnp_locate_key(ffi, "keyid", "DD23CEB7FEBEFF17", &key_handle));
     assert_rnp_success(rnp_key_unlock(key_handle, "password"));
     assert_rnp_failure(rnp_key_export_revocation(
-      key_handle, output, 0, "SHA256", "superseded", "test key revocation"));
+      key_handle, null_output, 0, "SHA256", "superseded", "test key revocation"));
     assert_rnp_success(rnp_key_handle_destroy(key_handle));
     /* try to export revocation having public key only */
     assert_rnp_success(rnp_unload_keys(ffi, RNP_KEY_UNLOAD_SECRET));
     assert_rnp_success(rnp_locate_key(ffi, "userid", "Alice <alice@rnp>", &key_handle));
     assert_rnp_failure(rnp_key_export_revocation(
-      key_handle, output, 0, "SHA256", "superseded", "test key revocation"));
+      key_handle, null_output, 0, "SHA256", "superseded", "test key revocation"));
     assert_rnp_success(rnp_key_handle_destroy(key_handle));
     /* load secret key and export revocation - should succeed with correct password */
     assert_true(import_sec_keys(ffi, "data/test_key_validity/alice-sec.asc"));
@@ -524,26 +525,29 @@ TEST_F(rnp_tests, test_ffi_export_revocation)
     assert_rnp_success(
       rnp_ffi_set_pass_provider(ffi, ffi_string_password_provider, (void *) "wrong"));
     assert_rnp_failure(rnp_key_export_revocation(
-      key_handle, output, 0, "SHA256", "superseded", "test key revocation"));
+      key_handle, null_output, 0, "SHA256", "superseded", "test key revocation"));
     assert_rnp_failure(rnp_key_export_revocation(key_handle,
-                                                 output,
+                                                 null_output,
                                                  RNP_KEY_EXPORT_ARMORED,
                                                  "SHA256",
                                                  "superseded",
                                                  "test key revocation"));
 
-    /* unlocked key - must succeed */
+    /* unlocked key - must succeed (output discarded to null sink) */
     assert_rnp_success(rnp_key_unlock(key_handle, "password"));
-    assert_rnp_success(rnp_key_export_revocation(key_handle, output, 0, "SHA256", NULL, NULL));
-    assert_rnp_success(rnp_output_destroy(output));
-    assert_rnp_success(rnp_output_to_path(&output, "alice-revocation.pgp"));
+    assert_rnp_success(
+      rnp_key_export_revocation(key_handle, null_output, 0, "SHA256", NULL, NULL));
+    assert_rnp_success(rnp_output_destroy(null_output));
+    /* file output for the success-path test that needs the produced artifact */
+    rnp_output_t file_output = NULL;
+    assert_rnp_success(rnp_output_to_path(&file_output, "alice-revocation.pgp"));
     /* correct password provider - must succeed */
     assert_rnp_success(rnp_key_lock(key_handle));
     assert_rnp_success(
       rnp_ffi_set_pass_provider(ffi, ffi_string_password_provider, (void *) "password"));
     assert_rnp_success(rnp_key_export_revocation(
-      key_handle, output, 0, "SHA256", "superseded", "test key revocation"));
-    assert_rnp_success(rnp_output_destroy(output));
+      key_handle, file_output, 0, "SHA256", "superseded", "test key revocation"));
+    assert_rnp_success(rnp_output_destroy(file_output));
 
     /* check that the output is binary or armored as requested */
     std::string data = file_to_str("alice-revocation.pgp");
@@ -600,15 +604,16 @@ TEST_F(rnp_tests, test_ffi_export_revocation)
     assert_rnp_success(rnp_locate_key(ffi, "userid", "Alice <alice@rnp>", &key_handle));
 
     // export revocation
-    assert_rnp_success(rnp_output_to_path(&output, "alice-revocation.asc"));
+    rnp_output_t armored_output = NULL;
+    assert_rnp_success(rnp_output_to_path(&armored_output, "alice-revocation.asc"));
     assert_rnp_success(rnp_key_unlock(key_handle, "password"));
     assert_rnp_success(rnp_key_export_revocation(key_handle,
-                                                 output,
+                                                 armored_output,
                                                  RNP_KEY_EXPORT_ARMORED,
                                                  "SHA256",
                                                  "superseded",
                                                  "test key revocation"));
-    assert_rnp_success(rnp_output_destroy(output));
+    assert_rnp_success(rnp_output_destroy(armored_output));
     assert_rnp_success(rnp_key_handle_destroy(key_handle));
 
     data = file_to_str("alice-revocation.asc");


### PR DESCRIPTION
## Summary

- Addresses [Coverity CID 1428747](https://github.com/rnpgp/rnp/issues/1246) — a USE_AFTER_FREE finding in `test_ffi_export_revocation`.
- Splits the single `output` variable into three purpose-specific output handles (`null_output`, `file_output`, `armored_output`), each with a single lifetime and a single destroy call.
- No behaviour change. Test passes (522 ms).

## Why this is a real fix even though the existing code was correct

Coverity flagged the destroy-then-reuse pattern:

```
rnp_key_export_revocation(key_handle, output, ...);   // use 1
rnp_output_destroy(output);                            // free
rnp_output_to_path(&output, "alice-revocation.pgp");  // re-initialise
rnp_key_export_revocation(key_handle, output, ...);   // use 2
```

The re-initialisation on the third line makes the second use safe. `assert_rnp_success` wraps `ASSERT_EQ(..., RNP_SUCCESS)` and aborts the test function on failure, so the re-init cannot be skipped. Coverity cannot model the gtest macro and conservatively flagged the path.

The restructure removes the destroy-reuse pattern entirely. Each output handle has one purpose, one lifetime, one destroy. The data flow now matches the code structure, which helps both human readers and future static-analysis tools.

## Systemic note

Per @ni4's comment on #1246, similar patterns exist in other tests. This PR fixes this one site; addressing the class project-wide is best done by either:
- A follow-up sweep that applies the same rename pattern to other flagged tests, OR
- A Coverity model file documenting that `ASSERT_EQ` / `EXPECT_EQ` abort the test function on failure (so future test-only findings of this class go away).

The Coverity workflow already builds with `-DBUILD_TESTING=Off`, so test code is not compiled in the production scan; the open finding is stale in the Coverity dashboard and should be triaged (dismissed) there once this PR merges.

## Test plan

- [x] `rnp_tests.test_ffi_export_revocation` passes locally (522 ms, OpenSSL backend).
- [ ] CI: full rnp_tests run green.
- [ ] Coverity: stale finding dismissed on the dashboard (out-of-band, by maintainer with dashboard access).

Closes #1246.
