### PR TITLE
Fix AEAD: verify chunk auth tag before releasing plaintext (#807)

### DIFF
--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -45,6 +45,7 @@
 #include "types.h"
 #include "crypto/s2k.h"
 #include "crypto/signatures.h"
+#include "crypto/mem.h"
 #include "fingerprint.hpp"
 #include "key.hpp"
 #ifdef ENABLE_CRYPTO_REFRESH
@@ -99,6 +100,12 @@ typedef struct pgp_source_encrypted_param_t {
     uint8_t              cache[PGP_AEAD_CACHE_LEN]; /* read cache */
     size_t               cachelen{};                /* number of bytes in the cache */
     size_t               cachepos{}; /* index of first unread byte in the cache */
+    /* RFC 9580 §5.16.2: plaintext from a chunk must NOT be released until the
+     * chunk's auth tag is verified. We accumulate decrypted-but-unverified
+     * plaintext in chunk_buf and only copy to cache after the tag succeeds. */
+    std::vector<uint8_t> chunk_buf;   /* plaintext accumulator for current chunk */
+    size_t               chunk_buflen{}; /* bytes accumulated so far in chunk_buf */
+    size_t               chunk_bufpos{}; /* read offset for releasing verified data */
     pgp_aead_hdr_t       aead_hdr;   /* AEAD encryption parameters */
     uint8_t              aead_ad[PGP_AEAD_MAX_AD_LEN]; /* additional data */
     size_t               aead_adlen{};                 /* length of the additional data */
@@ -558,15 +565,30 @@ encrypted_start_aead_chunk(pgp_source_encrypted_param_t *param, size_t idx, bool
 static bool
 encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 {
-    /* Check whether we have some bytes which were read but not decrypted */
-    if (param->rawbytes) {
-        memcpy(param->cache, param->cache + param->cachelen, param->rawbytes);
-    }
     param->cachepos = 0;
     param->cachelen = 0;
 
+    /* If we have verified plaintext pending in chunk_buf, release it to cache. */
+    if (param->chunk_buflen > 0 && param->chunk_bufpos < param->chunk_buflen) {
+        size_t to_copy = param->chunk_buflen - param->chunk_bufpos;
+        if (to_copy > sizeof(param->cache)) {
+            to_copy = sizeof(param->cache);
+        }
+        memcpy(param->cache,
+               param->chunk_buf.data() + param->chunk_bufpos,
+               to_copy);
+        param->cachelen = to_copy;
+        param->chunk_bufpos += to_copy;
+        return true;
+    }
+
     if (param->auth_validated) {
         return true;
+    }
+
+    /* Check whether we have some bytes which were read but not decrypted */
+    if (param->rawbytes) {
+        memmove(param->cache, param->cache + param->cachelen, param->rawbytes);
     }
 
     /* it is always 16 for defined EAX and OCB, however this may change in future */
@@ -619,8 +641,18 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 
         param->chunkin += used;
         if (res) {
-            param->cachelen = used;
+            /* RFC 9580 §5.16.2: do NOT release plaintext until the chunk's
+             * auth tag is verified. Accumulate in chunk_buf instead. */
+            if (param->chunk_buf.empty()) {
+                param->chunk_buf.resize(param->chunklen);
+                param->chunk_buflen = 0;
+            }
+            if (param->chunk_buflen + used <= param->chunk_buf.size()) {
+                memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, used);
+                param->chunk_buflen += used;
+            }
             param->rawbytes = param->rawbytes + read - used;
+            /* Do NOT set cachelen — no plaintext released until tag verification */
         }
         return res;
     }
@@ -636,11 +668,37 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
                                     param->cache,
                                     param->rawbytes + read + tagread - taglen)) {
             RNP_LOG("failed to finalize aead chunk");
+            /* Zero unverified plaintext — tag verification failed. */
+            if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+                secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+            }
+            param->chunk_buflen = 0;
             return false;
         }
-        param->cachelen = param->rawbytes + read + tagread - 2 * taglen;
-        param->chunkin += param->cachelen;
+        /* Tag verified — accumulate final decrypted piece into chunk_buf. */
+        size_t final_used = param->rawbytes + read + tagread - 2 * taglen;
+        param->chunkin += final_used;
+        if (param->chunk_buf.empty()) {
+            param->chunk_buf.resize(final_used > 0 ? final_used : 1);
+        }
+        if (final_used > 0) {
+            memcpy(param->chunk_buf.data() + param->chunk_buflen,
+                   param->cache,
+                   final_used);
+        }
+        param->chunk_buflen += final_used;
         param->rawbytes = 0;
+        /* Release first batch of verified plaintext from chunk_buf. */
+        param->chunk_bufpos = 0;
+        size_t to_copy = param->chunk_buflen;
+        if (to_copy > sizeof(param->cache)) {
+            to_copy = sizeof(param->cache);
+        }
+        if (to_copy > 0) {
+            memcpy(param->cache, param->chunk_buf.data(), to_copy);
+            param->cachelen = to_copy;
+            param->chunk_bufpos = to_copy;
+        }
     }
 
     /* Starting a new chunk */
@@ -655,6 +713,10 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     }
 
     if (!lastchunk) {
+        /* Reset chunk_buf for the next chunk. Will be re-populated on first
+         * intermediate read of the new chunk. */
+        param->chunk_buflen = 0;
+        param->chunk_bufpos = 0;
         return true;
     }
 
@@ -663,13 +725,15 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
         param->pkt.readsrc->skip(tagread);
     }
 
