### PR TITLE
tests: exclude slow fuzz timeout regressions from per-PR CI

### DIFF
--- a/.github/workflows/centos-and-fedora.yml
+++ b/.github/workflows/centos-and-fedora.yml
@@ -222,6 +222,7 @@ jobs:
           else
             exec sudo -u rnpuser ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
           fi
+          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"
 
       - name: Coverage
         if: env.BUILD_MODE == 'coverage'

--- a/.github/workflows/centos-and-fedora.yml
+++ b/.github/workflows/centos-and-fedora.yml
@@ -178,7 +178,7 @@ jobs:
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
-          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"
 
       - name: Coverage
         if: env.BUILD_MODE == 'coverage'

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -130,7 +130,7 @@ jobs:
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
-          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"
 
       - name: Package
         run: cpack -G DEB -B debian --config build/CPackConfig.cmake

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -110,7 +110,7 @@ jobs:
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
-          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"
 
       - name: Package
         run: cpack -G DEB -B debian --config build/CPackConfig.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -159,7 +159,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure -E '_slow$'
 
       - name: Configure and build with botan-config.cmake
         if:  matrix.backend == 'botan3'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -153,7 +153,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure -E '_slow$'
 
       - name: Configure and build with botan-config.cmake
         if:  matrix.backend == 'botan3'

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -109,4 +109,4 @@ jobs:
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
-          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -105,4 +105,4 @@ jobs:
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
-          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"

--- a/.github/workflows/time-machine.yml
+++ b/.github/workflows/time-machine.yml
@@ -193,4 +193,4 @@ jobs:
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
           echo Running tests for "$(LD_PRELOAD=/usr/lib64/faketime/libfaketime.so.1 date)"
-          exec su rnpuser -c "LD_PRELOAD=/usr/lib64/faketime/libfaketime.so.1 ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "LD_PRELOAD=/usr/lib64/faketime/libfaketime.so.1 ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"

--- a/.github/workflows/time-machine.yml
+++ b/.github/workflows/time-machine.yml
@@ -219,4 +219,4 @@ jobs:
           export PATH="$PWD/build/src/lib:$PATH"
           chown -R rnpuser:rnpuser $PWD
           echo Running tests for "$(LD_PRELOAD=/usr/lib64/faketime/libfaketime.so.1 date)"
-          exec su rnpuser -c "LD_PRELOAD=/usr/lib64/faketime/libfaketime.so.1 ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure"
+          exec su rnpuser -c "LD_PRELOAD=/usr/lib64/faketime/libfaketime.so.1 ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -139,7 +139,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
 
   cmake-offline-googletest-src:
     runs-on: ubuntu-latest
@@ -174,7 +174,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
 
       - name: Check googletest
         run: |
@@ -220,7 +220,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
 
       - name: Check googletest
         run: |
@@ -292,7 +292,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build -R rnp_tests --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -R rnp_tests --output-on-failure -E '_slow$'
 
   package-source:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -117,7 +117,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
 
   cmake-offline-googletest-src:
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
 
       - name: Check googletest
         run: |
@@ -198,7 +198,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'
 
       - name: Check googletest
         run: |
@@ -270,7 +270,7 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
-          ctest --parallel ${{ env.CORES }} --test-dir build -R rnp_tests --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -R rnp_tests --output-on-failure -E '_slow$'
 
   package-source:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -139,7 +139,7 @@ jobs:
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           export PATH="$PWD/build/src/lib:$PATH"
           export RNP_LOG_CONSOLE=1
-          ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -C Debug --output-on-failure -E '_slow$'
 
       - name: Install
         run: cmake --install build

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -221,4 +221,4 @@ jobs:
           fi
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
-          ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure -E '_slow$'

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -240,6 +240,6 @@ jobs:
           fi
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
-          ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure
+          ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure -E '_slow$'
         # Windows 11 ARM is a preview runner; don't gate the build on it.
         continue-on-error: ${{ matrix.os == 'windows-11-arm' }}

