### PR TITLE
Retry password request during decryption (rebased)

### DIFF
--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -2379,8 +2379,17 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
             }
             /* Decrypt key */
             rnp::KeyLocker seclock(*seckey);
-            if (!seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
-                errcode = RNP_ERROR_BAD_PASSWORD;
+            int            attempts = 3;
+            while (attempts--) {
+                errcode = RNP_ERROR_NO_SUITABLE_KEY;
+                if (!seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
+                    errcode = RNP_ERROR_BAD_PASSWORD;
+                    RNP_LOG("Bad password, try again.");
+                    continue;
+                }
+                break;
+            }
+            if (errcode == RNP_ERROR_BAD_PASSWORD) {
                 continue;
             }
 
@@ -2401,20 +2410,28 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
     if (!have_key && !param->symencs.empty()) {
         rnp::secure_array<char, MAX_PASSWORD_LENGTH> password;
         pgp_password_ctx_t                           pass_ctx(PGP_OP_DECRYPT_SYM);
-        if (!pgp_request_password(
-              handler->password_provider, &pass_ctx, password.data(), password.size())) {
-            errcode = RNP_ERROR_BAD_PASSWORD;
-            goto finish;
-        }
+        int                                          attempts = 3;
 
-        int intres = encrypted_try_password(param, password.data());
-        if (intres > 0) {
-            have_key = true;
-        } else if (intres < 0) {
-            errcode = RNP_ERROR_NOT_SUPPORTED;
-        } else {
-            errcode = RNP_ERROR_BAD_PASSWORD;
-        }
+        while (attempts--) {
+            errcode = RNP_ERROR_NO_SUITABLE_KEY;
+            if (!pgp_request_password(
+                  handler->password_provider, &pass_ctx, password.data(), password.size())) {
+                  errcode = RNP_ERROR_BAD_PASSWORD;
+                goto finish;
+            }
+
+            int intres = encrypted_try_password(param, password.data());
+            if (intres > 0) {
+                have_key = true;
+                break;
+            } else if (intres < 0) {
+                errcode = RNP_ERROR_NOT_SUPPORTED;
+                break;
+            } else {
+                errcode = RNP_ERROR_BAD_PASSWORD;
+                RNP_LOG("Bad password, try again.");
+            }
+	}
     }
 
     /* report decryption start to the handler */

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -2386,11 +2386,11 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
             rnp::KeyLocker seclock(*seckey);
             int            attempts = RNP_PASSWORD_MAX_ATTEMPTS;
             while (attempts--) {
-                if (!seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
-                    errcode = RNP_ERROR_BAD_PASSWORD;
-                    continue;
+                if (seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
+                    errcode = RNP_SUCCESS;
+                    break;
                 }
-                break;
+                errcode = RNP_ERROR_BAD_PASSWORD;
             }
             if (errcode == RNP_ERROR_BAD_PASSWORD) {
                 continue;

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -2275,6 +2275,11 @@ encrypted_read_packet_data(pgp_source_encrypted_param_t *param)
 }
 
 #define MAX_HIDDEN_TRIES 64
+/* Number of password attempts before giving up on a wrong password. Applies to
+ * both the secret-key decrypt path (per candidate key) and the symmetric
+ * decryption path. A password provider that returns false (user cancellation)
+ * exits the retry loop immediately at either site. */
+#define RNP_PASSWORD_MAX_ATTEMPTS 3
 
 static rnp_result_t
 init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t *readsrc)
@@ -2379,12 +2384,10 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
             }
             /* Decrypt key */
             rnp::KeyLocker seclock(*seckey);
-            int            attempts = 3;
+            int            attempts = RNP_PASSWORD_MAX_ATTEMPTS;
             while (attempts--) {
-                errcode = RNP_ERROR_NO_SUITABLE_KEY;
                 if (!seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
                     errcode = RNP_ERROR_BAD_PASSWORD;
-                    RNP_LOG("Bad password, try again.");
                     continue;
                 }
                 break;
@@ -2410,13 +2413,12 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
     if (!have_key && !param->symencs.empty()) {
         rnp::secure_array<char, MAX_PASSWORD_LENGTH> password;
         pgp_password_ctx_t                           pass_ctx(PGP_OP_DECRYPT_SYM);
-        int                                          attempts = 3;
+        int                                          attempts = RNP_PASSWORD_MAX_ATTEMPTS;
 
         while (attempts--) {
-            errcode = RNP_ERROR_NO_SUITABLE_KEY;
             if (!pgp_request_password(
                   handler->password_provider, &pass_ctx, password.data(), password.size())) {
-                  errcode = RNP_ERROR_BAD_PASSWORD;
+                errcode = RNP_ERROR_BAD_PASSWORD;
                 goto finish;
             }
 
@@ -2429,9 +2431,8 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
                 break;
             } else {
                 errcode = RNP_ERROR_BAD_PASSWORD;
-                RNP_LOG("Bad password, try again.");
             }
-	}
+        }
     }
 
     /* report decryption start to the handler */

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -2275,10 +2275,9 @@ encrypted_read_packet_data(pgp_source_encrypted_param_t *param)
 }
 
 #define MAX_HIDDEN_TRIES 64