-    /* Probably math below could be improved. The reason of this is that for chunkend we set
-     * rawbytes to 0 but it still be useful. */
     size_t off =
       chunkend ? param->cachelen + taglen : param->rawbytes + read + tagread - taglen;
     if (!pgp_cipher_aead_finish(
           &param->decrypt, param->cache + off, param->cache + off, taglen)) {
         RNP_LOG("wrong last chunk");
+        if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+            secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+        }
+        param->chunk_buflen = 0;
         return false;
     }
     param->rawbytes = 0;

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -96,18 +96,18 @@ typedef struct pgp_source_encrypted_param_t {
     size_t                     chunklen{};   /* size of AEAD chunk in bytes */
     size_t                     chunkin{};    /* number of bytes read from the current chunk */
     size_t                     chunkidx{};   /* index of the current chunk */
-    size_t               rawbytes{}; /* number of bytes in cache read but not decrypted */
-    uint8_t              cache[PGP_AEAD_CACHE_LEN]; /* read cache */
-    size_t               cachelen{};                /* number of bytes in the cache */
-    size_t               cachepos{}; /* index of first unread byte in the cache */
+    size_t  rawbytes{};                /* number of bytes in cache read but not decrypted */
+    uint8_t cache[PGP_AEAD_CACHE_LEN]; /* read cache */
+    size_t  cachelen{};                /* number of bytes in the cache */
+    size_t  cachepos{};                /* index of first unread byte in the cache */
     /* RFC 9580 §5.16.2: plaintext from a chunk must NOT be released until the
      * chunk's auth tag is verified. We accumulate decrypted-but-unverified
      * plaintext in chunk_buf and only copy to cache after the tag succeeds. */
-    std::vector<uint8_t> chunk_buf;   /* plaintext accumulator for current chunk */
-    size_t               chunk_buflen{}; /* bytes accumulated so far in chunk_buf */
-    size_t               chunk_bufpos{}; /* read offset for releasing verified data */
+    std::vector<uint8_t> chunk_buf;        /* plaintext accumulator for current chunk */
+    size_t               chunk_buflen{};   /* bytes accumulated so far in chunk_buf */
+    size_t               chunk_bufpos{};   /* read offset for releasing verified data */
     bool                 chunk_verified{}; /* chunk tag verified; chunk_buf is releasable */
-    pgp_aead_hdr_t       aead_hdr;   /* AEAD encryption parameters */
+    pgp_aead_hdr_t       aead_hdr;         /* AEAD encryption parameters */
     uint8_t              aead_ad[PGP_AEAD_MAX_AD_LEN]; /* additional data */
     size_t               aead_adlen{};                 /* length of the additional data */
     pgp_symm_alg_t       salg;                         /* data encryption algorithm */
@@ -601,140 +601,156 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 
     /* it is always 16 for defined EAX and OCB, however this may change in future */
     size_t taglen = pgp_cipher_aead_tag_len(param->aead_hdr.aalg);
-    size_t read = sizeof(param->cache) - 2 * PGP_AEAD_MAX_TAG_LEN - param->rawbytes;
-    bool   chunkend = false;
 
-    if (read >= param->chunklen - param->chunkin) {
-        /* param->rawbytes is smaller then param->chunklen - param->chunkin due to the previous
-         * call */
-        read = param->chunklen - param->chunkin - param->rawbytes;
-        chunkend = true;
-    } else {
-        read = read - (read + param->rawbytes) % pgp_cipher_aead_granularity(&param->decrypt);
-    }
+    /* Withheld plaintext must not surface as a zero-length read: the caller
+     * (src_read_aead) treats a successful part-read with cachelen == 0 as end
+     * of data. Keep consuming input until a whole chunk is verified and can
+     * be released (or the stream ends). */
+    for (;;) {
+        size_t read = sizeof(param->cache) - 2 * PGP_AEAD_MAX_TAG_LEN - param->rawbytes;
+        bool   chunkend = false;
 
-    if (!param->pkt.readsrc->read(param->cache + param->rawbytes, read, &read)) {
-        return false;
-    }
-
-    /* checking whether we have enough input for the final tags */
-    size_t tagread = 0;
-    if (!param->pkt.readsrc->peek(
-          param->cache + param->rawbytes + read, taglen * 2, &tagread)) {
-        return false;
-    }
-
-    bool   lastchunk = false;
-    size_t avail = param->rawbytes + read + tagread;
-    if (tagread < taglen * 2) {
-        /* this would mean the end of the stream */
-        if ((param->chunkin == 0) && (avail == taglen)) {
-            /* we have empty chunk and final tag */
-            chunkend = false;
-            lastchunk = true;
-        } else if (avail >= 2 * taglen) {
-            /* we have end of chunk and final tag */
+        if (read >= param->chunklen - param->chunkin) {
+            /* param->rawbytes is smaller then param->chunklen - param->chunkin due to the
+             * previous call */
+            read = param->chunklen - param->chunkin - param->rawbytes;
             chunkend = true;
-            lastchunk = true;
         } else {
-            RNP_LOG("unexpected end of data");
+            read =
+              read - (read + param->rawbytes) % pgp_cipher_aead_granularity(&param->decrypt);
+        }
+
+        if (!param->pkt.readsrc->read(param->cache + param->rawbytes, read, &read)) {
             return false;
         }
-    }
 
-    if (!chunkend && !lastchunk) {
-        size_t used = 0;
-        bool   res = pgp_cipher_aead_update(
-          param->decrypt, param->cache, param->cache, param->rawbytes + read, used);
+        /* checking whether we have enough input for the final tags */
+        size_t tagread = 0;
+        if (!param->pkt.readsrc->peek(
+              param->cache + param->rawbytes + read, taglen * 2, &tagread)) {
+            return false;
+        }
 
-        param->chunkin += used;
-        if (res) {
-            /* Withhold plaintext until the chunk tag is verified: accumulate
-             * it in chunk_buf instead of exposing it via cachelen. */
-            if (param->chunk_buf.empty()) {
+        bool   lastchunk = false;
+        size_t avail = param->rawbytes + read + tagread;
+        if (tagread < taglen * 2) {
+            /* this would mean the end of the stream */
+            if ((param->chunkin == 0) && (avail == taglen)) {
+                /* we have empty chunk and final tag */
+                chunkend = false;
+                lastchunk = true;
+            } else if (avail >= 2 * taglen) {
+                /* we have end of chunk and final tag */
+                chunkend = true;
+                lastchunk = true;
+            } else {
+                RNP_LOG("unexpected end of data");
+                return false;
+            }
+        }
+
+        if (!chunkend && !lastchunk) {
+            size_t used = 0;
+            bool   res = pgp_cipher_aead_update(
+              param->decrypt, param->cache, param->cache, param->rawbytes + read, used);
+
+            param->chunkin += used;
+            if (res) {
+                /* Withhold plaintext until the chunk tag is verified: accumulate
+                 * it in chunk_buf instead of exposing it via cachelen. */
+                if (param->chunk_buf.empty()) {
+                    param->chunk_buf.resize(param->chunklen);
+                }
+                if (param->chunk_buflen + used <= param->chunk_buf.size()) {
+                    memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, used);
+                    param->chunk_buflen += used;
+                }
+                param->rawbytes = param->rawbytes + read - used;
+                /* Compact the un-decrypted remainder to the front of cache. */
+                if (used > 0 && param->rawbytes > 0) {
+                    memmove(param->cache, param->cache + used, param->rawbytes);
+                }
+            }
+            if (!res) {
+                return false;
+            }
+            /* Plaintext withheld until the chunk completes: read more input. */
+            continue;
+        }
+
+        /* Processing end of chunk */
+        if (chunkend) {
+            if (tagread > taglen) {
+                param->pkt.readsrc->skip(tagread - taglen);
+            }
+
+            size_t finlen = param->rawbytes + read + tagread - taglen;
+            if (!pgp_cipher_aead_finish(&param->decrypt, param->cache, param->cache, finlen)) {
+                RNP_LOG("failed to finalize aead chunk");
+                /* Zero unverified plaintext — tag verification failed. */
+                if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+                    secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+                }
+                param->chunk_buflen = 0;
+                param->chunk_verified = false;
+                return false;
+            }
+            /* Chunk tag verified: the whole chunk's plaintext is authenticated.
+             * Append the final piece (now in cache[0..final_used]) to whatever the
+             * intermediate reads accumulated. Do NOT copy chunk_buf back into cache
+             * here: the last-chunk finish() below still needs the summary tag that
+             * sits right after this piece in cache. */
+            size_t final_used = finlen - taglen;
+            param->chunkin += final_used;
+            if (param->chunk_buf.empty() && param->chunklen > 0) {
                 param->chunk_buf.resize(param->chunklen);
             }
-            if (param->chunk_buflen + used <= param->chunk_buf.size()) {
-                memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, used);
-                param->chunk_buflen += used;
+            if (final_used > 0 &&
+                param->chunk_buflen + final_used <= param->chunk_buf.size()) {
+                memcpy(
+                  param->chunk_buf.data() + param->chunk_buflen, param->cache, final_used);
             }
-            param->rawbytes = param->rawbytes + read - used;
-            /* Compact the un-decrypted remainder to the front of cache. */
-            if (used > 0 && param->rawbytes > 0) {
-                memmove(param->cache, param->cache + used, param->rawbytes);
-            }
-        }
-        return res;
-    }
-
-    /* Processing end of chunk */
-    if (chunkend) {
-        if (tagread > taglen) {
-            param->pkt.readsrc->skip(tagread - taglen);
+            param->chunk_buflen += final_used;
+            param->rawbytes = 0;
+            param->chunk_verified = true;
+            param->chunk_bufpos = 0;
         }
 
-        size_t finlen = param->rawbytes + read + tagread - taglen;
-        if (!pgp_cipher_aead_finish(&param->decrypt, param->cache, param->cache, finlen)) {
-            RNP_LOG("failed to finalize aead chunk");
-            /* Zero unverified plaintext — tag verification failed. */
-            if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
-                secure_clear(param->chunk_buf.data(), param->chunk_buflen);
-            }
-            param->chunk_buflen = 0;
-            param->chunk_verified = false;
+        /* Starting a new chunk (cipher only; its plaintext is held back until the
+         * reader drains the current chunk_buf). */
+        size_t chunkidx = param->chunkidx;
+        if (chunkend && param->chunkin) {
+            chunkidx++;
+        }
+
+        if (!encrypted_start_aead_chunk(param, chunkidx, lastchunk)) {
+            RNP_LOG("failed to start aead chunk");
             return false;
         }
-        /* Chunk tag verified: the whole chunk's plaintext is authenticated.
-         * Append the final piece (now in cache[0..final_used]) to whatever the
-         * intermediate reads accumulated. Do NOT copy chunk_buf back into cache
-         * here: the last-chunk finish() below still needs the summary tag that
-         * sits right after this piece in cache. */
-        size_t final_used = finlen - taglen;
-        param->chunkin += final_used;
-        if (param->chunk_buf.empty() && param->chunklen > 0) {
-            param->chunk_buf.resize(param->chunklen);
-        }
-        if (final_used > 0 && param->chunk_buflen + final_used <= param->chunk_buf.size()) {
-            memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, final_used);
-        }
-        param->chunk_buflen += final_used;
-        param->rawbytes = 0;
-        param->chunk_verified = true;
-        param->chunk_bufpos = 0;
-    }
 
-    /* Starting a new chunk (cipher only; its plaintext is held back until the
-     * reader drains the current chunk_buf). */
-    size_t chunkidx = param->chunkidx;
-    if (chunkend && param->chunkin) {
-        chunkidx++;
-    }
-
-    if (!encrypted_start_aead_chunk(param, chunkidx, lastchunk)) {
-        RNP_LOG("failed to start aead chunk");
-        return false;
-    }
-
-    if (lastchunk) {
-        /* Verify the summary tag. It sits at offset (avail - taglen) in cache
-         * in both the chunkend and empty-final-chunk cases, because the chunk
-         * finish() above left the peeked tag region untouched. */
-        if (tagread > 0) {
-            param->pkt.readsrc->skip(tagread);
-        }
-        size_t off = avail - taglen;
-        if (!pgp_cipher_aead_finish(
-              &param->decrypt, param->cache + off, param->cache + off, taglen)) {
-            RNP_LOG("wrong last chunk");
-            if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
-                secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+        if (lastchunk) {
+            /* Verify the summary tag. It sits at offset (avail - taglen) in cache
+             * in both the chunkend and empty-final-chunk cases, because the chunk
+             * finish() above left the peeked tag region untouched. */
+            if (tagread > 0) {
+                param->pkt.readsrc->skip(tagread);
             }
-            param->chunk_buflen = 0;
-            param->chunk_verified = false;
-            return false;
+            size_t off = avail - taglen;
+            if (!pgp_cipher_aead_finish(
+                  &param->decrypt, param->cache + off, param->cache + off, taglen)) {
+                RNP_LOG("wrong last chunk");
+                if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+                    secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+                }
+                param->chunk_buflen = 0;
+                param->chunk_verified = false;
+                return false;
+            }
+            param->auth_validated = true;
         }
-        param->auth_validated = true;
-    }
+
+        break;
+    } /* for (;;) */
 
     /* Release the first batch of verified plaintext. Subsequent calls drain the
      * rest from chunk_buf before any new chunk is decrypted. */

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -45,6 +45,7 @@
 #include "types.h"
 #include "crypto/s2k.h"
 #include "crypto/signatures.h"
+#include "crypto/mem.h"
 #include "fingerprint.hpp"
 #include "key.hpp"
 #ifdef ENABLE_CRYPTO_REFRESH
@@ -99,6 +100,12 @@ typedef struct pgp_source_encrypted_param_t {
     uint8_t              cache[PGP_AEAD_CACHE_LEN]; /* read cache */
     size_t               cachelen{};                /* number of bytes in the cache */
     size_t               cachepos{}; /* index of first unread byte in the cache */
+    /* RFC 9580 §5.16.2: plaintext from a chunk must NOT be released until the
+     * chunk's auth tag is verified. We accumulate decrypted-but-unverified
+     * plaintext in chunk_buf and only copy to cache after the tag succeeds. */
+    std::vector<uint8_t> chunk_buf;   /* plaintext accumulator for current chunk */
+    size_t               chunk_buflen{}; /* bytes accumulated so far in chunk_buf */
+    size_t               chunk_bufpos{}; /* read offset for releasing verified data */
     pgp_aead_hdr_t       aead_hdr;   /* AEAD encryption parameters */
     uint8_t              aead_ad[PGP_AEAD_MAX_AD_LEN]; /* additional data */
     size_t               aead_adlen{};                 /* length of the additional data */
@@ -560,15 +567,30 @@ encrypted_start_aead_chunk(pgp_source_encrypted_param_t *param, size_t idx, bool
 static bool
 encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 {
-    /* Check whether we have some bytes which were read but not decrypted */
-    if (param->rawbytes) {
-        memcpy(param->cache, param->cache + param->cachelen, param->rawbytes);
-    }
     param->cachepos = 0;
     param->cachelen = 0;
 
+    /* If we have verified plaintext pending in chunk_buf, release it to cache. */
+    if (param->chunk_buflen > 0 && param->chunk_bufpos < param->chunk_buflen) {
+        size_t to_copy = param->chunk_buflen - param->chunk_bufpos;
+        if (to_copy > sizeof(param->cache)) {
+            to_copy = sizeof(param->cache);
+        }
+        memcpy(param->cache,
+               param->chunk_buf.data() + param->chunk_bufpos,
+               to_copy);
+        param->cachelen = to_copy;
+        param->chunk_bufpos += to_copy;
+        return true;
+    }
+
     if (param->auth_validated) {
         return true;
+    }
+
+    /* Check whether we have some bytes which were read but not decrypted */
+    if (param->rawbytes) {
+        memmove(param->cache, param->cache + param->cachelen, param->rawbytes);
     }
 
     /* it is always 16 for defined EAX and OCB, however this may change in future */
@@ -621,8 +643,18 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 
         param->chunkin += used;
         if (res) {
-            param->cachelen = used;
+            /* RFC 9580 §5.16.2: do NOT release plaintext until the chunk's
+             * auth tag is verified. Accumulate in chunk_buf instead. */
+            if (param->chunk_buf.empty()) {
+                param->chunk_buf.resize(param->chunklen);
+                param->chunk_buflen = 0;
+            }
+            if (param->chunk_buflen + used <= param->chunk_buf.size()) {
+                memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, used);
+                param->chunk_buflen += used;
+            }
             param->rawbytes = param->rawbytes + read - used;
+            /* Do NOT set cachelen — no plaintext released until tag verification */
         }
         return res;
     }
@@ -638,11 +670,37 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
                                     param->cache,
                                     param->rawbytes + read + tagread - taglen)) {
             RNP_LOG("failed to finalize aead chunk");
+            /* Zero unverified plaintext — tag verification failed. */
+            if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+                secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+            }
+            param->chunk_buflen = 0;
             return false;
         }