--- a/src/tests/fuzz_keyimport.cpp
+++ b/src/tests/fuzz_keyimport.cpp
@@ -51,7 +51,13 @@ TEST_F(rnp_tests, test_fuzz_keyimport)
 
     data = file_to_vec(DATA_PATH "leak_371b211d7e9cf9857befcf06c7da74835e249ee7");
     assert_int_equal(keyimport_LLVMFuzzerTestOneInput(data.data(), data.size()), 0);
+}
 
-    data = file_to_vec(DATA_PATH "timeout-9c10372fe9ebdcdb0b6e275d05f8af4f4e3d6051");
+/* 182KB timeout-regression corpus from oss-fuzz. Split from test_fuzz_keyimport
+ * because it takes ~1 minute on slower CPUs. CI excludes *_slow tests on per-PR
+ * runs; see test_fuzz_keyring_slow for the same pattern. */
+TEST_F(rnp_tests, test_fuzz_keyimport_slow)
+{
+    auto data = file_to_vec(DATA_PATH "timeout-9c10372fe9ebdcdb0b6e275d05f8af4f4e3d6051");
     assert_int_equal(keyimport_LLVMFuzzerTestOneInput(data.data(), data.size()), 0);
 }

--- a/src/tests/fuzz_keyring.cpp
+++ b/src/tests/fuzz_keyring.cpp
@@ -48,7 +48,14 @@ TEST_F(rnp_tests, test_fuzz_keyring)
     /* Issue 25302 in oss-fuzz: rnp:fuzz_keyring: Direct-leak in Botan::HashFunction::create */
     data = file_to_vec(DATA_PATH "leak-5ee77f7ae99d7815d069afe037c42f4887193215");
     assert_int_equal(keyring_LLVMFuzzerTestOneInput(data.data(), data.size()), 0);
+}
 
-    data = file_to_vec(DATA_PATH "timeout-6140201111519232");
+/* Regression for oss-fuzz issue #46208: a 791KB corpus that previously timed out.
+ * Split from test_fuzz_keyring because it takes several minutes to load on slower
+ * CPUs. CI excludes *_slow tests on per-PR runs; run via ctest without the
+ * --gtest_filter=-*_slow exclusion on nightly schedules. */
+TEST_F(rnp_tests, test_fuzz_keyring_slow)
+{
+    auto data = file_to_vec(DATA_PATH "timeout-6140201111519232");
     assert_int_equal(keyring_LLVMFuzzerTestOneInput(data.data(), data.size()), 0);
 }


### PR DESCRIPTION
## Summary

- Splits `test_fuzz_keyring` and `test_fuzz_keyimport` into fast + `*_slow` variants. The slow variants contain only the oss-fuzz timeout-regression corpora that take minutes to load.
- Adds `-E '_slow$'` to every per-PR `ctest` invocation across all distro workflows so the slow tests are excluded from per-PR runs.
- The slow tests remain registered — they run under default `ctest` (nightly, manual dispatch, local full runs).

## Why

Profiled `rnp_tests` on macOS Botan: ~9.9 min total. Two tests dominated:

| Test | Time |
| --- | --- |
| `test_fuzz_keyring` | 273 s |
| `test_fuzz_keyimport` | 52 s |
| **Subtotal** | **325 s / 592 s** |

Both spend their time loading a single large oss-fuzz corpus file (`timeout-6140201111519232`, 791 KB; `timeout-9c10372fe9ebdcdb0b6e275d05f8af4f4e3d6051`, 182 KB). These are regression guards against previously-fixed timeout bugs — they're valuable but shouldn't gate every PR.

Excluding them drops per-PR `rnp_tests` runtime to ~4.5 min on this machine. The slow tests still pass when included.

## Test plan

- [x] Built and ran `rnp_tests` locally — both fast and slow variants pass
- [x] Verified `ctest -N -E '_slow$'` excludes exactly the two new `_slow` tests (285 → 283)
- [x] Verified `ctest -N -R '_slow$'` lists exactly the two new `_slow` tests (+ fixture)
- [ ] CI green on all platforms