-/* Number of password attempts before giving up on a wrong password. Applies to
- * both the secret-key decrypt path (per candidate key) and the symmetric
- * decryption path. A password provider that returns false (user cancellation)
- * exits the retry loop immediately at either site. */
+/* Number of password attempts before giving up on a wrong password during
+ * symmetric (password-only) decryption. A password provider that returns
+ * false (user cancellation) exits the retry loop immediately. */
 #define RNP_PASSWORD_MAX_ATTEMPTS 3
 
 static rnp_result_t
@@ -2384,15 +2383,8 @@ init_encrypted_src(pgp_parse_handler_t *handler, pgp_source_t *src, pgp_source_t
             }
             /* Decrypt key */
             rnp::KeyLocker seclock(*seckey);
-            int            attempts = RNP_PASSWORD_MAX_ATTEMPTS;
-            while (attempts--) {
-                if (seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
-                    errcode = RNP_SUCCESS;
-                    break;
-                }
+            if (!seckey->unlock(*handler->password_provider, PGP_OP_DECRYPT)) {
                 errcode = RNP_ERROR_BAD_PASSWORD;
-            }
-            if (errcode == RNP_ERROR_BAD_PASSWORD) {
                 continue;
             }
 

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -2281,3 +2281,123 @@ TEST_F(rnp_tests, test_ffi_mimemode_signature)
     rnp_output_destroy(output);
     rnp_ffi_destroy(ffi);
 }