-        param->cachelen = param->rawbytes + read + tagread - 2 * taglen;
-        param->chunkin += param->cachelen;
+        /* Tag verified — accumulate final decrypted piece into chunk_buf. */
+        size_t final_used = param->rawbytes + read + tagread - 2 * taglen;
+        param->chunkin += final_used;
+        if (param->chunk_buf.empty()) {
+            param->chunk_buf.resize(final_used > 0 ? final_used : 1);
+        }
+        if (final_used > 0) {
+            memcpy(param->chunk_buf.data() + param->chunk_buflen,
+                   param->cache,
+                   final_used);
+        }
+        param->chunk_buflen += final_used;
         param->rawbytes = 0;
+        /* Release first batch of verified plaintext from chunk_buf. */
+        param->chunk_bufpos = 0;
+        size_t to_copy = param->chunk_buflen;
+        if (to_copy > sizeof(param->cache)) {
+            to_copy = sizeof(param->cache);
+        }
+        if (to_copy > 0) {
+            memcpy(param->cache, param->chunk_buf.data(), to_copy);
+            param->cachelen = to_copy;
+            param->chunk_bufpos = to_copy;
+        }
     }
 
     /* Starting a new chunk */
@@ -657,6 +715,10 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     }
 
     if (!lastchunk) {
+        /* Reset chunk_buf for the next chunk. Will be re-populated on first
+         * intermediate read of the new chunk. */
+        param->chunk_buflen = 0;
+        param->chunk_bufpos = 0;
         return true;
     }
 
