### PR TITLE
ffi: security rule enumeration API + FIPS mode foundation

### DIFF
--- a/.github/workflows/fips-mode.yml
+++ b/.github/workflows/fips-mode.yml
@@ -1,0 +1,80 @@
+name: fips-mode
+
+# Build rnp with -DENABLE_FIPS_MODE=On and run the test suite. FIPS mode
+# requires the OpenSSL backend (3.x); this workflow exists so the FIPS build
+# gets CI coverage even though most distro legs use the default profile.
+# See docs/security.adoc and roadmap item #06.
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/fips-mode.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  fips-build-and-test:
+    name: FIPS mode (openssl 3.x)
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install cmake libbz2-dev libjson-c-dev libssl-dev asciidoctor
+
+      - name: Configure
+        run: |
+          echo CORES="$(nproc --all)" >> $GITHUB_ENV
+          cmake -B build \
+                -DBUILD_SHARED_LIBS=ON \
+                -DCRYPTO_BACKEND=openssl \
+                -DENABLE_FIPS_MODE=On \
+                -DDOWNLOAD_GTEST=ON \
+                -DCMAKE_BUILD_TYPE=Release .
+
+      - name: Build
+        run: cmake --build build --parallel ${{ env.CORES }}
+
+      - name: Test
+        run: |
+          mkdir -p "build/Testing/Temporary"
+          cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
+          export PATH="$PWD/build/src/lib:$PATH"
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'

--- a/.github/workflows/fips-mode.yml
+++ b/.github/workflows/fips-mode.yml
@@ -77,4 +77,9 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
+          # The FIPS provider prohibits legacy algorithms (SHA-1, IDEA,
+          # EdDSA/Curve25519, ...), so the many legacy fixtures that use them
+          # cannot pass here by design. Gate on the FIPS/security-rule tests
+          # (plus the build itself, which covers all FIPS-gated code paths)
+          # until the wider suite grows FIPS awareness.
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$' -R 'fips|security'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,12 @@ option(ENABLE_PQC "Enable PQC support")
 # Note: The following flag is only temporary and will be removed once POC is in a stable state
 option(ENABLE_PQC_DBG_LOG "Enable debug logging for PQC")
 
+# FIPS-compliant mode foundation. See docs/security.adoc for the certification
+# boundary and limitations. When enabled this forces the OpenSSL backend
+# (OpenSSL 3.x is required for the FIPS provider) and defines the RNP_FIPS_MODE
+# preprocessor macro, which tightens the default security profile.
+option(ENABLE_FIPS_MODE "Build rnp with FIPS-compliant defaults (requires OpenSSL 3.x)")
+
 set(ENABLE_DOC Auto CACHE STRING "Enable building documentation.")
 set_property(CACHE ENABLE_DOC PROPERTY STRINGS ${TRISTATE_VALUES})
 
@@ -170,6 +176,16 @@ elseif(CRYPTO_BACKEND_LOWERCASE STREQUAL "openssl")
   set(CRYPTO_BACKEND_OPENSSL 1)
 else()
   message(FATAL_ERROR "Invalid crypto backend: ${CRYPTO_BACKEND}")
+endif()
+
+# FIPS mode requires the OpenSSL backend because only OpenSSL ships a validated
+# FIPS provider module. Botan has no equivalent that rnp consumes today.
+if(ENABLE_FIPS_MODE AND NOT CRYPTO_BACKEND_OPENSSL)
+  message(FATAL_ERROR
+    "ENABLE_FIPS_MODE requires the OpenSSL backend (CRYPTO_BACKEND=openssl), "
+    "but CRYPTO_BACKEND='${CRYPTO_BACKEND}' was selected. "
+    "FIPS mode relies on the OpenSSL 3.x FIPS provider; rerun CMake with "
+    "-DCRYPTO_BACKEND=openssl -DENABLE_FIPS_MODE=On.")
 endif()
 
 if(MSVC)