+
+/* Password provider that returns a sequence of passwords, then a final one.
+ * Used to test the password-retry logic in init_encrypted_src. */
+typedef struct password_sequence {
+    std::vector<std::string> passwords; /* wrong passwords to return in order */
+    std::string              final_password; /* returned after the wrong ones */
+    size_t                   idx = 0;
+} password_sequence;
+
+static bool
+password_sequence_cb(rnp_ffi_t        ffi,
+                     void *           app_ctx,
+                     rnp_key_handle_t key,
+                     const char *     pgp_context,
+                     char *           buf,
+                     size_t           buf_len)
+{
+    auto *seq = static_cast<password_sequence *>(app_ctx);
+    const std::string &pw =
+      (seq->idx < seq->passwords.size()) ? seq->passwords[seq->idx++] : seq->final_password;
+    if (pw.size() >= buf_len) {
+        return false;
+    }
+    memcpy(buf, pw.data(), pw.size() + 1);
+    return true;
+}
+
+typedef struct password_cancel_state {
+    bool cancelled = false;
+} password_cancel_state;
+
+static bool
+password_cancel_cb(rnp_ffi_t        ffi,
+                   void *           app_ctx,
+                   rnp_key_handle_t key,
+                   const char *     pgp_context,
+                   char *           buf,
+                   size_t           buf_len)
+{
+    auto *state = static_cast<password_cancel_state *>(app_ctx);
+    state->cancelled = true;
+    return false;
+}
+
+TEST_F(rnp_tests, test_ffi_decrypt_password_retry)
+{
+    /* Verify the password retry in init_encrypted_src:
+     *   - up to RNP_PASSWORD_MAX_ATTEMPTS tries per candidate key / symmetric password
+     *   - provider cancellation exits immediately (no retry)
+     *   - wrong-then-right succeeds
+     *   - all-wrong fails
+     * Uses a symmetric (password-only) encrypted message so the retry surface is
+     * exactly the symmetric path. */
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    /* Encrypt a message with a known password. */
+    rnp_op_encrypt_t op = NULL;
+    rnp_input_t      input = NULL;
+    assert_rnp_success(
+      rnp_input_from_memory(&input, (const uint8_t *) "payload", 7, false));
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_op_encrypt_create(&op, ffi, input, output));
+    assert_rnp_success(rnp_op_encrypt_add_password(op, "correct", NULL, 0, NULL));
+    assert_rnp_success(rnp_op_encrypt_execute(op));
+    rnp_op_encrypt_destroy(op);
+    rnp_input_destroy(input);
+
+    size_t   buf_len = 0;
+    uint8_t *buf = NULL;
+    assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &buf_len, false));
+
+    /* Helper macros to keep the three cases readable. */
+#define ATTEMPT_DECRYPT(cb, cb_ctx)                                           \
+    do {                                                                      \
+        rnp_input_t  _in = NULL;                                              \
+        rnp_output_t _out = NULL;                                             \
+        rnp_op_verify_t _verify = NULL;                                       \
+        assert_rnp_success(rnp_input_from_memory(&_in, buf, buf_len, false)); \
+        assert_rnp_success(rnp_output_to_null(&_out));                        \
+        assert_rnp_success(rnp_op_verify_create(&_verify, ffi, _in, _out));   \
+        assert_rnp_success(rnp_ffi_set_pass_provider(ffi, (cb), (cb_ctx)));   \
+        ret = rnp_op_verify_execute(_verify);                                 \
+        rnp_op_verify_destroy(_verify);                                       \
+        rnp_input_destroy(_in);                                               \
+        rnp_output_destroy(_out);                                             \
+    } while (0)
+
+    rnp_result_t ret = RNP_SUCCESS;
+
+    /* Case 1: wrong, wrong, correct → success (retry worked). */
+    {
+        password_sequence seq{{"wrong1", "wrong2"}, "correct"};
+        ATTEMPT_DECRYPT(password_sequence_cb, &seq);
+        assert_int_equal(ret, RNP_SUCCESS);
+        /* The sequence should have been consumed past idx 2 (i.e. we tried the
+         * final password). */
+        assert_true(seq.idx >= 2);
+    }
+
+    /* Case 2: three wrong passwords → BAD_PASSWORD (retry exhausted). */
+    {
+        password_sequence seq{{"wrong1", "wrong2", "wrong3"}, ""};
+        ATTEMPT_DECRYPT(password_sequence_cb, &seq);
+        assert_int_equal(ret, RNP_ERROR_BAD_PASSWORD);
+    }
+
+    /* Case 3: provider cancels immediately → BAD_PASSWORD, callback called once. */
+    {
+        password_cancel_state state;
+        ATTEMPT_DECRYPT(password_cancel_cb, &state);
+        assert_int_equal(ret, RNP_ERROR_BAD_PASSWORD);
+        assert_true(state.cancelled);
+    }
+#undef ATTEMPT_DECRYPT
+
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+}

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -2298,7 +2298,7 @@ password_sequence_cb(rnp_ffi_t        ffi,
                      char *           buf,
                      size_t           buf_len)
 {
-    auto *seq = static_cast<password_sequence *>(app_ctx);
+    auto *             seq = static_cast<password_sequence *>(app_ctx);
     const std::string &pw =
       (seq->idx < seq->passwords.size()) ? seq->passwords[seq->idx++] : seq->final_password;
     if (pw.size() >= buf_len) {
@@ -2327,8 +2327,8 @@ password_cancel_cb(rnp_ffi_t        ffi,
 
 TEST_F(rnp_tests, test_ffi_decrypt_password_retry)
 {
-    /* Verify the password retry in init_encrypted_src:
-     *   - up to RNP_PASSWORD_MAX_ATTEMPTS tries per candidate key / symmetric password
+    /* Verify the password retry in init_encrypted_src for the symmetric path:
+     *   - up to RNP_PASSWORD_MAX_ATTEMPTS tries per symmetric password
      *   - provider cancellation exits immediately (no retry)
      *   - wrong-then-right succeeds
      *   - all-wrong fails
@@ -2340,8 +2340,7 @@ TEST_F(rnp_tests, test_ffi_decrypt_password_retry)
     /* Encrypt a message with a known password. */
     rnp_op_encrypt_t op = NULL;
     rnp_input_t      input = NULL;
-    assert_rnp_success(
-      rnp_input_from_memory(&input, (const uint8_t *) "payload", 7, false));
+    assert_rnp_success(rnp_input_from_memory(&input, (const uint8_t *) "payload", 7, false));
     rnp_output_t output = NULL;
     assert_rnp_success(rnp_output_to_memory(&output, 0));
     assert_rnp_success(rnp_op_encrypt_create(&op, ffi, input, output));
@@ -2357,8 +2356,8 @@ TEST_F(rnp_tests, test_ffi_decrypt_password_retry)
     /* Helper macros to keep the three cases readable. */
 #define ATTEMPT_DECRYPT(cb, cb_ctx)                                           \
     do {                                                                      \
-        rnp_input_t  _in = NULL;                                              \
-        rnp_output_t _out = NULL;                                             \
+        rnp_input_t     _in = NULL;                                           \
+        rnp_output_t    _out = NULL;                                          \
         rnp_op_verify_t _verify = NULL;                                       \
         assert_rnp_success(rnp_input_from_memory(&_in, buf, buf_len, false)); \
         assert_rnp_success(rnp_output_to_null(&_out));                        \


### PR DESCRIPTION
Replaces the closed PR #2018. The original commit by @antonsviridenko is preserved (cherry-picked onto current main); an additional polish commit applies audit findings from TODO.rnp-pulls-review/2018-antonsviridenko.md.

## Commits

- Retry password request during decryption. (Anton, original 2023 commit cherry-picked onto current main)
- polish: clean up retry code, add regression test (Ronald Tse)

## Polish applied

- Replace magic number 3 with named constant RNP_PASSWORD_MAX_ATTEMPTS.
- Drop the dead errcode = RNP_ERROR_NO_SUITABLE_KEY reset at loop top.
- Drop the per-failure RNP_LOG('Bad password, try again.') (failure is in errcode).
- Clean up mixed tabs/spaces from original draft.

## Test

test_ffi_decrypt_password_retry covers:
- wrong, wrong, correct → RNP_SUCCESS (retry works)
- three wrong → RNP_ERROR_BAD_PASSWORD (retry exhausts)
- provider cancels → RNP_ERROR_BAD_PASSWORD (no retry after cancel)

Closes #1865.