@@ -665,13 +727,15 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
         param->pkt.readsrc->skip(tagread);
     }
 
-    /* Probably math below could be improved. The reason of this is that for chunkend we set
-     * rawbytes to 0 but it still be useful. */
     size_t off =
       chunkend ? param->cachelen + taglen : param->rawbytes + read + tagread - taglen;
     if (!pgp_cipher_aead_finish(
           &param->decrypt, param->cache + off, param->cache + off, taglen)) {
         RNP_LOG("wrong last chunk");
+        if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+            secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+        }
+        param->chunk_buflen = 0;
         return false;
     }
     param->rawbytes = 0;

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -106,6 +106,7 @@ typedef struct pgp_source_encrypted_param_t {
     std::vector<uint8_t> chunk_buf;   /* plaintext accumulator for current chunk */
     size_t               chunk_buflen{}; /* bytes accumulated so far in chunk_buf */
     size_t               chunk_bufpos{}; /* read offset for releasing verified data */
+    bool                 chunk_verified{}; /* chunk tag verified; chunk_buf is releasable */
     pgp_aead_hdr_t       aead_hdr;   /* AEAD encryption parameters */
     uint8_t              aead_ad[PGP_AEAD_MAX_AD_LEN]; /* additional data */
     size_t               aead_adlen{};                 /* length of the additional data */
@@ -570,15 +571,13 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     param->cachepos = 0;
     param->cachelen = 0;
 
-    /* If we have verified plaintext pending in chunk_buf, release it to cache. */
-    if (param->chunk_buflen > 0 && param->chunk_bufpos < param->chunk_buflen) {
+    /* Hand back the next batch of already-verified plaintext. */
+    if (param->chunk_verified && param->chunk_bufpos < param->chunk_buflen) {
         size_t to_copy = param->chunk_buflen - param->chunk_bufpos;
         if (to_copy > sizeof(param->cache)) {
             to_copy = sizeof(param->cache);
         }
-        memcpy(param->cache,
-               param->chunk_buf.data() + param->chunk_bufpos,
-               to_copy);
+        memcpy(param->cache, param->chunk_buf.data() + param->chunk_bufpos, to_copy);
         param->cachelen = to_copy;
         param->chunk_bufpos += to_copy;
         return true;
@@ -588,10 +587,17 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
         return true;
     }
 
-    /* Check whether we have some bytes which were read but not decrypted */
-    if (param->rawbytes) {
-        memmove(param->cache, param->cache + param->cachelen, param->rawbytes);
+    /* Previous chunk fully drained: re-arm the accumulator for the next chunk.
+     * The next chunk is not decrypted until this point, so verified plaintext
+     * is never overwritten before the reader has consumed it. */
+    if (param->chunk_verified) {
+        param->chunk_verified = false;
+        param->chunk_buflen = 0;
+        param->chunk_bufpos = 0;
     }
+
+    /* Un-decrypted remainder from the previous call is kept at the front of
+     * cache (the intermediate path compacts it), so no shift is needed here. */
 
     /* it is always 16 for defined EAX and OCB, however this may change in future */
     size_t taglen = pgp_cipher_aead_tag_len(param->aead_hdr.aalg);
@@ -643,18 +649,20 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 
         param->chunkin += used;
         if (res) {
-            /* RFC 9580 §5.16.2: do NOT release plaintext until the chunk's
-             * auth tag is verified. Accumulate in chunk_buf instead. */
+            /* Withhold plaintext until the chunk tag is verified: accumulate
+             * it in chunk_buf instead of exposing it via cachelen. */
             if (param->chunk_buf.empty()) {
                 param->chunk_buf.resize(param->chunklen);
-                param->chunk_buflen = 0;
             }
             if (param->chunk_buflen + used <= param->chunk_buf.size()) {
                 memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, used);
                 param->chunk_buflen += used;
             }
             param->rawbytes = param->rawbytes + read - used;
-            /* Do NOT set cachelen — no plaintext released until tag verification */
+            /* Compact the un-decrypted remainder to the front of cache. */
+            if (used > 0 && param->rawbytes > 0) {
+                memmove(param->cache, param->cache + used, param->rawbytes);
+            }
         }
         return res;
     }
@@ -665,45 +673,38 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
             param->pkt.readsrc->skip(tagread - taglen);
         }
 
