### PR TITLE
fuzzing: allow fuzz targets to build under the OpenSSL backend (#19)

### DIFF
--- a/.github/workflows/fuzzing-openssl.yml
+++ b/.github/workflows/fuzzing-openssl.yml
@@ -1,0 +1,102 @@
+name: fuzzing-openssl
+
+# Build the fuzz targets under the OpenSSL crypto backend and exercise them
+# against the existing corpus. oss-fuzz currently only covers the Botan
+# backend (see projects/rnp/build.sh in google/oss-fuzz), so this workflow
+# catches OpenSSL-specific link/build and dispatch bugs before they reach
+# oss-fuzz. See roadmap item #19 and issue rnpgp/rnp#1988.
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/fuzzing-openssl.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  fuzzing-openssl:
+    name: fuzzers (openssl, libfuzzer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install cmake libbz2-dev libjson-c-dev libssl-dev clang
+
+      - name: Configure
+        run: |
+          echo CORES="$(nproc --all)" >> $GITHUB_ENV
+          cmake -B build \
+                -DCRYPTO_BACKEND=openssl \
+                -DENABLE_FUZZERS=ON \
+                -DENABLE_SANITIZERS=OFF \
+                -DBUILD_SHARED_LIBS=ON \
+                -DBUILD_TESTING=OFF \
+                -DCMAKE_BUILD_TYPE=Release .
+
+      - name: Build fuzzers
+        run: cmake --build build --parallel ${{ env.CORES }} --target fuzz_dump fuzz_keyring fuzz_keyimport fuzz_sigimport fuzz_verify fuzz_verify_detached fuzz_keyring_kbx fuzz_keyring_g10
+
+      - name: Prepare corpus
+        run: |
+          mkdir -p corpus
+          find src/tests/data -type f -print0 | while IFS= read -r -d '' f; do
+            cp "$f" "corpus/$(sha256sum "$f" | cut -c1-16)"
+          done
+          echo "Corpus entries: $(find corpus -type f | wc -l)"
+
+      - name: Smoke-test fuzzers
+        run: |
+          set -e
+          export LD_LIBRARY_PATH="$PWD/build/src/lib:$LD_LIBRARY_PATH"
+          for fuzzer in fuzz_dump fuzz_keyring fuzz_keyimport fuzz_sigimport fuzz_verify fuzz_verify_detached fuzz_keyring_kbx fuzz_keyring_g10; do
+            bin="build/src/fuzzing/$fuzzer"
+            echo "== $fuzzer =="
+            # Run each fuzzer for a short window against the shared corpus.
+            # A non-zero exit indicates a crash; -max_len caps input size so
+            # the run finishes within the CI budget.
+            timeout 60 "$bin" corpus -runs=500 -max_len=4096 || \
+              code=$?
+            if [ "${code:-0}" = "124" ]; then
+              echo "$fuzzer: timed out after 60s (acceptable)"
+            elif [ -n "${code:-}" ] && [ "$code" != "0" ]; then
+              echo "$fuzzer: exited with $code"
+              exit "$code"
+            fi
+          done

--- a/src/fuzzing/CMakeLists.txt
+++ b/src/fuzzing/CMakeLists.txt
@@ -22,8 +22,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-find_package(Botan 2.14.0 REQUIRED)
-
+# Fuzz targets link against the librnp target that the top-level CMakeLists
+# has already configured for the selected CRYPTO_BACKEND (botan or openssl).
+# Only the g10 key-store fuzzer needs the static rnp target because it calls
+# into internal rnp::KeyStore APIs that are not exported from the shared
+# library; librnp-static carries the backend dependency on its own, so no
+# explicit Botan::Botan / OpenSSL::Crypto link is required here.
 if(NOT DEFINED ENV{LIB_FUZZING_ENGINE})
   add_compile_options(-fsanitize=fuzzer-no-link)
   add_link_options(-fsanitize=fuzzer)
@@ -139,7 +143,6 @@ target_include_directories(fuzz_keyring_g10
 target_link_libraries(fuzz_keyring_g10
   PRIVATE
     librnp-static
-    Botan::Botan
 )
 
 if (ENABLE_SANITIZERS)


### PR DESCRIPTION
## Summary

Implements roadmap item #19 (extend oss-fuzz coverage to the OpenSSL backend) and addresses issue #1988.

rnp supports two crypto backends, but the fuzz targets in `src/fuzzing/` only built against Botan because `CMakeLists.txt` hard-coded `find_package(Botan)` and linked `Botan::Botan` directly on `fuzz_keyring_g10`. oss-fuzz (in `google/oss-fuzz/projects/rnp/build.sh`) likewise only builds the Botan backend. This meant any bug introduced in the OpenSSL dispatch path could only be found by end users.

## What changed

### `src/fuzzing/CMakeLists.txt`
- Removed the unconditional `find_package(Botan 2.14.0 REQUIRED)` at the top of the file. The top-level `CMakeLists.txt` already configures the selected `CRYPTO_BACKEND` (botan or openssl) and attaches the right library to `librnp-obj`.
- Removed the redundant `Botan::Botan` direct link from `fuzz_keyring_g10`. The `librnp-static` target already carries the backend library via `INTERFACE_LINK_LIBRARIES` (see the propagation loop in `src/lib/CMakeLists.txt`), so the g10 fuzzer pulls in whichever backend CMake selected.

### `.github/workflows/fuzzing-openssl.yml` (new)
A self-contained CI job that:
1. Configures CMake with `-DCRYPTO_BACKEND=openssl -DENABLE_FUZZERS=ON` on ubuntu-latest using clang.
2. Builds all eight fuzz targets (`fuzz_dump`, `fuzz_keyring`, `fuzz_keyimport`, `fuzz_sigimport`, `fuzz_verify`, `fuzz_verify_detached`, `fuzz_keyring_kbx`, `fuzz_keyring_g10`).
3. Prepares a corpus from `src/tests/data/`.
4. Smoke-tests each fuzzer for 500 runs / 60s / 4096-byte inputs.

This catches OpenSSL-backend link/build regressions before they reach oss-fuzz.

## Local verification

CMake configure and link-line inspection were performed for **both** backends on macOS:

```
# OpenSSL backend
cmake -DCRYPTO_BACKEND=openssl -DENABLE_FUZZERS=ON ...
# fuzz_keyring_g10 link line correctly pulls in libcrypto.dylib, no Botan
# fuzz_dump link line correctly pulls in libcrypto.dylib via shared librnp

# Botan backend (no regression)
cmake -DCRYPTO_BACKEND=botan -DENABLE_FUZZERS=ON ...
# fuzz_keyring_g10 link line correctly pulls in libbotan-3.dylib
```

Full compilation was not possible locally because the Homebrew clang on this machine has a libc++ header search path issue and Apple clang lacks the libfuzzer runtime. The new CI workflow is what verifies the full build end-to-end.

## Downstream work (out of this repo)

The upstream `google/oss-fuzz/projects/rnp/build.sh` still hard-codes the Botan build. A separate PR to `google/oss-fuzz` is needed to:
- Build rnp a second time with `-DCRYPTO_BACKEND=openssl`.
- Emit OpenSSL-backed fuzz binaries (e.g. suffixed `_ossl`) alongside the existing Botan ones.
- Copy `libcrypto.so.*` into `$OUT/lib` alongside `libbotan-3.so.*`.

That PR will be opened against `google/oss-fuzz` separately and linked here once it exists. The upstream `project.yaml` does not need changes (it already permits the relevant sanitizers and engines).

## Test plan

- [ ] `fuzzing-openssl` CI job passes on this PR.
- [ ] Existing `fuzzing` (cifuzz/Botan) workflow still passes — no regression.
- [ ] Reviewer confirms the g10 fuzzer does not actually need a direct Botan symbol that `librnp-static` would not provide (it only calls `rnp::KeyStore::load_g10`, which lives in `librekey`, compiled into `librnp-obj`).

## Related

- Closes #1988 (once the downstream oss-fuzz PR lands).
- Roadmap item #19.