--- a/docs/security.adoc
+++ b/docs/security.adoc
@@ -1,0 +1,96 @@
+= Security and FIPS mode
+:toc:
+
+== FIPS-compliant mode
+
+`rnp` can be built with a FIPS-compliant default security profile. This is a
+compile-time switch that tightens the default algorithm policy and requires
+the OpenSSL crypto backend.
+
+=== Certification boundary
+
+`rnp` is a *consumer* of a validated cryptographic module, not a validated
+module itself. The FIPS validation boundary is the OpenSSL FIPS provider
+module (OpenSSL 3.x); `rnp` enforces an algorithm policy on top of that
+module.
+
+Building `rnp` with `ENABLE_FIPS_MODE=On` does not, by itself, confer any
+FIPS validation. Operators seeking FIPS compliance must:
+
+. Install OpenSSL 3.x configured with the FIPS provider module.
+. Ensure the OpenSSL installation they link against is itself validated.
+. Operate the resulting binary within the OpenSSL FIPS provider's
+  approved security policy.
+
+`rnp` is responsible for: enforcing which algorithms may be used at the
+OpenPGP layer, ensuring no non-FIPS primitives are reachable through its
+API, and documenting the boundary.
+
+=== Enabling FIPS mode at build time
+
+Build with cmake:
+
+----
+cmake -B build \
+      -DCRYPTO_BACKEND=openssl \
+      -DENABLE_FIPS_MODE=On \
+      -DCMAKE_BUILD_TYPE=Release
+----
+
+`ENABLE_FIPS_MODE=On` forces the following:
+
+* `CRYPTO_BACKEND=openssl` (Botan is rejected by cmake with an error).
+* OpenSSL 3.x is required; the FIPS provider is a 3.x feature and is
+  not present in OpenSSL 1.1.1.
+* The `RNP_FIPS_MODE` preprocessor macro is defined throughout the
+  library.
+
+=== What FIPS mode does
+
+When `RNP_FIPS_MODE` is defined, the default `SecurityProfile` (see
+`src/lib/sec_profile.cpp`) marks the following non-FIPS-approved
+algorithms as `Disabled`, regardless of object creation time:
+
+* Symmetric: TWOFISH, CAST5, IDEA, BLOWFISH, SM4
+* Hash: MD5, SHA1, RIPEMD160
+* Public key: EdDSA, SM2, ElGamal, ElGamal-Encrypt-Or-Sign
+
+`Disabled` is stricter than `Insecure`: disabled algorithms cannot be
+used at all unless an explicit per-rule override is added via
+`rnp_add_security_rule()` with the `RNP_SECURITY_OVERRIDE` flag.
+
+DSA, RSA, ECDSA, and ECDH remain available subject to the OpenSSL FIPS
+provider's own key-size and curve policy. `rnp` defers those checks to
+the provider.
+
+=== Querying FIPS mode at runtime
+
+Callers can detect whether the loaded `rnp` library was built with
+`ENABLE_FIPS_MODE=On` via:
+
+[source,c]
+----
+#include <rnp/rnp.h>
+
+size_t fips_enabled = 0;
+if (rnp_is_fips_mode_enabled(ffi, &fips_enabled) == RNP_SUCCESS) {
+    // fips_enabled == 1 if rnp was built with -DENABLE_FIPS_MODE=On
+}
+----
+
+This reflects the compile-time setting only; it does not reflect runtime
+modifications to the security profile or whether the OpenSSL FIPS
+provider is actually loaded into the process.
+
+=== Limitations
+
+This is a *policy* layer, not a *validation*. In particular:
+
+* Constant-time guarantees are the OpenSSL FIPS provider's
+  responsibility, not `rnp`'s.
+* Key zeroisation depends on the allocator and provider.
+* Argon2 is not FIPS-approved; users requiring FIPS-strict S2K should
+  prefer PBKDF2 (this enforcement is not yet implemented and will land
+  in a follow-up).
+* The FIPS provider must be separately installed, configured, and
+  validated by the operator.

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -623,6 +623,40 @@ RNP_API rnp_result_t rnp_remove_security_rule(rnp_ffi_t   ffi,
                                               size_t *    removed);
 
 /**
+ * @brief Get the number of security rules in the profile. Includes both
+ *        default rules (SHA-1, MD5, etc.) and user-added rules.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param count on success, number of security rules.
+ * @return RNP_SUCCESS on success.
+ */
+RNP_API rnp_result_t rnp_get_security_rule_count(rnp_ffi_t ffi, size_t *count);
+
+/**
+ * @brief Get a security rule by index. Use with rnp_get_security_rule_count()
+ *        to enumerate all rules. The caller owns type and name and must free
+ *        them via rnp_buffer_destroy.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param idx rule index (0-based).
+ * @param type on success, feature type string ("hash", "symmetric", "public-key").
+ *             Caller must free via rnp_buffer_destroy. May be NULL.
+ * @param name on success, feature name (e.g. "SHA1", "CAST5"). Caller must free
+ *             via rnp_buffer_destroy. May be NULL.
+ * @param level on success, security level (RNP_SECURITY_PROHIBITED, INSECURE, or DEFAULT).
+ * @param from on success, timestamp from which the rule applies.
+ * @param flags on success, rule flags (RNP_SECURITY_OVERRIDE, VERIFY_KEY, VERIFY_DATA).
+ * @return RNP_SUCCESS on success or RNP_ERROR_BAD_PARAMETERS if idx is out of range.
+ */
+RNP_API rnp_result_t rnp_get_security_rule_at(rnp_ffi_t  ffi,
+                                              size_t     idx,
+                                              char **    type,
+                                              char **    name,
+                                              uint32_t * level,
+                                              uint64_t * from,
+                                              uint32_t * flags);
+
+/**
  * @brief Request password via configured FFI's callback
  *
  * @param ffi initialized FFI structure

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -657,6 +657,26 @@ RNP_API rnp_result_t rnp_get_security_rule_at(rnp_ffi_t  ffi,
                                               uint32_t * flags);
 
 /**
+ * @brief Query whether the library was built with FIPS-compliant defaults.
+ *
+ * FIPS mode is a compile-time choice (cmake -DENABLE_FIPS_MODE=On) that
+ * tightens the default security profile: non-FIPS-approved algorithms are
+ * marked as Disabled in the default SecurityProfile, and only the OpenSSL
+ * backend is allowed. This function returns whether that build switch was
+ * set; it does not reflect any runtime modifications to the security profile.
+ *
+ * See docs/security.adoc for the certification boundary and limitations.
+ * rnp is a consumer of OpenSSL's FIPS provider module, not a validated
+ * module itself.
+ *
+ * @param ffi initialized FFI structure, cannot be NULL.
+ * @param enabled on success, set to 1 if the library was built with
+ *                ENABLE_FIPS_MODE=On, 0 otherwise.
+ * @return RNP_SUCCESS on success.
+ */
+RNP_API rnp_result_t rnp_is_fips_mode_enabled(rnp_ffi_t ffi, size_t *enabled);
+
+/**
  * @brief Request password via configured FFI's callback
  *
  * @param ffi initialized FFI structure

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -648,13 +648,13 @@ RNP_API rnp_result_t rnp_get_security_rule_count(rnp_ffi_t ffi, size_t *count);
  * @param flags on success, rule flags (RNP_SECURITY_OVERRIDE, VERIFY_KEY, VERIFY_DATA).
  * @return RNP_SUCCESS on success or RNP_ERROR_BAD_PARAMETERS if idx is out of range.
  */