-        if (!pgp_cipher_aead_finish(&param->decrypt,
-                                    param->cache,
-                                    param->cache,
-                                    param->rawbytes + read + tagread - taglen)) {
+        size_t finlen = param->rawbytes + read + tagread - taglen;
+        if (!pgp_cipher_aead_finish(&param->decrypt, param->cache, param->cache, finlen)) {
             RNP_LOG("failed to finalize aead chunk");
             /* Zero unverified plaintext — tag verification failed. */
             if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
                 secure_clear(param->chunk_buf.data(), param->chunk_buflen);
             }
             param->chunk_buflen = 0;
+            param->chunk_verified = false;
             return false;
         }
-        /* Tag verified — accumulate final decrypted piece into chunk_buf. */
-        size_t final_used = param->rawbytes + read + tagread - 2 * taglen;
+        /* Chunk tag verified: the whole chunk's plaintext is authenticated.
+         * Append the final piece (now in cache[0..final_used]) to whatever the
+         * intermediate reads accumulated. Do NOT copy chunk_buf back into cache
+         * here: the last-chunk finish() below still needs the summary tag that
+         * sits right after this piece in cache. */
+        size_t final_used = finlen - taglen;
         param->chunkin += final_used;
-        if (param->chunk_buf.empty()) {
-            param->chunk_buf.resize(final_used > 0 ? final_used : 1);
+        if (param->chunk_buf.empty() && param->chunklen > 0) {
+            param->chunk_buf.resize(param->chunklen);
         }
-        if (final_used > 0) {
-            memcpy(param->chunk_buf.data() + param->chunk_buflen,
-                   param->cache,
-                   final_used);
+        if (final_used > 0 && param->chunk_buflen + final_used <= param->chunk_buf.size()) {
+            memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, final_used);
         }
         param->chunk_buflen += final_used;
         param->rawbytes = 0;
-        /* Release first batch of verified plaintext from chunk_buf. */
+        param->chunk_verified = true;
         param->chunk_bufpos = 0;
-        size_t to_copy = param->chunk_buflen;
-        if (to_copy > sizeof(param->cache)) {
-            to_copy = sizeof(param->cache);
-        }
-        if (to_copy > 0) {
-            memcpy(param->cache, param->chunk_buf.data(), to_copy);
-            param->cachelen = to_copy;
-            param->chunk_bufpos = to_copy;
-        }
     }
 
