### PR TITLE
ci: expand platform coverage (ARM Linux, Alpine, Win2025/ARM, macOS 26)

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of rnp
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+name: alpine
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/alpine.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+# Alpine uses musl libc, not glibc. Some rnp code paths (notably the
+# error-number string tables, passwd-related paths, and the more pedantic
+# warnings-as-errors compilers) behave differently. We test the current
+# Alpine stable (3.21) and edge in parallel.
+jobs:
+  tests:
+    name: alpine:${{ matrix.alpine }} [CC ${{ matrix.env.CC }}; ${{ matrix.backend.name }}]
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:${{ matrix.alpine }}
+    strategy:
+      fail-fast: false
+      matrix:
+        alpine: [ '3.21', 'edge' ]
+        backend:
+          - { name: 'botan',   package: 'botan-dev' }
+          - { name: 'openssl', package: 'openssl-dev' }
+        env:
+          - { CC: gcc,   CXX: g++ }
+          - { CC: clang, CXX: clang++ }
+        exclude:
+          # Clang on Alpine edge occasionally trails behind gcc; keep one
+          # clang leg on stable only to surface musl+clang-specific issues
+          # without burning runner time on the moving target.
+          - alpine: 'edge'
+            env: { CC: clang, CXX: clang++ }
+
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    env: ${{ matrix.env }}
+    timeout-minutes: 50
+    steps:
+      - name: Install Alpine dependencies
+        run: |
+          apk add --no-cache \
+              build-base cmake clang ninja \
+              git bash perl \
+              zlib-dev bzip2-dev json-c-dev \
+              ${{ matrix.backend.package }} \
+              gpg gpgme-dev
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Configure
+        run: |
+          echo CORES="$(nproc --all)" >> $GITHUB_ENV
+          cmake -B build   -DBUILD_SHARED_LIBS=ON                \
+                           -DCRYPTO_BACKEND=${{ matrix.backend.name }} \
+                           -DDOWNLOAD_GTEST=ON                            \
+                           -DCMAKE_BUILD_TYPE=Release  .
+
+      - name: Build
+        run: cmake --build build --parallel ${{ env.CORES }}
+
+      - name: Test
+        run: |
+          mkdir -p "build/Testing/Temporary"
+          cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
+          export PATH="$PWD/build/src/lib:$PATH"
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -61,7 +61,7 @@ concurrency:
 # Alpine uses musl libc, not glibc. Some rnp code paths (notably the
 # error-number string tables, passwd-related paths, and the more pedantic
 # warnings-as-errors compilers) behave differently. We test the current
-# Alpine stable (3.21) and edge in parallel.
+# Alpine stable (3.23) and edge in parallel.
 jobs:
   tests:
     name: alpine:${{ matrix.alpine }} [CC ${{ matrix.env.CC }}; ${{ matrix.backend.name }}]
@@ -71,9 +71,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alpine: [ '3.21', 'edge' ]
+        alpine: [ '3.23', 'edge' ]
         backend:
-          - { name: 'botan',   package: 'botan-dev' }
+          - { name: 'botan',   package: 'botan3-dev' }
           - { name: 'openssl', package: 'openssl-dev' }
         env:
           - { CC: gcc,   CXX: g++ }
@@ -93,7 +93,7 @@ jobs:
         run: |
           apk add --no-cache \
               build-base cmake clang ninja \
-              git bash perl \
+              git bash perl python3 \
               zlib-dev bzip2-dev json-c-dev \
               ${{ matrix.backend.package }} \
               gpg gpgme-dev

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -136,7 +136,7 @@ jobs:
 # Alpine uses musl libc, not glibc. Some rnp code paths (notably the
 # error-number string tables, passwd-related paths, and the more pedantic
 # warnings-as-errors compilers) behave differently. We test the current
-# Alpine stable (3.21) and edge in parallel.
+# Alpine stable (3.23) and edge in parallel.
 jobs:
   tests:
     name: alpine:${{ matrix.alpine }} [CC ${{ matrix.env.CC }}; ${{ matrix.backend.name }}]
@@ -146,9 +146,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alpine: [ '3.21', 'edge' ]
+        alpine: [ '3.23', 'edge' ]
         backend:
-          - { name: 'botan',   package: 'botan-dev' }
+          - { name: 'botan',   package: 'botan3-dev' }
           - { name: 'openssl', package: 'openssl-dev' }
         env:
           - { CC: gcc,   CXX: g++ }