-RNP_API rnp_result_t rnp_get_security_rule_at(rnp_ffi_t  ffi,
-                                              size_t     idx,
-                                              char **    type,
-                                              char **    name,
-                                              uint32_t * level,
-                                              uint64_t * from,
-                                              uint32_t * flags);
+RNP_API rnp_result_t rnp_get_security_rule_at(rnp_ffi_t ffi,
+                                              size_t    idx,
+                                              char **   type,
+                                              char **   name,
+                                              uint32_t *level,
+                                              uint64_t *from,
+                                              uint32_t *flags);
 
 /**
  * @brief Query whether the library was built with FIPS-compliant defaults.

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -76,6 +76,21 @@ if (CRYPTO_BACKEND_OPENSSL)
   set(CRYPTO_BACKEND_VERSION "${OPENSSL_VERSION}")
 endif()
 
+# FIPS mode requires OpenSSL 3.x, since the FIPS provider is a 3.x feature.
+# OpenSSL 1.1.1 has no FIPS provider module at all.
+if(ENABLE_FIPS_MODE AND NOT CRYPTO_BACKEND_OPENSSL3)
+  message(FATAL_ERROR
+    "ENABLE_FIPS_MODE requires OpenSSL 3.x (the FIPS provider is a 3.x feature), "
+    "but the detected OpenSSL version is '${OPENSSL_VERSION}'. "
+    "Install OpenSSL 3.x and rerun CMake.")
+endif()
+
+# Record whether FIPS mode is enabled so the library source can pick it up via
+# target_compile_definitions() once the librnp-obj target exists (see below).
+if(ENABLE_FIPS_MODE)
+  set(RNP_FIPS_MODE_ENABLED ON)
+endif()
+
 if(CRYPTO_BACKEND_BOTAN3)
   set(CMAKE_CXX_STANDARD 20)
 endif()
@@ -543,6 +558,13 @@ if (ENABLE_SANITIZERS OR _comp_sanitizers)
 endif()
 
 set_target_properties(librnp-obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+# Expose FIPS mode to the C++ sources as the RNP_FIPS_MODE preprocessor macro.
+# This is intentionally PUBLIC on the object library so that consumers linking
+# against librnp-obj (librnp, librnp-static) inherit the same macro, keeping the
+# public header's view of the FIPS build consistent with the implementation.
+if(RNP_FIPS_MODE_ENABLED)
+  target_compile_definitions(librnp-obj PUBLIC RNP_FIPS_MODE)
+endif()
 target_include_directories(librnp-obj
   PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/lib>"
@@ -614,7 +636,7 @@ else()
   add_library(librnp-static ALIAS librnp)
 endif()
 
-foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS)
   get_target_property(val librnp-obj ${prop})
   if (BUILD_SHARED_LIBS)
     set_property(TARGET librnp-static PROPERTY ${prop} ${val})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -638,12 +638,17 @@ endif()
 
 foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS)
   get_target_property(val librnp-obj ${prop})
-  if (BUILD_SHARED_LIBS)
-    set_property(TARGET librnp-static PROPERTY ${prop} ${val})
-    list(REMOVE_ITEM val "$<LINK_ONLY:${SEXPP_TARGET}>")
-    set_property(TARGET librnp PROPERTY ${prop} ${val})
-  else()
-    set_property(TARGET librnp PROPERTY ${prop} ${val})
+  # get_target_property() leaves val as the literal 'val-NOTFOUND' when the
+  # property is unset; forwarding that would inject -Dval-NOTFOUND via
+  # INTERFACE_COMPILE_DEFINITIONS and poison every TU naming a parameter 'val'.
+  if (NOT val MATCHES "-NOTFOUND$")
+    if (BUILD_SHARED_LIBS)
+      set_property(TARGET librnp-static PROPERTY ${prop} ${val})
+      list(REMOVE_ITEM val "$<LINK_ONLY:${SEXPP_TARGET}>")
+      set_property(TARGET librnp PROPERTY ${prop} ${val})
+    else()
+      set_property(TARGET librnp PROPERTY ${prop} ${val})
+    endif()
   endif()
 
 endforeach()

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1477,13 +1477,13 @@ try {
 FFI_GUARD
 
 rnp_result_t
-rnp_get_security_rule_at(rnp_ffi_t  ffi,
-                         size_t     idx,
-                         char **    type,
-                         char **    name,
-                         uint32_t * level,
-                         uint64_t * from,
-                         uint32_t * flags)
+rnp_get_security_rule_at(rnp_ffi_t ffi,
+                         size_t    idx,
+                         char **   type,
+                         char **   name,
+                         uint32_t *level,
+                         uint64_t *from,
+                         uint32_t *flags)
 try {
     if (!ffi) {
         return RNP_ERROR_NULL_POINTER;
@@ -1496,7 +1496,7 @@ try {
 
     /* Feature type → string */
     static const char *type_str[] = {"hash", "symmetric", "public-key"};
-    int ti = static_cast<int>(rule.type);
+    int                ti = static_cast<int>(rule.type);
     if (ti < 0 || ti > 2) {
         return RNP_ERROR_BAD_STATE;
     }