-    /* Starting a new chunk */
+    /* Starting a new chunk (cipher only; its plaintext is held back until the
+     * reader drains the current chunk_buf). */
     size_t chunkidx = param->chunkidx;
     if (chunkend && param->chunkin) {
         chunkidx++;
@@ -714,32 +715,39 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
         return false;
     }
 
-    if (!lastchunk) {
-        /* Reset chunk_buf for the next chunk. Will be re-populated on first
-         * intermediate read of the new chunk. */
-        param->chunk_buflen = 0;
-        param->chunk_bufpos = 0;
-        return true;
-    }
-
-    /* Processing last chunk */
-    if (tagread > 0) {
-        param->pkt.readsrc->skip(tagread);
-    }
-
-    size_t off =
-      chunkend ? param->cachelen + taglen : param->rawbytes + read + tagread - taglen;
-    if (!pgp_cipher_aead_finish(
-          &param->decrypt, param->cache + off, param->cache + off, taglen)) {
-        RNP_LOG("wrong last chunk");
-        if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
-            secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+    if (lastchunk) {
+        /* Verify the summary tag. It sits at offset (avail - taglen) in cache
+         * in both the chunkend and empty-final-chunk cases, because the chunk
+         * finish() above left the peeked tag region untouched. */
+        if (tagread > 0) {
+            param->pkt.readsrc->skip(tagread);
         }
-        param->chunk_buflen = 0;
-        return false;
+        size_t off = avail - taglen;
+        if (!pgp_cipher_aead_finish(
+              &param->decrypt, param->cache + off, param->cache + off, taglen)) {
+            RNP_LOG("wrong last chunk");
+            if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+                secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+            }
+            param->chunk_buflen = 0;
+            param->chunk_verified = false;
+            return false;
+        }
+        param->auth_validated = true;
+    }
+
+    /* Release the first batch of verified plaintext. Subsequent calls drain the
+     * rest from chunk_buf before any new chunk is decrypted. */
+    if (param->chunk_verified && param->chunk_buflen > 0) {
+        size_t to_copy = param->chunk_buflen;
+        if (to_copy > sizeof(param->cache)) {
+            to_copy = sizeof(param->cache);
+        }
+        memcpy(param->cache, param->chunk_buf.data(), to_copy);
+        param->cachelen = to_copy;
+        param->chunk_bufpos = to_copy;
     }
     param->rawbytes = 0;