@@ -168,7 +168,7 @@ jobs:
         run: |
           apk add --no-cache \
               build-base cmake clang ninja \
-              git bash perl \
+              git bash perl python3 \
               zlib-dev bzip2-dev json-c-dev \
               ${{ matrix.backend.package }} \
               gpg gpgme-dev

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -117,7 +117,9 @@ jobs:
 
       - name: Test
         run: |
+          # Permission/access tests must run as a non-root user; the container defaults to root.
+          adduser -D -h /home/rnp -s /bin/sh rnp 2>/dev/null || true
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
-          export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          chown -R rnp "$GITHUB_WORKSPACE"
+          su rnp -s /bin/sh -c "cd \"$GITHUB_WORKSPACE\" && PATH=\"$PWD/build/src/lib:\$PATH\" ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -18,6 +18,7 @@
 # BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 # SUBSTITUTE GOODS OR SERVICES, LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
@@ -50,6 +51,19 @@ on:
       - 'src/lib/CMakeLists.txt'
       - 'src/libsexpp/CMakeLists.txt'
       - '.github/workflows/alpine.yml'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/alpine.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
@@ -119,6 +133,59 @@ jobs:
                 -DCMAKE_CXX_FLAGS_RELEASE="-UNDEBUG"               \
                 -DCMAKE_C_FLAGS_RELEASE="-UNDEBUG"                 \
                 .
+# Alpine uses musl libc, not glibc. Some rnp code paths (notably the
+# error-number string tables, passwd-related paths, and the more pedantic
+# warnings-as-errors compilers) behave differently. We test the current
+# Alpine stable (3.21) and edge in parallel.
+jobs:
+  tests:
+    name: alpine:${{ matrix.alpine }} [CC ${{ matrix.env.CC }}; ${{ matrix.backend.name }}]
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:${{ matrix.alpine }}
+    strategy:
+      fail-fast: false
+      matrix:
+        alpine: [ '3.21', 'edge' ]
+        backend:
+          - { name: 'botan',   package: 'botan-dev' }
+          - { name: 'openssl', package: 'openssl-dev' }
+        env:
+          - { CC: gcc,   CXX: g++ }
+          - { CC: clang, CXX: clang++ }
+        exclude:
+          # Clang on Alpine edge occasionally trails behind gcc; keep one
+          # clang leg on stable only to surface musl+clang-specific issues
+          # without burning runner time on the moving target.
+          - alpine: 'edge'
+            env: { CC: clang, CXX: clang++ }
+
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    env: ${{ matrix.env }}
+    timeout-minutes: 50
+    steps:
+      - name: Install Alpine dependencies
+        run: |
+          apk add --no-cache \
+              build-base cmake clang ninja \
+              git bash perl \
+              zlib-dev bzip2-dev json-c-dev \
+              ${{ matrix.backend.package }} \
+              gpg gpgme-dev
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Configure
+        run: |
+          echo CORES="$(nproc --all)" >> $GITHUB_ENV
+          cmake -B build   -DBUILD_SHARED_LIBS=ON                \
+                           -DCRYPTO_BACKEND=${{ matrix.backend.name }} \
+                           -DDOWNLOAD_GTEST=ON                            \
+                           -DCMAKE_BUILD_TYPE=Release  .
 
       - name: Build
         run: cmake --build build --parallel ${{ env.CORES }}
@@ -131,3 +198,6 @@ jobs:
           chown -R rnpuser:rnpuser $PWD
           # BusyBox su requires explicit shell even when the user has one set.
           su -s /bin/sh rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
+          export PATH="$PWD/build/src/lib:$PATH"
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -192,6 +192,8 @@ jobs:
 
       - name: Test
         run: |
+          # Permission/access tests must run as a non-root user; the container defaults to root.
+          adduser -D -h /home/rnp -s /bin/sh rnp 2>/dev/null || true
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary" || true
           export PATH="$PWD/build/src/lib:$PATH"
@@ -199,5 +201,5 @@ jobs:
           # BusyBox su requires explicit shell even when the user has one set.
           su -s /bin/sh rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
-          export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          chown -R rnp "$GITHUB_WORKSPACE"
+          su rnp -s /bin/sh -c "cd \"$GITHUB_WORKSPACE\" && PATH=\"$PWD/build/src/lib:\$PATH\" ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
       - uses: DoozyX/clang-format-lint-action@v0.20
         with:
-          clangFormatVersion: 11.0.0
+          clangFormatVersion: 11.0.1
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
       - uses: DoozyX/clang-format-lint-action@v0.18.2
         with:
-          clangFormatVersion: 11.0.0
+          clangFormatVersion: 11.0.1
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
       - uses: DoozyX/clang-format-lint-action@v0.20
         with:
-          clangFormatVersion: 11.0.1
+          clangFormatVersion: 11.1.0
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -74,10 +74,13 @@ jobs:
         backend: [ 'botan' ]
         shared_libs: [ 'on' ]
         include:
-          - { os: 'macos-14', backend: 'openssl@1.1', shared_libs: 'on' }
-          - { os: 'macos-15', backend: 'openssl@3', shared_libs: 'on' }
-          - { os: 'macos-15-intel', backend: 'botan', shared_libs: 'off' }
-          - { os: 'macos-26', backend: 'botan3', shared_libs: 'on' }          
+          # macos-14 (deprecated) and openssl@1.1 (EOL since 2024) removed together.
+          # The arm64 Intel-mac audience is shrinking but still present in the
+          # enterprise installed base; keep one Intel leg on the current macOS.
+          - { os: 'macos-15',       backend: 'openssl@3', shared_libs: 'on' }
+          - { os: 'macos-15-intel', backend: 'botan',     shared_libs: 'off' }
+          - { os: 'macos-26',       backend: 'botan3',    shared_libs: 'on' }
+          - { os: 'macos-26-intel', backend: 'botan',     shared_libs: 'on' }
 
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 250
@@ -87,15 +90,6 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
-
-      - name: Configure openssl 1.1 backend
-        if: matrix.backend == 'openssl@1.1'
-        run: |
-          echo "brew \"openssl@1.1\"" >> Brewfile
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
-          echo "CRYPTO_BACKEND=openssl" >> $GITHUB_ENV
-          # Harsh workaround against CLang adding /usr/local/include path, where OpenSSL 3.0 headers are
-          rm -r /usr/local/include/openssl || true
 
       - name: Configure openssl 3 backend
         if: matrix.backend == 'openssl@3'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         shared_libs: [ 'on' ]
         backend:
           - { name: 'botan',    package: 'libbotan-2-dev' }
@@ -74,15 +74,30 @@ jobs:
           - { CC: gcc,    CXX: g++     }
           - { CC: clang,  CXX: clang++ }
         include:
-        # Since ubuntu-20.04 runner is deprecated we do not test OpenSSL 1.1.1 here.
+        # OpenSSL 1.1.1 coverage: ubuntu runners no longer ship openssl 1.1.x
+        # in apt (ubuntu-22.04+ moved to 3.x). OpenSSL 1.1.1 is exercised via
+        # containers in centos-and-fedora.yml (RHEL 8 ubi) and debian.yml
+        # (Debian 11), both of which ship openssl 1.1 in their distro repos.
           - os: ubuntu-22.04
             shared_libs: 'on'
             backend: { name: 'openssl',  package: 'libssl-dev' }
             env: { CC: gcc, CXX: g++ }
 
-          - os: ubuntu-latest
+          # Static-link sanity check
+          - os: ubuntu-24.04
             shared_libs: 'off'
             backend: { name: 'botan',    package: 'libbotan-2-dev' }
+            env: { CC: gcc, CXX: g++ }
+
+          # ARM64 Linux (native runner; Thunderbird-on-ARM-Linux is a growing audience)
+          - os: ubuntu-24.04-arm
+            shared_libs: 'on'
+            backend: { name: 'botan',    package: 'libbotan-2-dev' }
+            env: { CC: gcc, CXX: g++ }
+
+          - os: ubuntu-24.04-arm
+            shared_libs: 'on'
+            backend: { name: 'openssl',  package: 'libssl-dev' }
             env: { CC: gcc, CXX: g++ }
 
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -74,13 +74,20 @@ jobs:
           - { CC: gcc,    CXX: g++     }
           - { CC: clang,  CXX: clang++ }
         include:
+        # Ubuntu 22.04 LTS (jammy) — supported until 2027 (ESM 2032).
+        # Ships Botan 2.19.1 (older 2.x than noble's 2.19.3) and OpenSSL 3.0.
         # OpenSSL 1.1.1 coverage: ubuntu runners no longer ship openssl 1.1.x
         # in apt (ubuntu-22.04+ moved to 3.x). OpenSSL 1.1.1 is exercised via
         # containers in centos-and-fedora.yml (RHEL 8 ubi) and debian.yml
         # (Debian 11), both of which ship openssl 1.1 in their distro repos.
           - os: ubuntu-22.04
             shared_libs: 'on'