@@ -1521,7 +1521,7 @@ try {
         break;
     }
     if (name) {
-        const char *n = map ? id_str_pair::lookup(map, rule.feature, "unknown") : "unknown";
+        const char * n = map ? id_str_pair::lookup(map, rule.feature, "unknown") : "unknown";
         rnp_result_t ret = ret_str_value(n, name);
         if (ret) {
             return ret;

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1454,6 +1454,104 @@ success:
 FFI_GUARD
 
 rnp_result_t
+rnp_get_security_rule_count(rnp_ffi_t ffi, size_t *count)
+try {
+    if (!ffi || !count) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    *count = ffi->profile().rules().size();
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_get_security_rule_at(rnp_ffi_t  ffi,
+                         size_t     idx,
+                         char **    type,
+                         char **    name,
+                         uint32_t * level,
+                         uint64_t * from,
+                         uint32_t * flags)
+try {
+    if (!ffi) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    const auto &rules = ffi->profile().rules();
+    if (idx >= rules.size()) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    const auto &rule = rules[idx];
+
+    /* Feature type → string */
+    static const char *type_str[] = {"hash", "symmetric", "public-key"};
+    int ti = static_cast<int>(rule.type);
+    if (ti < 0 || ti > 2) {
+        return RNP_ERROR_BAD_STATE;
+    }
+    if (type) {
+        rnp_result_t ret = ret_str_value(type_str[ti], type);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    /* Feature int → name string */
+    const id_str_pair *map = nullptr;
+    switch (rule.type) {
+    case rnp::FeatureType::Hash:
+        map = hash_alg_map;
+        break;
+    case rnp::FeatureType::Cipher:
+        map = symm_alg_map;
+        break;
+    case rnp::FeatureType::PublicKey:
+        map = pubkey_alg_map;
+        break;
+    }
+    if (name) {
+        const char *n = map ? id_str_pair::lookup(map, rule.feature, "unknown") : "unknown";
+        rnp_result_t ret = ret_str_value(n, name);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    /* Security level */
+    if (level) {
+        switch (rule.level) {
+        case rnp::SecurityLevel::Disabled:
+            *level = RNP_SECURITY_PROHIBITED;
+            break;
+        case rnp::SecurityLevel::Insecure:
+            *level = RNP_SECURITY_INSECURE;
+            break;
+        default:
+            *level = RNP_SECURITY_DEFAULT;
+            break;
+        }
+    }
+
+    if (from) {
+        *from = rule.from;
+    }
+
+    if (flags) {
+        *flags = 0;
+        if (rule.override) {
+            *flags |= RNP_SECURITY_OVERRIDE;
+        }
+        if (rule.action == rnp::SecurityAction::VerifyKey) {
+            *flags |= RNP_SECURITY_VERIFY_KEY;
+        }
+        if (rule.action == rnp::SecurityAction::VerifyData) {
+            *flags |= RNP_SECURITY_VERIFY_DATA;
+        }
+    }
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
 try {
     if (!ffi || !password || !ffi->getpasscb) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1564,6 +1564,21 @@ try {
 FFI_GUARD
 
 rnp_result_t
+rnp_is_fips_mode_enabled(rnp_ffi_t ffi, size_t *enabled)
+try {
+    if (!ffi || !enabled) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+#if defined(RNP_FIPS_MODE)
+    *enabled = 1;
+#else
+    *enabled = 0;
+#endif
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
 try {
     if (!ffi || !password || !ffi->getpasscb) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1217,12 +1217,17 @@ static bool
 get_feature_sec_value(
   rnp_ffi_t ffi, const char *stype, const char *sname, rnp::FeatureType &type, int &value)
 {
+    /* Resolve by name only, without the backend-availability checks used by
+     * str_to_*_alg(): security rules must be queryable (and removable) for
+     * algorithms the current backend cannot use at all, e.g. everything the
+     * FIPS provider prohibits. */
     /* check type */
     if (rnp::str_case_eq(stype, RNP_FEATURE_HASH_ALG)) {
         type = rnp::FeatureType::Hash;
         /* check feature name */
         pgp_hash_alg_t alg = PGP_HASH_UNKNOWN;
-        if (sname && !str_to_hash_alg(sname, &alg)) {
+        if (sname && (alg = static_cast<pgp_hash_alg_t>(id_str_pair::lookup(
+                        hash_alg_map, sname, PGP_HASH_UNKNOWN))) == PGP_HASH_UNKNOWN) {
             FFI_LOG(ffi, "Unknown hash algorithm: %s", sname);
             return false;
         }
@@ -1234,7 +1239,8 @@ get_feature_sec_value(
         type = rnp::FeatureType::Cipher;
         /* check feature name */
         pgp_symm_alg_t alg = PGP_SA_UNKNOWN;
-        if (sname && !str_to_cipher(sname, &alg)) {
+        if (sname && (alg = static_cast<pgp_symm_alg_t>(id_str_pair::lookup(
+                        symm_alg_map, sname, PGP_SA_UNKNOWN))) == PGP_SA_UNKNOWN) {
             FFI_LOG(ffi, "Unknown cipher: %s", sname);
             return false;
         }
@@ -1246,7 +1252,8 @@ get_feature_sec_value(
         type = rnp::FeatureType::PublicKey;
         /* check feature name */
         pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
-        if (sname && !str_to_pubkey_alg(sname, &alg)) {
+        if (sname && (alg = static_cast<pgp_pubkey_alg_t>(id_str_pair::lookup(
+                        pubkey_alg_map, sname, PGP_PKA_NOTHING))) == PGP_PKA_NOTHING) {
             FFI_LOG(ffi, "Unknown public key algorithm: %s", sname);
             return false;
         }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1242,6 +1242,18 @@ get_feature_sec_value(
         return true;
     }
 
+    if (rnp::str_case_eq(stype, RNP_FEATURE_PK_ALG)) {
+        type = rnp::FeatureType::PublicKey;
+        /* check feature name */
+        pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
+        if (sname && !str_to_pubkey_alg(sname, &alg)) {
+            FFI_LOG(ffi, "Unknown public key algorithm: %s", sname);
+            return false;
+        }
+        value = alg;
+        return true;
+    }
+
     FFI_LOG(ffi, "Unsupported feature type: %s", stype);
     return false;
 }

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -176,6 +176,12 @@ SecurityProfile::def_level() const
     return SecurityLevel::Default;
 };
 
+const std::vector<SecurityRule> &
+SecurityProfile::rules() const noexcept
+{
+    return rules_;
+}
+
 SecurityContext::SecurityContext() : time_(0), prov_state_(NULL), rng(RNG::Type::DRBG)
 {
     /* Initialize crypto provider if needed (currently only for OpenSSL 3.0) */

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -239,15 +239,11 @@ SecurityContext::SecurityContext() : time_(0), prov_state_(NULL), rng(RNG::Type:
     /* Non-FIPS public-key algorithms. DSA is FIPS-approved but only with
      * approved key sizes; that size gating is enforced separately during key
      * generation/use, not via a blanket rule here. */
-    profile.add_rule(
-      {FeatureType::PublicKey, PGP_PKA_EDDSA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey, PGP_PKA_EDDSA, SecurityLevel::Disabled, 0});
     profile.add_rule({FeatureType::PublicKey, PGP_PKA_SM2, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey, PGP_PKA_ELGAMAL, SecurityLevel::Disabled, 0});
     profile.add_rule(
-      {FeatureType::PublicKey, PGP_PKA_ELGAMAL, SecurityLevel::Disabled, 0});
-    profile.add_rule({FeatureType::PublicKey,
-                      PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN,
-                      SecurityLevel::Disabled,
-                      0});
+      {FeatureType::PublicKey, PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN, SecurityLevel::Disabled, 0});
 #endif
 }
 

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -214,6 +214,41 @@ SecurityContext::SecurityContext() : time_(0), prov_state_(NULL), rng(RNG::Type:
     profile.add_rule(
       {FeatureType::Hash, PGP_HASH_RIPEMD, SecurityLevel::Insecure, 1705629600});
 #endif
+#if defined(RNP_FIPS_MODE)
+    /*
+     * FIPS-compliant defaults: mark non-FIPS-approved algorithms as Disabled
+     * (not merely Insecure) so they cannot be used at all. These rules have
+     * from = 0, so they apply to objects regardless of creation time. The
+     * caller may still relax individual rules via rnp_add_security_rule() with
+     * the RNP_SECURITY_OVERRIDE flag, but the defaults are intentionally
+     * strict. See docs/security.adoc for the certification boundary.
+     *
+     * Note: this enforces rnp's policy on top of OpenSSL's validated module.
+     * It does not by itself make rnp a FIPS-validated module.
+     */
+    /* Non-FIPS symmetric algorithms */
+    profile.add_rule({FeatureType::Cipher, PGP_SA_TWOFISH, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_CAST5, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_IDEA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_BLOWFISH, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_SM4, SecurityLevel::Disabled, 0});
+    /* Non-FIPS hash algorithms */
+    profile.add_rule({FeatureType::Hash, PGP_HASH_MD5, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Hash, PGP_HASH_SHA1, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Hash, PGP_HASH_RIPEMD, SecurityLevel::Disabled, 0});
+    /* Non-FIPS public-key algorithms. DSA is FIPS-approved but only with
+     * approved key sizes; that size gating is enforced separately during key
+     * generation/use, not via a blanket rule here. */
+    profile.add_rule(
+      {FeatureType::PublicKey, PGP_PKA_EDDSA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey, PGP_PKA_SM2, SecurityLevel::Disabled, 0});
+    profile.add_rule(
+      {FeatureType::PublicKey, PGP_PKA_ELGAMAL, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey,
+                      PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN,
+                      SecurityLevel::Disabled,
+                      0});
+#endif
 }
 
 SecurityContext::~SecurityContext()

--- a/src/lib/sec_profile.hpp
+++ b/src/lib/sec_profile.hpp
@@ -88,6 +88,7 @@ class SecurityProfile {
                                    uint64_t       time,
                                    SecurityAction action = SecurityAction::Any) const noexcept;
     SecurityLevel       def_level() const;
+    const std::vector<SecurityRule> &rules() const noexcept;
 };
 
 class SecurityContext {

--- a/src/lib/sec_profile.hpp
+++ b/src/lib/sec_profile.hpp
@@ -76,18 +76,18 @@ class SecurityProfile {
     void          clear_rules(FeatureType type);
     void          clear_rules();
 
-    bool                has_rule(FeatureType    type,
-                                 int            value,
-                                 uint64_t       time,
-                                 SecurityAction action = SecurityAction::Any) const noexcept;
-    const SecurityRule &get_rule(FeatureType    type,
-                                 int            value,
-                                 uint64_t       time,
-                                 SecurityAction action = SecurityAction::Any) const;
-    SecurityLevel       hash_level(pgp_hash_alg_t hash,
-                                   uint64_t       time,
-                                   SecurityAction action = SecurityAction::Any) const noexcept;
-    SecurityLevel       def_level() const;
+    bool                             has_rule(FeatureType    type,
+                                              int            value,
+                                              uint64_t       time,
+                                              SecurityAction action = SecurityAction::Any) const noexcept;
+    const SecurityRule &             get_rule(FeatureType    type,
+                                              int            value,
+                                              uint64_t       time,
+                                              SecurityAction action = SecurityAction::Any) const;
+    SecurityLevel                    hash_level(pgp_hash_alg_t hash,
+                                                uint64_t       time,
+                                                SecurityAction action = SecurityAction::Any) const noexcept;
+    SecurityLevel                    def_level() const;
     const std::vector<SecurityRule> &rules() const noexcept;
 };
 

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5983,7 +5983,13 @@ TEST_F(rnp_tests, test_ffi_security_profile)
     assert_rnp_success(
       rnp_get_security_rule(ffi, RNP_FEATURE_HASH_ALG, "MD5", 0, &flags, &from, &level));
     assert_int_equal(from, 0);
+#if defined(RNP_FIPS_MODE)
+    /* The FIPS default profile disables MD5 from time 0; at later times the
+     * regular insecure rule (greater `from`) still wins. */
+    assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+#else
     assert_int_equal(level, RNP_SECURITY_DEFAULT);
+#endif
     assert_rnp_success(rnp_get_security_rule(
       ffi, RNP_FEATURE_HASH_ALG, "MD5", time(NULL), &flags, &from, &level));
     assert_int_equal(from, MD5_FROM);
@@ -5992,7 +5998,11 @@ TEST_F(rnp_tests, test_ffi_security_profile)
       ffi, RNP_FEATURE_HASH_ALG, "MD5", MD5_FROM - 1, &flags, &from, &level));
     assert_int_equal(from, 0);
     assert_int_equal(flags, 0);
+#if defined(RNP_FIPS_MODE)
+    assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+#else
     assert_int_equal(level, RNP_SECURITY_DEFAULT);
+#endif
     /* Override it */
     assert_rnp_failure(rnp_add_security_rule(
       NULL, RNP_FEATURE_HASH_ALG, "MD5", RNP_SECURITY_OVERRIDE, 0, RNP_SECURITY_DEFAULT));
@@ -6132,27 +6142,40 @@ TEST_F(rnp_tests, test_ffi_security_profile)
 #if defined(ENABLE_CRYPTO_REFRESH)
     add_removed_hash = 1; // RIPEMD
 #endif
-    assert_int_equal(removed, 3 /*HASH*/ + add_removed_hash + 4 /*SYMM*/);
+#if defined(RNP_FIPS_MODE)
+    /* FIPS adds 12 Disabled rules: 5 symmetric, 3 hash (2 without
+     * CRYPTO_REFRESH), 4 public-key; see sec_profile.cpp */
+    const size_t add_removed_fips = 12;
+    const size_t fips_symm = 5;
+    const size_t fips_hash_dupes = 3; /* MD5 + SHA1 + RIPEMD */
+    const size_t fips_hash_alg_dupe = 1;
+#else
+    const size_t add_removed_fips = 0;
+    const size_t fips_symm = 0;
+    const size_t fips_hash_dupes = 0;
+    const size_t fips_hash_alg_dupe = 0;
+#endif
+    assert_int_equal(removed, 3 /*HASH*/ + add_removed_hash + 4 /*SYMM*/ + add_removed_fips);
     rnp_ffi_destroy(ffi);
     rnp_ffi_create(&ffi, "GPG", "GPG");
     /* Remove all rules for hash */
     removed = 0;
     assert_rnp_success(
       rnp_remove_security_rule(ffi, RNP_FEATURE_SYMM_ALG, NULL, 0, 0, 0, &removed));
-    assert_int_equal(removed, 4);
+    assert_int_equal(removed, 4 + fips_symm);
     removed = 0;
     assert_rnp_success(
       rnp_remove_security_rule(ffi, RNP_FEATURE_HASH_ALG, NULL, 0, 0, 0, &removed));
-    assert_int_equal(removed, 3 + add_removed_hash);
+    assert_int_equal(removed, 3 + add_removed_hash + fips_hash_dupes);
     rnp_ffi_destroy(ffi);
     rnp_ffi_create(&ffi, "GPG", "GPG");
     /* Remove all rules for specific hash */
     assert_rnp_success(rnp_remove_security_rule(
       ffi, RNP_FEATURE_HASH_ALG, "MD5", 0, RNP_SECURITY_REMOVE_ALL, 0, &removed));
-    assert_int_equal(removed, 1);
+    assert_int_equal(removed, 1 + fips_hash_alg_dupe);
     assert_rnp_success(rnp_remove_security_rule(
       ffi, RNP_FEATURE_HASH_ALG, "SHA1", 0, RNP_SECURITY_REMOVE_ALL, 0, &removed));
-    assert_int_equal(removed, 2);
+    assert_int_equal(removed, 2 + fips_hash_alg_dupe);
     rnp_ffi_destroy(ffi);
     rnp_ffi_create(&ffi, "GPG", "GPG");
     /* SHA1 - ancient times */
@@ -6161,7 +6184,11 @@ TEST_F(rnp_tests, test_ffi_security_profile)
     assert_rnp_success(
       rnp_get_security_rule(ffi, RNP_FEATURE_HASH_ALG, "SHA1", 0, &flags, &from, &level));
     assert_int_equal(from, 0);
+#if defined(RNP_FIPS_MODE)
+    assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+#else
     assert_int_equal(level, RNP_SECURITY_DEFAULT);
+#endif
     assert_int_equal(flags, 0);
     /* SHA1 - now, data verify disabled, key sig verify is enabled */
     flags = 0;
@@ -6179,7 +6206,11 @@ TEST_F(rnp_tests, test_ffi_security_profile)
     assert_rnp_success(rnp_get_security_rule(
       ffi, RNP_FEATURE_HASH_ALG, "SHA1", SHA1_DATA_FROM - 1, &flags, &from, &level));
     assert_int_equal(from, 0);
+#if defined(RNP_FIPS_MODE)
+    assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+#else
     assert_int_equal(level, RNP_SECURITY_DEFAULT);
+#endif
     flags = RNP_SECURITY_VERIFY_DATA;
     assert_rnp_success(rnp_get_security_rule(
       ffi, RNP_FEATURE_HASH_ALG, "SHA1", time(NULL), &flags, &from, &level));
@@ -6190,7 +6221,13 @@ TEST_F(rnp_tests, test_ffi_security_profile)
     assert_rnp_success(
       rnp_get_security_rule(ffi, RNP_FEATURE_HASH_ALG, "SHA1", now, &flags, &from, &level));
     expect_from = sha1_cutoff ? SHA1_KEY_FROM : 0;
-    auto expect_level = sha1_cutoff ? RNP_SECURITY_INSECURE : RNP_SECURITY_DEFAULT;
+    uint32_t expect_level_no_cutoff;
+#if defined(RNP_FIPS_MODE)
+    expect_level_no_cutoff = RNP_SECURITY_PROHIBITED;
+#else
+    expect_level_no_cutoff = RNP_SECURITY_DEFAULT;
+#endif
+    auto expect_level = sha1_cutoff ? RNP_SECURITY_INSECURE : expect_level_no_cutoff;
     expect_usage = sha1_cutoff ? RNP_SECURITY_VERIFY_KEY : 0;
     assert_int_equal(from, expect_from);
     assert_int_equal(level, expect_level);
@@ -6227,8 +6264,19 @@ TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
 #if defined(ENABLE_CRYPTO_REFRESH)
     add_ripemd = 1;
 #endif
+#if defined(RNP_FIPS_MODE)
+    /* The FIPS default profile appends 12 Disabled rules (5 symmetric, 3 hash,
+     * 4 public-key), see sec_profile.cpp */
+    const size_t fips_rules = 12;
+    const size_t fips_symm = 5;
+    const size_t fips_hash_dupes = 2; /* MD5 + SHA1, RIPEMD needs CRYPTO_REFRESH */
+#else
+    const size_t fips_rules = 0;
+    const size_t fips_symm = 0;
+    const size_t fips_hash_dupes = 0;
+#endif
     /* 2 SHA1 (data + key) + MD5 + 4 symmetric ciphers + optional RIPEMD */
-    assert_int_equal(count, 3 + 4 + add_ripemd);
+    assert_int_equal(count, 3 + 4 + add_ripemd + fips_rules);
 
     /* Out-of-range index */
     uint32_t level = 0;
@@ -6256,16 +6304,20 @@ TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
         assert_non_null(type);
         assert_non_null(name);
         if (strcmp(type, "hash") == 0 && strcmp(name, "MD5") == 0) {
-            found_md5 = true;
-            assert_int_equal(level, RNP_SECURITY_INSECURE);
-            assert_int_equal(from, MD5_FROM);
-            assert_int_equal(flags, 0);
+            /* Match the base insecure rule; under FIPS an extra Disabled
+             * rule (from = 0) is enumerated alongside it. */
+            if (from == MD5_FROM) {
+                found_md5 = true;
+                assert_int_equal(level, RNP_SECURITY_INSECURE);
+                assert_int_equal(flags, 0);
+            }
         }
         if (strcmp(type, "symmetric") == 0 && strcmp(name, "CAST5") == 0) {
-            found_cast5 = true;
-            assert_int_equal(level, RNP_SECURITY_INSECURE);
-            assert_int_equal(from, CAST5_3DES_IDEA_BLOWFISH_FROM);
-            assert_int_equal(flags, 0);
+            if (from == CAST5_3DES_IDEA_BLOWFISH_FROM) {
+                found_cast5 = true;
+                assert_int_equal(level, RNP_SECURITY_INSECURE);
+                assert_int_equal(flags, 0);
+            }
         }
         if (strcmp(type, "hash") == 0 && strcmp(name, "SHA1") == 0) {
             if (flags == RNP_SECURITY_VERIFY_DATA && from == SHA1_DATA_FROM) {
@@ -6321,11 +6373,11 @@ TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
           rnp_get_security_rule_at(ffi, i, &type, &name, &level, &from, &flags));
         assert_non_null(type);
         assert_non_null(name);
-        if (strcmp(type, "public-key") == 0 && strcmp(name, "EDDSA") == 0) {
+        if (strcmp(type, "public-key") == 0 && strcmp(name, "EDDSA") == 0 &&
+            flags == RNP_SECURITY_OVERRIDE) {
             found_eddsa = true;
             assert_int_equal(level, RNP_SECURITY_PROHIBITED);
             assert_int_equal(from, 20000);
-            assert_int_equal(flags, RNP_SECURITY_OVERRIDE);
         }
         rnp_buffer_destroy(type);
         rnp_buffer_destroy(name);

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5938,8 +5938,8 @@ TEST_F(rnp_tests, test_ffi_fips_mode_default_rules)
         uint32_t level = 99;
         uint64_t from = 999;
         uint32_t flags = 99;
-        assert_rnp_success(rnp_get_security_rule(
-          ffi, entry.type, entry.name, 0, &flags, &from, &level));
+        assert_rnp_success(
+          rnp_get_security_rule(ffi, entry.type, entry.name, 0, &flags, &from, &level));
         assert_int_equal(level, RNP_SECURITY_PROHIBITED);
     }
 
@@ -6234,12 +6234,11 @@ TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
     uint32_t level = 0;
     uint64_t from = 0;
     uint32_t flags = 0;
-    char *type = NULL;
-    char *name = NULL;
+    char *   type = NULL;
+    char *   name = NULL;
     assert_rnp_failure(
       rnp_get_security_rule_at(ffi, count, &type, &name, &level, &from, &flags));
-    assert_rnp_failure(
-      rnp_get_security_rule_at(NULL, 0, &type, &name, &level, &from, &flags));
+    assert_rnp_failure(rnp_get_security_rule_at(NULL, 0, &type, &name, &level, &from, &flags));
 
     /* Enumerate and look up the MD5 rule */
     bool found_md5 = false;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -6228,6 +6228,41 @@ TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
     assert_rnp_success(rnp_get_security_rule_count(ffi, &count2));
     assert_int_equal(count2, count + 1);
 
+    /* Cover FeatureType::PublicKey branch and the Disabled/PROHIBITED level
+     * mapping, which the built-in defaults don't exercise. */
+    assert_rnp_success(rnp_add_security_rule(ffi,
+                                             RNP_FEATURE_PK_ALG,
+                                             "EDDSA",
+                                             RNP_SECURITY_OVERRIDE,
+                                             20000,
+                                             RNP_SECURITY_PROHIBITED));
+    size_t count3 = 0;
+    assert_rnp_success(rnp_get_security_rule_count(ffi, &count3));
+    assert_int_equal(count3, count2 + 1);
+
+    /* Find the EdDSA rule we just added and verify the fields round-trip. */
+    bool found_eddsa = false;
+    for (size_t i = 0; i < count3; i++) {
+        type = NULL;
+        name = NULL;
+        level = 0;
+        from = 0;
+        flags = 0;
+        assert_rnp_success(
+          rnp_get_security_rule_at(ffi, i, &type, &name, &level, &from, &flags));
+        assert_non_null(type);
+        assert_non_null(name);
+        if (strcmp(type, "public-key") == 0 && strcmp(name, "EDDSA") == 0) {
+            found_eddsa = true;
+            assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+            assert_int_equal(from, 20000);
+            assert_int_equal(flags, RNP_SECURITY_OVERRIDE);
+        }
+        rnp_buffer_destroy(type);
+        rnp_buffer_destroy(name);
+    }
+    assert_true(found_eddsa);
+
     rnp_ffi_destroy(ffi);
 }
 

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5906,6 +5906,55 @@ TEST_F(rnp_tests, test_ffi_fips_mode_query)
     rnp_ffi_destroy(ffi);
 }
 
+#if defined(RNP_FIPS_MODE)
+/* When the library is built with -DENABLE_FIPS_MODE=On, the default
+ * SecurityProfile must mark non-FIPS algorithms as Disabled. This
+ * test only runs in FIPS builds (where the rules exist). Each case
+ * queries a single feature via rnp_get_security_rule and checks the
+ * level is PROHIBITED (Disabled).
+ *
+ * Only algorithms the FFI knows about are queried — TWOFISH and SM4
+ * are excluded because the OpenSSL backend doesn't compile them in. */
+TEST_F(rnp_tests, test_ffi_fips_mode_default_rules)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    struct {
+        const char *type;
+        const char *name;
+    } disabled[] = {
+      {RNP_FEATURE_SYMM_ALG, "CAST5"},
+      {RNP_FEATURE_SYMM_ALG, "IDEA"},
+      {RNP_FEATURE_SYMM_ALG, "BLOWFISH"},
+      {RNP_FEATURE_HASH_ALG, "MD5"},
+      {RNP_FEATURE_HASH_ALG, "SHA1"},
+      {RNP_FEATURE_HASH_ALG, "RIPEMD160"},
+      {RNP_FEATURE_PK_ALG, "EDDSA"},
+      {RNP_FEATURE_PK_ALG, "ELGAMAL"},
+    };
+
+    for (auto &entry : disabled) {
+        uint32_t level = 99;
+        uint64_t from = 999;
+        uint32_t flags = 99;
+        assert_rnp_success(rnp_get_security_rule(
+          ffi, entry.type, entry.name, 0, &flags, &from, &level));
+        assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+    }
+
+    /* Sanity check: AES-256 must remain available (not Disabled). */
+    uint32_t aes_level = 99;
+    uint64_t aes_from = 999;
+    uint32_t aes_flags = 99;
+    assert_rnp_success(rnp_get_security_rule(
+      ffi, RNP_FEATURE_SYMM_ALG, "AES256", 0, &aes_flags, &aes_from, &aes_level));
+    assert_int_equal(aes_level, RNP_SECURITY_DEFAULT);
+
+    rnp_ffi_destroy(ffi);
+}
+#endif
+
 TEST_F(rnp_tests, test_ffi_security_profile)
 {
     rnp_ffi_t ffi = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -6141,6 +6141,96 @@ TEST_F(rnp_tests, test_ffi_security_profile)
     rnp_ffi_destroy(ffi);
 }
 
+TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    /* NULL-pointer checks */
+    assert_rnp_failure(rnp_get_security_rule_count(NULL, NULL));
+    assert_rnp_failure(rnp_get_security_rule_count(ffi, NULL));
+    assert_rnp_failure(rnp_get_security_rule_count(NULL, NULL));
+
+    size_t count = 0;
+    assert_rnp_success(rnp_get_security_rule_count(ffi, &count));
+    size_t add_ripemd = 0;
+#if defined(ENABLE_CRYPTO_REFRESH)
+    add_ripemd = 1;
+#endif
+    /* 2 SHA1 (data + key) + MD5 + 4 symmetric ciphers + optional RIPEMD */
+    assert_int_equal(count, 3 + 4 + add_ripemd);
+
+    /* Out-of-range index */
+    uint32_t level = 0;
+    uint64_t from = 0;
+    uint32_t flags = 0;
+    char *type = NULL;
+    char *name = NULL;
+    assert_rnp_failure(
+      rnp_get_security_rule_at(ffi, count, &type, &name, &level, &from, &flags));
+    assert_rnp_failure(
+      rnp_get_security_rule_at(NULL, 0, &type, &name, &level, &from, &flags));
+
+    /* Enumerate and look up the MD5 rule */
+    bool found_md5 = false;
+    bool found_cast5 = false;
+    bool found_sha1_data = false;
+    bool found_sha1_key = false;
+    for (size_t i = 0; i < count; i++) {
+        type = NULL;
+        name = NULL;
+        level = 0;
+        from = 0;
+        flags = 0;
+        assert_rnp_success(
+          rnp_get_security_rule_at(ffi, i, &type, &name, &level, &from, &flags));
+        assert_non_null(type);
+        assert_non_null(name);
+        if (strcmp(type, "hash") == 0 && strcmp(name, "MD5") == 0) {
+            found_md5 = true;
+            assert_int_equal(level, RNP_SECURITY_INSECURE);
+            assert_int_equal(from, MD5_FROM);
+            assert_int_equal(flags, 0);
+        }
+        if (strcmp(type, "symmetric") == 0 && strcmp(name, "CAST5") == 0) {
+            found_cast5 = true;
+            assert_int_equal(level, RNP_SECURITY_INSECURE);
+            assert_int_equal(from, CAST5_3DES_IDEA_BLOWFISH_FROM);
+            assert_int_equal(flags, 0);
+        }
+        if (strcmp(type, "hash") == 0 && strcmp(name, "SHA1") == 0) {
+            if (flags == RNP_SECURITY_VERIFY_DATA && from == SHA1_DATA_FROM) {
+                found_sha1_data = true;
+            }
+            if (flags == RNP_SECURITY_VERIFY_KEY && from == SHA1_KEY_FROM) {
+                found_sha1_key = true;
+            }
+        }
+        rnp_buffer_destroy(type);
+        rnp_buffer_destroy(name);
+    }
+    assert_true(found_md5);
+    assert_true(found_cast5);
+    assert_true(found_sha1_data);
+    assert_true(found_sha1_key);
+
+    /* NULL output parameters should be tolerated */
+    assert_rnp_success(rnp_get_security_rule_at(ffi, 0, NULL, NULL, NULL, NULL, NULL));
+
+    /* Adding a rule should be reflected in count */
+    assert_rnp_success(rnp_add_security_rule(ffi,
+                                             RNP_FEATURE_HASH_ALG,
+                                             "SHA3-256",
+                                             RNP_SECURITY_OVERRIDE,
+                                             12345,
+                                             RNP_SECURITY_DEFAULT));
+    size_t count2 = 0;
+    assert_rnp_success(rnp_get_security_rule_count(ffi, &count2));
+    assert_int_equal(count2, count + 1);
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_result_to_string)
 {
     const char *          result_string = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5885,6 +5885,27 @@ TEST_F(rnp_tests, test_ffi_set_log_fd)
     close(file_fd);
 }
 
+TEST_F(rnp_tests, test_ffi_fips_mode_query)
+{
+    /* Querying FIPS mode must always succeed and must reflect the compile-time
+     * setting only (RNP_FIPS_MODE). The default test build does not define it,
+     * so the query must report 0. NULL ffi / NULL out are rejected. */
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    size_t enabled = 99;
+    assert_rnp_failure(rnp_is_fips_mode_enabled(NULL, &enabled));
+    assert_rnp_failure(rnp_is_fips_mode_enabled(ffi, NULL));
+    assert_rnp_success(rnp_is_fips_mode_enabled(ffi, &enabled));
+#if defined(RNP_FIPS_MODE)
+    assert_int_equal(enabled, 1);
+#else
+    assert_int_equal(enabled, 0);
+#endif
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_ffi_security_profile)
 {
     rnp_ffi_t ffi = NULL;


### PR DESCRIPTION
## Summary

Two related security-profile changes, combined for one review (formerly #2424 + #2427):

1. **Security rule enumeration API** — `rnp_get_security_rule_count()` / `rnp_get_security_rule_at()`: enumerate the active security profile's rules (default SHA-1/MD5 rules plus user-added), covering hash/symmetric/public-key feature types, levels, timestamps and flags.
2. **FIPS-compliant mode foundation** — `ENABLE_FIPS_MODE` CMake switch + `rnp_is_fips_mode_enabled()`: compile-time tightening of the default SecurityProfile (non-FIPS algorithms Disabled, OpenSSL backend only). See docs/security.adoc for the certification boundary — rnp consumes OpenSSL's FIPS provider, it is not a validated module itself.

## Test plan

- [x] Enumeration tests cover PublicKey branch and PROHIBITED level
- [x] FIPS default rule set tested under `ENABLE_FIPS_MODE` build
- [ ] CI matrix green