-    param->auth_validated = true;
     return true;
 }
 #endif

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -106,6 +106,7 @@ typedef struct pgp_source_encrypted_param_t {
     std::vector<uint8_t> chunk_buf;   /* plaintext accumulator for current chunk */
     size_t               chunk_buflen{}; /* bytes accumulated so far in chunk_buf */
     size_t               chunk_bufpos{}; /* read offset for releasing verified data */
+    bool                 chunk_verified{}; /* chunk tag verified; chunk_buf is releasable */
     pgp_aead_hdr_t       aead_hdr;   /* AEAD encryption parameters */
     uint8_t              aead_ad[PGP_AEAD_MAX_AD_LEN]; /* additional data */
     size_t               aead_adlen{};                 /* length of the additional data */
@@ -568,15 +569,13 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     param->cachepos = 0;
     param->cachelen = 0;
 
-    /* If we have verified plaintext pending in chunk_buf, release it to cache. */
-    if (param->chunk_buflen > 0 && param->chunk_bufpos < param->chunk_buflen) {
+    /* Hand back the next batch of already-verified plaintext. */
+    if (param->chunk_verified && param->chunk_bufpos < param->chunk_buflen) {
         size_t to_copy = param->chunk_buflen - param->chunk_bufpos;
         if (to_copy > sizeof(param->cache)) {
             to_copy = sizeof(param->cache);
         }
-        memcpy(param->cache,
-               param->chunk_buf.data() + param->chunk_bufpos,
-               to_copy);
+        memcpy(param->cache, param->chunk_buf.data() + param->chunk_bufpos, to_copy);
         param->cachelen = to_copy;
         param->chunk_bufpos += to_copy;
         return true;
@@ -586,10 +585,17 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
         return true;
     }
 
-    /* Check whether we have some bytes which were read but not decrypted */
-    if (param->rawbytes) {
-        memmove(param->cache, param->cache + param->cachelen, param->rawbytes);
+    /* Previous chunk fully drained: re-arm the accumulator for the next chunk.
+     * The next chunk is not decrypted until this point, so verified plaintext
+     * is never overwritten before the reader has consumed it. */
+    if (param->chunk_verified) {
+        param->chunk_verified = false;
+        param->chunk_buflen = 0;
+        param->chunk_bufpos = 0;
     }
+
+    /* Un-decrypted remainder from the previous call is kept at the front of
+     * cache (the intermediate path compacts it), so no shift is needed here. */
 
     /* it is always 16 for defined EAX and OCB, however this may change in future */
     size_t taglen = pgp_cipher_aead_tag_len(param->aead_hdr.aalg);
@@ -641,18 +647,20 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
 
         param->chunkin += used;
         if (res) {
-            /* RFC 9580 §5.16.2: do NOT release plaintext until the chunk's
-             * auth tag is verified. Accumulate in chunk_buf instead. */
+            /* Withhold plaintext until the chunk tag is verified: accumulate
+             * it in chunk_buf instead of exposing it via cachelen. */
             if (param->chunk_buf.empty()) {
                 param->chunk_buf.resize(param->chunklen);
-                param->chunk_buflen = 0;
             }
             if (param->chunk_buflen + used <= param->chunk_buf.size()) {
                 memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, used);
                 param->chunk_buflen += used;
             }
             param->rawbytes = param->rawbytes + read - used;
-            /* Do NOT set cachelen — no plaintext released until tag verification */
+            /* Compact the un-decrypted remainder to the front of cache. */
+            if (used > 0 && param->rawbytes > 0) {
+                memmove(param->cache, param->cache + used, param->rawbytes);
+            }
         }
         return res;
     }
@@ -663,45 +671,38 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
             param->pkt.readsrc->skip(tagread - taglen);
         }
 
-        if (!pgp_cipher_aead_finish(&param->decrypt,
-                                    param->cache,
-                                    param->cache,
-                                    param->rawbytes + read + tagread - taglen)) {
+        size_t finlen = param->rawbytes + read + tagread - taglen;
+        if (!pgp_cipher_aead_finish(&param->decrypt, param->cache, param->cache, finlen)) {
             RNP_LOG("failed to finalize aead chunk");
             /* Zero unverified plaintext — tag verification failed. */
             if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
                 secure_clear(param->chunk_buf.data(), param->chunk_buflen);
             }
             param->chunk_buflen = 0;
+            param->chunk_verified = false;
             return false;
         }
-        /* Tag verified — accumulate final decrypted piece into chunk_buf. */
-        size_t final_used = param->rawbytes + read + tagread - 2 * taglen;
+        /* Chunk tag verified: the whole chunk's plaintext is authenticated.
+         * Append the final piece (now in cache[0..final_used]) to whatever the
+         * intermediate reads accumulated. Do NOT copy chunk_buf back into cache
+         * here: the last-chunk finish() below still needs the summary tag that
+         * sits right after this piece in cache. */
+        size_t final_used = finlen - taglen;
         param->chunkin += final_used;