-            backend: { name: 'openssl',  package: 'libssl-dev' }
+            backend: { name: 'botan',   package: 'libbotan-2-dev' }
+            env: { CC: gcc, CXX: g++ }
+
+          - os: ubuntu-22.04
+            shared_libs: 'on'
+            backend: { name: 'openssl', package: 'libssl-dev' }
             env: { CC: gcc, CXX: g++ }
 
           # Static-link sanity check

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -65,12 +65,13 @@ env:
 
 jobs:
   build_and_test:
-    name: Windows-2022 [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
-    runs-on: windows-2022
+    name: ${{ matrix.os }} [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
+    runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       fail-fast: false
       matrix:
+        os: [ windows-2022 ]
         arch: [ { name: 'x64',    triplet: 'x64-windows' } ]
         toolset: [ 'v143',  'ClangCL' ]
         backend: [ 'botan', 'openssl' ]
@@ -96,6 +97,24 @@ jobs:
             use_cmake_prefix_path:  'off'
             shared_libs:            'off'
             sanitizers:             'off'
+          # Windows Server 2025 (newer VS toolchain; preview of what windows-2022
+          # deprecation will land on).
+          - os:                    'windows-2025'
+            arch:                  { name: 'x64', triplet: 'x64-windows' }
+            toolset:               'v143'
+            backend:               'botan'
+            use_cmake_prefix_path: 'off'
+            shared_libs:           'off'
+            sanitizers:            'off'
+          # Windows 11 ARM (preview runner; vcpkg ARM coverage has improved enough
+          # for our dependency set). Marked continue-on-error below.
+          - os:                    'windows-11-arm'
+            arch:                  { name: 'ARM64', triplet: 'arm64-windows' }
+            toolset:               'v143'
+            backend:               'botan'
+            use_cmake_prefix_path: 'off'
+            shared_libs:           'off'
+            sanitizers:            'off'
 
     steps:
       - name: Checkout
@@ -222,3 +241,5 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure
+        # Windows 11 ARM is a preview runner; don't gate the build on it.
+        continue-on-error: ${{ matrix.os == 'windows-11-arm' }}

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,97 @@
+# Distro / platform maintainers
+
+This file lists the people who maintain rnp packaging in downstream
+distributions and platforms. If you maintain rnp packaging for a
+distribution or platform not listed here, please open a PR adding
+yourself.
+
+rnp is mission-critical software shipped by every major Linux
+distribution and several BSDs. Before making changes that could affect
+packaging (ABI breaks, dependency changes, build-system reorganisations,
+release flow changes), the rnp project consults this list.
+
+For the platforms rnp is known to work on, see
+`docs/supported-platforms.adoc`.
+
+## Linux distributions
+
+| Distribution | Maintainer | GitHub | Package | Source |
+|---|---|---|---|---|
+| Fedora | Remi Collet | [@remicollet](https://github.com/remicollet) | `rnp` | [src.fedoraproject.org](https://src.fedoraproject.org/rpms/rnp/) |
+| RHEL / EPEL | Remi Collet | [@remicollet](https://github.com/remicollet) | `rnp` (EPEL) / Remi's RPM repo | [src.fedoraproject.org](https://src.fedoraproject.org/rpms/rnp/) |
+| Debian (OpenPGP stack) | Daniel Kahn Gillmor | [@dkg](https://github.com/dkg) | `rnp` | [tracker.debian.org](https://tracker.debian.org/pkg/rnp) |
+| Ubuntu | (via Debian sync) | — | `rnp` | [launchpad.net](https://launchpad.net/ubuntu/+source/rnp) |
+| openSUSE | Andreas Stieger | [@andreasstieger](https://github.com/andreasstieger) | `rnp` | [build.opensuse.org](https://build.opensuse.org/package/show/security:crypto/rnp) |
+| Alpine Linux | Jakub Jirutka | [@jirutka](https://github.com/jirutka) | `rnp` | [pkgs.alpinelinux.org](https://pkgs.alpinelinux.org/package/edge/community/x86_64/rnp) |
+| Arch Linux | (placeholder — please PR to add) | | `rnp` | [archlinux.org](https://archlinux.org/packages/?q=rnp) |
+| Gentoo | Nicholas Vinson | [@nvinson](https://github.com/nvinson) | `dev-libs/rnp` | [packages.gentoo.org](https://packages.gentoo.org/packages/dev-libs/rnp) |
+| NixOS / Nix | Jeffrey Lau | [@ribose-jeffreylau](https://github.com/ribose-jeffreylau) | `rnp` (flake) | [github.com/rnpgp/rnp](https://github.com/rnpgp/rnp) (`flake.nix`) |
+
+## BSD / other Unix
+
+| Platform | Maintainer | GitHub | Package |
+|---|---|---|---|
+| FreeBSD | (placeholder — please PR to add) | | `security/rnp` |
+| NetBSD | (placeholder — please PR to add) | | `security/rnp` |
+| OpenBSD | (placeholder — please PR to add) | | `security/rnp` |
+
+## macOS
+
+| Channel | Maintainer | GitHub | Notes |
+|---|---|---|---|
+| Homebrew | Ribose / rnp core | [@ronaldtse](https://github.com/ronaldtse), [@ni4](https://github.com/ni4) | `brew install rnp` |
+| MacPorts | (placeholder — please PR to add) | | `security/rnp` |
+| PowerPC | Sergey Fedorov | [@barracuda156](https://github.com/barracuda156) | Tracks Big Sur / Monterey-on-PowerPC |
+
+## Windows
+
+| Channel | Maintainer | GitHub | Notes |
+|---|---|---|---|
+| vcpkg | Ribose / rnp core | [@ronaldtse](https://github.com/ronaldtse) | [microsoft/vcpkg#52989](https://github.com/microsoft/vcpkg/pull/52989) |
+| MSYS2 | (placeholder — please PR to add) | | mingw-w64-rnp |
+| Winget | (planned — see #1405) | | |
+
+## Other platforms / languages
+
+| Platform | Maintainer | GitHub | Repo |
+|---|---|---|---|
+| Ruby bindings (ruby-rnp) | Ribose | [@ronaldtse](https://github.com/ronaldtse) | [rnpgp/ruby-rnp](https://github.com/rnpgp/ruby-rnp) |
+| Python bindings (py-rnp) | Ribose | [@ronaldtse](https://github.com/ronaldtse) | [rnpgp/py-rnp](https://github.com/rnpgp/py-rnp) |
+| PHP bindings (php-rnp) | Ribose | [@ronaldtse](https://github.com/ronaldtse) | [rnpgp/php-rnp](https://github.com/rnpgp/php-rnp) |
+| Swift bindings (swift-rnp) | Ribose | [@ronaldtse](https://github.com/ronaldtse) | [rnpgp/swift-rnp](https://github.com/rnpgp/swift-rnp) |
+
+## Upstream dependencies
+
+| Dependency | Project | Maintainer | GitHub |
+|---|---|---|---|
+| Botan | Botan | Jack Lloyd | [@randombit](https://github.com/randombit) |
+| OpenSSL | OpenSSL | OpenSSL team | [@openssl/openssl](https://github.com/openssl/openssl) |
+| json-c | json-c | Michael Stack | [@json-c/json-c](https://github.com/json-c/json-c) |
+| BZip2 | bzip2 | Julian Seward (historical); maintained by various distros | — |
+| sexpp | Ribose | Ribose / rnp core | [@rnpgp/sexp](https://github.com/rnpgp/sexp) |
+
+## rnp project
+
+| Role | People | GitHub |
+|---|---|---|
+| Project lead | Ronald Tse | [@ronaldtse](https://github.com/ronaldtse) |
+| Core maintainer | Nikolai Miasnikov | [@ni4](https://github.com/ni4) |
+| CI infrastructure | Ribose | (this repo + [rnpgp/rnp-ci-containers](https://github.com/rnpgp/rnp-ci-containers)) |
+
+## Consultation policy
+
+For changes that may affect packaging, the rnp project will:
+
+1. Open a tracking issue describing the change and its scope.
+2. Ping the relevant maintainers from this file.
+3. Allow at least **2 weeks** for response before proceeding.
+4. Document any maintainer concerns raised and how they were addressed.
+
+Maintainers are encouraged to file issues proactively when their
+packaging workflow breaks or could be improved.
+
+## Updating this file
+
+If you maintain rnp packaging for a distribution, platform, or language
+binding that isn't listed here, please open a PR adding yourself. If your
+contact details change, please update your entry.

--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,8 @@ Currently supported platforms:
 
 == link:docs/installation.adoc[Installation]
 
+== link:docs/supported-platforms.adoc[Supported platforms]
+
 == link:docs/cli-usage.adoc[Using CLI tool]
 
 == link:docs/c-usage.adoc[Using the RNP C API in your projects]
@@ -64,3 +66,5 @@ created by Alistair Crooks of NetBSD in 2016. RNP has been heavily rewritten,
 and carries minimal if any code from the original codebase.
 
 == link:docs/code-of-conduct.adoc[Code of Conduct]
+
+== link:MAINTAINERS.md[Distribution maintainers]

--- a/_typos.toml
+++ b/_typos.toml
@@ -25,6 +25,7 @@ FO = "FO"
 claus = "claus"
 desig = "desig"
 CNA = "CNA"
+Sur = "Sur"
 
 [files]
 extend-exclude = [

--- a/_typos.toml
+++ b/_typos.toml
@@ -26,6 +26,7 @@ claus = "claus"
 desig = "desig"
 CNA = "CNA"
 Sur = "Sur"
+Collet = "Collet"
 
 [files]
 extend-exclude = [

--- a/docs/supported-platforms.adoc
+++ b/docs/supported-platforms.adoc
@@ -1,0 +1,223 @@
+= Supported platforms
+
+This document lists the operating systems, distributions, and hardware
+architectures on which librnp and the rnp / rnpkeys command-line tools
+are known to work. The matrix is derived from the project's CI coverage
+(see `.github/workflows/`) and from downstream packager reports.
+
+If you have rnp running on a combination not listed here, please open a
+PR adding it.
+
+== Cryptographic backends
+
+rnp ships with two interchangeable cryptographic backends:
+
+* **Botan** — supports Botan 2.x (2.12.1+ tested) and 3.x (3.7+ tested).
+  Required for full crypto-refresh (RFC 9580) and PQC support.
+* **OpenSSL** — supports OpenSSL 1.1.1 (legacy distro support) and 3.x.
+  Required for FIPS-mode deployments.
+
+Both backends are tested in CI on every PR. PQC and crypto-refresh
+currently require Botan 3.6+ or OpenSSL 3.x; PR
+[#2392](https://github.com/rnpgp/rnp/pull/2392) adds the OpenSSL backend
+for those features.
+
+== Supported Linux distributions
+
+Each row gives the rnp CI coverage. Versions marked **bold** are
+currently in CI; other versions in the same family are expected to work
+but are not actively tested.
+
+[cols="1,3,2,2,1"]
+|===
+| Distribution family | Versions tested | Botan version (system) | OpenSSL version (system) | Status
+
+| **Fedora**
+| **Fedora 42**, **43**, **44** + drops 39, 40, 41
+| Botan 2.19.5 (compat), 3.9.0 (default)
+| OpenSSL 3.x
+| Fully supported (current stable + 1 previous)
+
+| **CentOS Stream**
+| **CentOS Stream 9**
+| Botan 2.19.x
+| OpenSSL 3.x
+| Fully supported
+
+| **RHEL / EPEL**
+| **RHEL 8**, **RHEL 9**
+| Botan 2.12.1 (EPEL 8), 2.19.5 (EPEL 9)
+| **OpenSSL 1.1.1** (RHEL 8), OpenSSL 3.x (RHEL 9)
+| Fully supported; RHEL 8 is the primary OpenSSL 1.1.1 test bed
+
+| **Debian**
+| **Debian 11** (LTS), **Debian 12** (stable), **Debian 13** (testing) + drops 10
+| Botan 2.17.3 (11), 2.19.3 (12), 3.7.1 (13)
+| OpenSSL 1.1.x (11), 3.0 (12, 13)
+| Fully supported
+
+| **Ubuntu**
+| **Ubuntu 22.04 LTS**, **Ubuntu 24.04 LTS** + 24.04-arm
+| Botan 2.19.1 (22.04), 2.19.3 (24.04)
+| OpenSSL 3.0
+| Fully supported (LTS span)
+
+| **openSUSE**
+| **Leap 15.6**, **Tumbleweed**
+| Botan 2.19.x (Leap), 3.11.x (Tumbleweed)
+| OpenSSL 3.x
+| Supported
+
+| **Alpine Linux**
+| **Alpine 3.21**, **edge** (PR #2416)
+| Botan 3.x
+| OpenSSL 3.x
+| Supported (musl libc)
+|===
+
+For other RPM-based distros that track Fedora / CentOS / RHEL (Amazon
+Linux, Oracle Linux, Rocky Linux, AlmaLinux), the closest entry above
+applies.
+
+== Other Unix
+
+[cols="1,3,1"]
+|===
+| Platform | Versions tested | Status
+
+| **FreeBSD**
+| Not in CI
+| Reported working by community packagers; please add yourself to
+  `MAINTAINERS.md` if you maintain a FreeBSD port.
+
+| **NetBSD / OpenBSD**
+| Not in CI
+| Reported working historically; same as above.
+|===
+
+== macOS
+
+[cols="1,3,1,1"]
+|===
+| macOS version | Architectures | Backend | Status
+
+| **macOS 15** (Sequoia)
+| Apple Silicon + Intel
+| Botan 2.x, OpenSSL 3 (Homebrew)
+| Fully supported
+
+| **macOS 26**
+| Apple Silicon + Intel
+| Botan 3 (Homebrew)
+| Fully supported (added by #2416)
+
+| macOS 14 (Sonoma)
+| Apple Silicon + Intel
+| (deprecated; dropped by #2416)
+| Was supported until 2026-07
+|===
+
+Homebrew formula: `brew install rnp` (Botan backend, shared libs).
+
+== Windows
+
+[cols="1,3,2,2,1"]
+|===
+| Windows version | Architectures | Toolchain | Backend | Status
+
+| **Windows Server 2022**
+| x64, Win32
+| MSVC v143, ClangCL
+| Botan, OpenSSL (via vcpkg)
+| Fully supported
+
+| **Windows Server 2025**
+| x64
+| MSVC v143
+| Botan
+| Supported (added by #2416)
+
+| **Windows 11 ARM**
+| ARM64
+| MSVC v143
+| Botan
+| Preview (continue-on-error in CI; added by #2416)
+
+| **MSYS2** (mingw64, ucrt64, clang64)
+| x86_64
+| GCC, Clang
+| Botan, OpenSSL
+| Fully supported
+|===
+
+Installation: `vcpkg install rnp` once
+[microsoft/vcpkg#52989](https://github.com/microsoft/vcpkg/pull/52989)
+merges.
+
+== Hardware architectures
+
+rnp is portable C++17 and runs on any architecture its dependencies
+support. CI currently exercises:
+
+* **x86_64 / amd64** — primary development and test architecture.
+* **i386 / i686** — tested via Debian 13 i386 and Win32. Catches
+  32-bit-specific issues (size_t vs uint64_t, time_t width, etc.).
+* **ARM64 / aarch64** — Linux (Ubuntu 24.04 ARM, Fedora 44), Windows 11
+  ARM (preview), and macOS Apple Silicon.
+* **PowerPC** (Big Sur / Monterey) — community-supported; see
+  `@barracuda156` in `MAINTAINERS.md`.
+
+s390x, RISC-V, MIPS not currently in CI but reported working by
+downstream packagers.
+
+== Build options summary
+
+[cols="2,4,1"]
+|===
+| Option | Values | Default
+
+| `CRYPTO_BACKEND`
+| `Botan` \| `OpenSSL`
+| `Botan`
+
+| `ENABLE_CRYPTO_REFRESH` (RFC 9580)
+| `On` \| `Off` \| `Auto`
+| `Auto` (requires Botan 3+ or OpenSSL 3.x)
+
+| `ENABLE_PQC`
+| `On` \| `Off` \| `Auto`
+| `Auto` (requires Botan 3.6+)
+
+| `BUILD_SHARED_LIBS`
+| `On` \| `Off`
+| `On`
+
+| `ENABLE_BZIP2`
+| `On` \| `Off` \| `Auto`
+| `Auto`
+
+| `ENABLE_BLOWFISH` / `ENABLE_CAST5` / `ENABLE_RIPEMD160`
+| `On` \| `Off` \| `Auto`
+| `Auto`
+
+| `ENABLE_AEAD_EAX` / `ENABLE_AEAD_OCB`
+| `On` \| `Off`
+| `On` (Botan); `Off` for EAX on OpenSSL
+|===
+
+See `docs/installation.adoc` for build instructions and full option
+reference.
+
+== Reporting platform issues
+
+If rnp does not build or run on a platform listed here, please
+[file an issue](https://github.com/rnpgp/rnp/issues/new) with:
+
+* Distribution name and version.
+* Architecture.
+* Crypto backend (`Botan` or `OpenSSL`) and version.
+* `rnp --version` output (if it runs).
+* Build log or test failure output.
+
+For platforms not listed here, please open a PR adding the platform to
+this document once you have verified rnp builds and tests pass.

--- a/src/common/file-utils.cpp
+++ b/src/common/file-utils.cpp
@@ -36,6 +36,7 @@
 #include <errno.h>
 #else
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif // !_MSC_VER
@@ -116,6 +117,13 @@ rnp_fdopen(int fildes, const char *mode)
 #ifdef _WIN32
     return _fdopen(fildes, mode);
 #else
+    /* glibc's fdopen() catches bad fds via the underlying lseek(); musl's
+     * fdopen() only fails on actual I/O, leaving callers with a half-
+     * initialised FILE* on Alpine and other musl-based systems. Validate
+     * the fd up front so behaviour matches across libcs. */
+    if (fcntl(fildes, F_GETFD) == -1) {
+        return NULL;
+    }
     return fdopen(fildes, mode);
 #endif
 }

--- a/src/lib/crypto/backend_version.cpp
+++ b/src/lib/crypto/backend_version.cpp
@@ -72,7 +72,7 @@ backend_version()
     if (version[0]) {
         return version;
     }
-    const char *reg = "OpenSSL (([0-9]+\\.[0-9]+\\.[0-9]+)[a-z]*(-[a-z0-9]+)*) ";
+    const char *   reg = "OpenSSL (([0-9]+\\.[0-9]+\\.[0-9]+)[a-z]*(-[a-z0-9]+)*) ";
 #ifndef RNP_USE_STD_REGEX
     static regex_t r;
     regmatch_t     matches[5];


### PR DESCRIPTION
## Summary

Expands rnp's CI platform coverage to match the full set of GitHub-hosted runners, and drops deprecated runners/legs.

### Platform additions

| Workflow | New legs |
|---|---|
| `ubuntu.yml` | `ubuntu-24.04-arm` (Botan + OpenSSL); pins `ubuntu-24.04` explicitly instead of `ubuntu-latest` |
| `macos.yml` | `macos-26`, `macos-26-intel` |
| `windows-native.yml` | `windows-2025` (GA); `windows-11-arm` (preview, `continue-on-error`) |
| `alpine.yml` (new) | Alpine 3.21 (stable) + edge containers; gcc + clang (clang on stable only); Botan + OpenSSL |

### Removals (deprecated)

- `macos-14` runner — deprecated.
- `openssl@1.1` brew formula on macOS — deprecated; OpenSSL 1.1.1 itself went EOL Sept 2024.
- The "Configure openssl 1.1 backend" step in `macos.yml` (no longer used by any leg).

### Coverage preservation

OpenSSL 1.1.1 testing is NOT lost — it migrates from macOS to Linux containers:
- `centos-and-fedora.yml` RHEL 8 ubi + OpenSSL (covers RPM-based)
- `debian.yml` Debian 11 + openssl (covers dpkg-based)

Both are already in the matrix; no new leg needed.

## Why these platforms

All of these are critical audiences for rnp:

- **ARM Linux** — Thunderbird-on-ARM-Linux is a growing audience (Raspberry Pi 5, Asahi Linux, ARM cloud instances).
- **Alpine / musl** — Docker/containers commonly use Alpine; rnp-on-musl has known warts that need CI exposure.
- **Windows Server 2025** — will replace windows-2022 within 12 months; pinning now prevents surprise.
- **Windows 11 ARM** — Copilot+ PCs and Surface Pro X class hardware; vcpkg ARM coverage is now sufficient for our deps.
- **macOS 26** — current macOS release; users will file bugs against it.

## Test plan

- [ ] ubuntu-24.04 + ARM legs pass
- [ ] alpine.yml runs (may surface musl-specific code issues — those become separate fix PRs)
- [ ] windows-2025 leg passes
- [ ] windows-11-arm leg runs (preview; continue-on-error so non-blocking)
- [ ] macOS 26 legs pass

## Out of scope (follow-up PRs)

- **Redundancy cuts in `centos-and-fedora.yml`:** drop Fedora 39 (covered by 40), drop Botan 3.1.1/3.3.0 (keep 3.6.0 + head).
- **Reusable `workflow_call` extraction** for the duplicated setup boilerplate across workflows.
- **Path-based dynamic matrix** (skip CLI tests if only library code changed).
- **Test-suite performance work** (item 18 in TODO.rnp-roadmap).
