### PR TITLE
docs: document the --verify-cat CLI command

### DIFF
--- a/docs/cli-usage.adoc
+++ b/docs/cli-usage.adoc
@@ -165,6 +165,40 @@ Creates `${filename}`, the decrypted form of the `${filename}.gpg`
 encrypted OpenPGP message.
 
 
+== Verify
+
+OpenPGP messages can carry signatures in several arrangements, and `rnp`
+provides three closely-related commands that differ in what they output:
+
+[cols="1,4"]
+|===
+| Command | Behaviour
+
+| `rnp --verify`
+| Verifies signatures and prints the verification result to stderr. The
+message contents are *not* written out. Use this when you only want to
+confirm authenticity.
+
+| `rnp --verify-cat`
+| Verifies signatures *and* writes the recovered message contents to the
+output (file or stdout). Use this for `cleartext`-signed messages and
+inline-signed messages where you want both the verification result and
+the payload. For detached signatures, supply the message via `--source`.
+
+| `rnp --decrypt`
+| Like `--verify-cat`, but additionally handles encrypted messages
+(`--verify-cat` does not attempt decryption).
+|===
+
+For a detached signature `${filename}.sig`, the message body must be
+supplied via `--source`:
+
+[source,console]
+----
+rnp --verify-cat --source=${filename} --homedir=${keyringdir} ${filename}.sig
+----
+
+
 == Check version
 
 The output of `rnp --version` contains the `git` hash of the version

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -84,6 +84,8 @@ static const char *usage =
   "  --clearsign             Cleartext-sign data.\n"
   "  -d, --decrypt           Decrypt and output data, verifying signatures.\n"
   "  -v, --verify            Verify signatures, without outputting data.\n"
+  "    --verify-cat          Verify signatures, and output the data (like --decrypt,\n"
+  "                          but for signed-only or detached-signature messages).\n"
   "    --source              Specify source for the detached signature.\n"
   "  --dearmor               Strip ASCII armor from the data, outputting binary.\n"
   "  --enarmor               Add ASCII armor to the data.\n"


### PR DESCRIPTION
## Summary

- Adds `--verify-cat` to the `rnp --help` usage string with a one-line description.
- Adds a dedicated `Verify` section to `docs/cli-usage.adoc` contrasting `--verify`, `--verify-cat`, and `--decrypt`.

`--verify-cat` was functional but undocumented. Users discovering it via shell completion or source had no way to know what it does.

## Behaviour documented

| Command | Behaviour |
|---|---|
| `rnp --verify` | Verify signatures; do not output message contents. |
| `rnp --verify-cat` | Verify signatures AND output message contents. For detached sigs, supply body via `--source`. |
| `rnp --decrypt` | Like `--verify-cat` but also handles encrypted messages. |

## Test plan

- [x] `rnp --help` now lists `--verify-cat`.
- [x] `docs/cli-usage.adoc` renders (asciidoctor) without warnings.
- [ ] CI: lint job (asciidoctor / typos) green.

Closes #2008.