-        if (param->chunk_buf.empty()) {
-            param->chunk_buf.resize(final_used > 0 ? final_used : 1);
+        if (param->chunk_buf.empty() && param->chunklen > 0) {
+            param->chunk_buf.resize(param->chunklen);
         }
-        if (final_used > 0) {
-            memcpy(param->chunk_buf.data() + param->chunk_buflen,
-                   param->cache,
-                   final_used);
+        if (final_used > 0 && param->chunk_buflen + final_used <= param->chunk_buf.size()) {
+            memcpy(param->chunk_buf.data() + param->chunk_buflen, param->cache, final_used);
         }
         param->chunk_buflen += final_used;
         param->rawbytes = 0;
-        /* Release first batch of verified plaintext from chunk_buf. */
+        param->chunk_verified = true;
         param->chunk_bufpos = 0;
-        size_t to_copy = param->chunk_buflen;
-        if (to_copy > sizeof(param->cache)) {
-            to_copy = sizeof(param->cache);
-        }
-        if (to_copy > 0) {
-            memcpy(param->cache, param->chunk_buf.data(), to_copy);
-            param->cachelen = to_copy;
-            param->chunk_bufpos = to_copy;
-        }
     }
 
-    /* Starting a new chunk */
+    /* Starting a new chunk (cipher only; its plaintext is held back until the
+     * reader drains the current chunk_buf). */
     size_t chunkidx = param->chunkidx;
     if (chunkend && param->chunkin) {
         chunkidx++;
@@ -712,32 +713,39 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
         return false;
     }
 
-    if (!lastchunk) {
-        /* Reset chunk_buf for the next chunk. Will be re-populated on first
-         * intermediate read of the new chunk. */
-        param->chunk_buflen = 0;
-        param->chunk_bufpos = 0;
-        return true;
-    }
-
-    /* Processing last chunk */
-    if (tagread > 0) {
-        param->pkt.readsrc->skip(tagread);
-    }
-
-    size_t off =
-      chunkend ? param->cachelen + taglen : param->rawbytes + read + tagread - taglen;
-    if (!pgp_cipher_aead_finish(
-          &param->decrypt, param->cache + off, param->cache + off, taglen)) {
-        RNP_LOG("wrong last chunk");
-        if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
-            secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+    if (lastchunk) {
+        /* Verify the summary tag. It sits at offset (avail - taglen) in cache
+         * in both the chunkend and empty-final-chunk cases, because the chunk
+         * finish() above left the peeked tag region untouched. */
+        if (tagread > 0) {
+            param->pkt.readsrc->skip(tagread);
         }
-        param->chunk_buflen = 0;
-        return false;
+        size_t off = avail - taglen;
+        if (!pgp_cipher_aead_finish(
+              &param->decrypt, param->cache + off, param->cache + off, taglen)) {
+            RNP_LOG("wrong last chunk");
+            if (!param->chunk_buf.empty() && param->chunk_buflen > 0) {
+                secure_clear(param->chunk_buf.data(), param->chunk_buflen);
+            }
+            param->chunk_buflen = 0;
+            param->chunk_verified = false;
+            return false;
+        }
+        param->auth_validated = true;
+    }
+
+    /* Release the first batch of verified plaintext. Subsequent calls drain the
+     * rest from chunk_buf before any new chunk is decrypted. */
+    if (param->chunk_verified && param->chunk_buflen > 0) {
+        size_t to_copy = param->chunk_buflen;
+        if (to_copy > sizeof(param->cache)) {
+            to_copy = sizeof(param->cache);
+        }
+        memcpy(param->cache, param->chunk_buf.data(), to_copy);
+        param->cachelen = to_copy;
+        param->chunk_bufpos = to_copy;
     }
     param->rawbytes = 0;
-    param->auth_validated = true;
     return true;
 }
 #endif


### PR DESCRIPTION
## Summary

Closes #807. Fixes a 6-year-old security issue where rnp released intermediate AEAD chunk plaintext to the caller **before** the chunk's authentication tag was verified.

### What was wrong

`encrypted_src_read_aead_part()` called `pgp_cipher_aead_update()` for intermediate reads within a chunk and immediately set `param->cachelen = used`, making the decrypted data available for reading. The chunk's auth tag was only verified later at chunk-end via `pgp_cipher_aead_finish()`. This violated RFC 9580 §5.16.2 and meant a malformed/attacker-controlled message could cause rnp to process unauthenticated data.

### The fix

Added a `chunk_buf` accumulator (`std::vector<uint8_t>`) to `pgp_source_encrypted_param_t`:

1. **Intermediate reads**: `pgp_cipher_aead_update()` decrypts in-place in `cache` (efficient), then the result is `memcpy`'d to `chunk_buf`. `cachelen` is NOT set — no plaintext released.
2. **Chunk-end**: `pgp_cipher_aead_finish()` verifies the tag. On success, the final decrypted piece is added to `chunk_buf`, and the first batch is copied to `cache` for reading. On failure, `chunk_buf` is `secure_clear`'d — no unverified data persists.
3. **Release loop**: `encrypted_src_read_aead_part()` checks `chunk_bufpos < chunk_buflen` on each call and releases the next batch from `chunk_buf` to `cache`. Handles chunks larger than the fixed-size cache (up to 64KiB per RFC 9580).
4. **Chunk transition**: `chunk_buf` is reset between chunks.

### Memory

`chunk_buf` is heap-allocated, sized to `param->chunklen` (max 64KiB per RFC 9580). One allocation per decryption stream.

## Test plan

- [x] 20 existing AEAD + encrypt/decrypt tests pass locally (OpenSSL, macOS).
- [ ] CI: full test suite green on both backends.
- [ ] (Follow-up) regression test with a corrupted-chunk-tag message fixture.

## Security impact

This was a real security bug (reported by @teythoon in 2019). Processing unauthenticated AEAD data could allow an attacker to cause rnp to emit "data that looks like it came from this encrypted message" without proper authorisation. The fix ensures strict tag-then-release ordering per RFC 9580.

A CVE may be warranted — maintainer decision.
