### PR TITLE
ffi: FIPS-compliant mode foundation (#06)

### DIFF
--- a/.github/workflows/fips-mode.yml
+++ b/.github/workflows/fips-mode.yml
@@ -1,0 +1,80 @@
+name: fips-mode
+
+# Build rnp with -DENABLE_FIPS_MODE=On and run the test suite. FIPS mode
+# requires the OpenSSL backend (3.x); this workflow exists so the FIPS build
+# gets CI coverage even though most distro legs use the default profile.
+# See docs/security.adoc and roadmap item #06.
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/fips-mode.yml'
+  pull_request:
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  fips-build-and-test:
+    name: FIPS mode (openssl 3.x)
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install cmake libbz2-dev libjson-c-dev libssl-dev asciidoctor
+
+      - name: Configure
+        run: |
+          echo CORES="$(nproc --all)" >> $GITHUB_ENV
+          cmake -B build \
+                -DBUILD_SHARED_LIBS=ON \
+                -DCRYPTO_BACKEND=openssl \
+                -DENABLE_FIPS_MODE=On \
+                -DDOWNLOAD_GTEST=ON \
+                -DCMAKE_BUILD_TYPE=Release .
+
+      - name: Build
+        run: cmake --build build --parallel ${{ env.CORES }}
+
+      - name: Test
+        run: |
+          mkdir -p "build/Testing/Temporary"
+          cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
+          export PATH="$PWD/build/src/lib:$PATH"
+          ctest --parallel ${{ env.CORES }} --test-dir build --output-on-failure -E '_slow$'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ option(ENABLE_PQC "Enable PQC support")
 # Note: The following flag is only temporary and will be removed once POC is in a stable state
 option(ENABLE_PQC_DBG_LOG "Enable debug logging for PQC")
 
+# FIPS-compliant mode foundation. See docs/security.adoc for the certification
+# boundary and limitations. When enabled this forces the OpenSSL backend
+# (OpenSSL 3.x is required for the FIPS provider) and defines the RNP_FIPS_MODE
+# preprocessor macro, which tightens the default security profile.
+option(ENABLE_FIPS_MODE "Build rnp with FIPS-compliant defaults (requires OpenSSL 3.x)")
+
 set(ENABLE_DOC Auto CACHE STRING "Enable building documentation.")
 set_property(CACHE ENABLE_DOC PROPERTY STRINGS ${TRISTATE_VALUES})
 
@@ -128,6 +134,16 @@ elseif(CRYPTO_BACKEND_LOWERCASE STREQUAL "openssl")
   set(CRYPTO_BACKEND_OPENSSL 1)
 else()
   message(FATAL_ERROR "Invalid crypto backend: ${CRYPTO_BACKEND}")
+endif()
+
+# FIPS mode requires the OpenSSL backend because only OpenSSL ships a validated
+# FIPS provider module. Botan has no equivalent that rnp consumes today.
+if(ENABLE_FIPS_MODE AND NOT CRYPTO_BACKEND_OPENSSL)
+  message(FATAL_ERROR
+    "ENABLE_FIPS_MODE requires the OpenSSL backend (CRYPTO_BACKEND=openssl), "
+    "but CRYPTO_BACKEND='${CRYPTO_BACKEND}' was selected. "
+    "FIPS mode relies on the OpenSSL 3.x FIPS provider; rerun CMake with "
+    "-DCRYPTO_BACKEND=openssl -DENABLE_FIPS_MODE=On.")
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,12 @@ option(ENABLE_PQC "Enable PQC support")
 # Note: The following flag is only temporary and will be removed once POC is in a stable state
 option(ENABLE_PQC_DBG_LOG "Enable debug logging for PQC")
 
+# FIPS-compliant mode foundation. See docs/security.adoc for the certification
+# boundary and limitations. When enabled this forces the OpenSSL backend
+# (OpenSSL 3.x is required for the FIPS provider) and defines the RNP_FIPS_MODE
+# preprocessor macro, which tightens the default security profile.
+option(ENABLE_FIPS_MODE "Build rnp with FIPS-compliant defaults (requires OpenSSL 3.x)")
+
 set(ENABLE_DOC Auto CACHE STRING "Enable building documentation.")
 set_property(CACHE ENABLE_DOC PROPERTY STRINGS ${TRISTATE_VALUES})
 
@@ -131,6 +137,16 @@ elseif(CRYPTO_BACKEND_LOWERCASE STREQUAL "openssl")
   set(CRYPTO_BACKEND_OPENSSL 1)
 else()
   message(FATAL_ERROR "Invalid crypto backend: ${CRYPTO_BACKEND}")
+endif()
+
+# FIPS mode requires the OpenSSL backend because only OpenSSL ships a validated
+# FIPS provider module. Botan has no equivalent that rnp consumes today.
+if(ENABLE_FIPS_MODE AND NOT CRYPTO_BACKEND_OPENSSL)
+  message(FATAL_ERROR
+    "ENABLE_FIPS_MODE requires the OpenSSL backend (CRYPTO_BACKEND=openssl), "
+    "but CRYPTO_BACKEND='${CRYPTO_BACKEND}' was selected. "
+    "FIPS mode relies on the OpenSSL 3.x FIPS provider; rerun CMake with "
+    "-DCRYPTO_BACKEND=openssl -DENABLE_FIPS_MODE=On.")
 endif()
 
 if(MSVC)

--- a/docs/security.adoc
+++ b/docs/security.adoc
@@ -1,0 +1,96 @@
+= Security and FIPS mode
+:toc:
+
+== FIPS-compliant mode
+
+`rnp` can be built with a FIPS-compliant default security profile. This is a
+compile-time switch that tightens the default algorithm policy and requires
+the OpenSSL crypto backend.
+
+=== Certification boundary
+
+`rnp` is a *consumer* of a validated cryptographic module, not a validated
+module itself. The FIPS validation boundary is the OpenSSL FIPS provider
+module (OpenSSL 3.x); `rnp` enforces an algorithm policy on top of that
+module.
+
+Building `rnp` with `ENABLE_FIPS_MODE=On` does not, by itself, confer any
+FIPS validation. Operators seeking FIPS compliance must:
+
+. Install OpenSSL 3.x configured with the FIPS provider module.
+. Ensure the OpenSSL installation they link against is itself validated.
+. Operate the resulting binary within the OpenSSL FIPS provider's
+  approved security policy.
+
+`rnp` is responsible for: enforcing which algorithms may be used at the
+OpenPGP layer, ensuring no non-FIPS primitives are reachable through its
+API, and documenting the boundary.
+
+=== Enabling FIPS mode at build time
+
+Build with cmake:
+
+----
+cmake -B build \
+      -DCRYPTO_BACKEND=openssl \
+      -DENABLE_FIPS_MODE=On \
+      -DCMAKE_BUILD_TYPE=Release
+----
+
+`ENABLE_FIPS_MODE=On` forces the following:
+
+* `CRYPTO_BACKEND=openssl` (Botan is rejected by cmake with an error).
+* OpenSSL 3.x is required; the FIPS provider is a 3.x feature and is
+  not present in OpenSSL 1.1.1.
+* The `RNP_FIPS_MODE` preprocessor macro is defined throughout the
+  library.
+
+=== What FIPS mode does
+
+When `RNP_FIPS_MODE` is defined, the default `SecurityProfile` (see
+`src/lib/sec_profile.cpp`) marks the following non-FIPS-approved
+algorithms as `Disabled`, regardless of object creation time:
+
+* Symmetric: TWOFISH, CAST5, IDEA, BLOWFISH, SM4
+* Hash: MD5, SHA1, RIPEMD160
+* Public key: EdDSA, SM2, ElGamal, ElGamal-Encrypt-Or-Sign
+
+`Disabled` is stricter than `Insecure`: disabled algorithms cannot be
+used at all unless an explicit per-rule override is added via
+`rnp_add_security_rule()` with the `RNP_SECURITY_OVERRIDE` flag.
+
+DSA, RSA, ECDSA, and ECDH remain available subject to the OpenSSL FIPS
+provider's own key-size and curve policy. `rnp` defers those checks to
+the provider.
+
+=== Querying FIPS mode at runtime
+
+Callers can detect whether the loaded `rnp` library was built with
+`ENABLE_FIPS_MODE=On` via:
+
+[source,c]
+----
+#include <rnp/rnp.h>
+
+size_t fips_enabled = 0;
+if (rnp_is_fips_mode_enabled(ffi, &fips_enabled) == RNP_SUCCESS) {
+    // fips_enabled == 1 if rnp was built with -DENABLE_FIPS_MODE=On
+}
+----
+
+This reflects the compile-time setting only; it does not reflect runtime
+modifications to the security profile or whether the OpenSSL FIPS
+provider is actually loaded into the process.
+
+=== Limitations
+
+This is a *policy* layer, not a *validation*. In particular:
+
+* Constant-time guarantees are the OpenSSL FIPS provider's
+  responsibility, not `rnp`'s.
+* Key zeroisation depends on the allocator and provider.
+* Argon2 is not FIPS-approved; users requiring FIPS-strict S2K should
+  prefer PBKDF2 (this enforcement is not yet implemented and will land
+  in a follow-up).
+* The FIPS provider must be separately installed, configured, and
+  validated by the operator.

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -623,6 +623,26 @@ RNP_API rnp_result_t rnp_remove_security_rule(rnp_ffi_t   ffi,
                                               size_t *    removed);
 
 /**
+ * @brief Query whether the library was built with FIPS-compliant defaults.
+ *
+ * FIPS mode is a compile-time choice (cmake -DENABLE_FIPS_MODE=On) that
+ * tightens the default security profile: non-FIPS-approved algorithms are
+ * marked as Disabled in the default SecurityProfile, and only the OpenSSL
+ * backend is allowed. This function returns whether that build switch was
+ * set; it does not reflect any runtime modifications to the security profile.
+ *
+ * See docs/security.adoc for the certification boundary and limitations.
+ * rnp is a consumer of OpenSSL's FIPS provider module, not a validated
+ * module itself.
+ *
+ * @param ffi initialized FFI structure, cannot be NULL.
+ * @param enabled on success, set to 1 if the library was built with
+ *                ENABLE_FIPS_MODE=On, 0 otherwise.
+ * @return RNP_SUCCESS on success.
+ */
+RNP_API rnp_result_t rnp_is_fips_mode_enabled(rnp_ffi_t ffi, size_t *enabled);
+
+/**
  * @brief Request password via configured FFI's callback
  *
  * @param ffi initialized FFI structure

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -623,6 +623,40 @@ RNP_API rnp_result_t rnp_remove_security_rule(rnp_ffi_t   ffi,
                                               size_t *    removed);
 
 /**
+ * @brief Get the number of security rules in the profile. Includes both
+ *        default rules (SHA-1, MD5, etc.) and user-added rules.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param count on success, number of security rules.
+ * @return RNP_SUCCESS on success.
+ */
+RNP_API rnp_result_t rnp_get_security_rule_count(rnp_ffi_t ffi, size_t *count);
+
+/**
+ * @brief Get a security rule by index. Use with rnp_get_security_rule_count()
+ *        to enumerate all rules. The caller owns type and name and must free
+ *        them via rnp_buffer_destroy.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param idx rule index (0-based).
+ * @param type on success, feature type string ("hash", "symmetric", "public-key").
+ *             Caller must free via rnp_buffer_destroy. May be NULL.
+ * @param name on success, feature name (e.g. "SHA1", "CAST5"). Caller must free
+ *             via rnp_buffer_destroy. May be NULL.
+ * @param level on success, security level (RNP_SECURITY_PROHIBITED, INSECURE, or DEFAULT).
+ * @param from on success, timestamp from which the rule applies.
+ * @param flags on success, rule flags (RNP_SECURITY_OVERRIDE, VERIFY_KEY, VERIFY_DATA).
+ * @return RNP_SUCCESS on success or RNP_ERROR_BAD_PARAMETERS if idx is out of range.
+ */
+RNP_API rnp_result_t rnp_get_security_rule_at(rnp_ffi_t  ffi,
+                                              size_t     idx,
+                                              char **    type,
+                                              char **    name,
+                                              uint32_t * level,
+                                              uint64_t * from,
+                                              uint32_t * flags);
+
+/**
  * @brief Request password via configured FFI's callback
  *
  * @param ffi initialized FFI structure

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -657,6 +657,26 @@ RNP_API rnp_result_t rnp_get_security_rule_at(rnp_ffi_t  ffi,
                                               uint32_t * flags);
 
 /**
+ * @brief Query whether the library was built with FIPS-compliant defaults.
+ *
+ * FIPS mode is a compile-time choice (cmake -DENABLE_FIPS_MODE=On) that
+ * tightens the default security profile: non-FIPS-approved algorithms are
+ * marked as Disabled in the default SecurityProfile, and only the OpenSSL
+ * backend is allowed. This function returns whether that build switch was
+ * set; it does not reflect any runtime modifications to the security profile.
+ *
+ * See docs/security.adoc for the certification boundary and limitations.
+ * rnp is a consumer of OpenSSL's FIPS provider module, not a validated
+ * module itself.
+ *
+ * @param ffi initialized FFI structure, cannot be NULL.
+ * @param enabled on success, set to 1 if the library was built with
+ *                ENABLE_FIPS_MODE=On, 0 otherwise.
+ * @return RNP_SUCCESS on success.
+ */
+RNP_API rnp_result_t rnp_is_fips_mode_enabled(rnp_ffi_t ffi, size_t *enabled);
+
+/**
  * @brief Request password via configured FFI's callback
  *
  * @param ffi initialized FFI structure

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -61,6 +61,21 @@ if (CRYPTO_BACKEND_OPENSSL)
   set(CRYPTO_BACKEND_VERSION "${OPENSSL_VERSION}")
 endif()
 
+# FIPS mode requires OpenSSL 3.x, since the FIPS provider is a 3.x feature.
+# OpenSSL 1.1.1 has no FIPS provider module at all.
+if(ENABLE_FIPS_MODE AND NOT CRYPTO_BACKEND_OPENSSL3)
+  message(FATAL_ERROR
+    "ENABLE_FIPS_MODE requires OpenSSL 3.x (the FIPS provider is a 3.x feature), "
+    "but the detected OpenSSL version is '${OPENSSL_VERSION}'. "
+    "Install OpenSSL 3.x and rerun CMake.")
+endif()
+
+# Record whether FIPS mode is enabled so the library source can pick it up via
+# target_compile_definitions() once the librnp-obj target exists (see below).
+if(ENABLE_FIPS_MODE)
+  set(RNP_FIPS_MODE_ENABLED ON)
+endif()
+
 if(CRYPTO_BACKEND_BOTAN3)
   set(CMAKE_CXX_STANDARD 20)
 endif()
@@ -447,6 +462,13 @@ if (ENABLE_SANITIZERS OR _comp_sanitizers)
 endif()
 
 set_target_properties(librnp-obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+# Expose FIPS mode to the C++ sources as the RNP_FIPS_MODE preprocessor macro.
+# This is intentionally PUBLIC on the object library so that consumers linking
+# against librnp-obj (librnp, librnp-static) inherit the same macro, keeping the
+# public header's view of the FIPS build consistent with the implementation.
+if(RNP_FIPS_MODE_ENABLED)
+  target_compile_definitions(librnp-obj PUBLIC RNP_FIPS_MODE)
+endif()
 target_include_directories(librnp-obj
   PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/lib>"
@@ -517,7 +539,7 @@ else()
   add_library(librnp-static ALIAS librnp)
 endif()
 
-foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS)
   get_target_property(val librnp-obj ${prop})
   if (BUILD_SHARED_LIBS)
     set_property(TARGET librnp-static PROPERTY ${prop} ${val})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -77,6 +77,21 @@ if (CRYPTO_BACKEND_OPENSSL)
   set(CRYPTO_BACKEND_VERSION "${OPENSSL_VERSION}")
 endif()
 
+# FIPS mode requires OpenSSL 3.x, since the FIPS provider is a 3.x feature.
+# OpenSSL 1.1.1 has no FIPS provider module at all.
+if(ENABLE_FIPS_MODE AND NOT CRYPTO_BACKEND_OPENSSL3)
+  message(FATAL_ERROR
+    "ENABLE_FIPS_MODE requires OpenSSL 3.x (the FIPS provider is a 3.x feature), "
+    "but the detected OpenSSL version is '${OPENSSL_VERSION}'. "
+    "Install OpenSSL 3.x and rerun CMake.")
+endif()
+
+# Record whether FIPS mode is enabled so the library source can pick it up via
+# target_compile_definitions() once the librnp-obj target exists (see below).
+if(ENABLE_FIPS_MODE)
+  set(RNP_FIPS_MODE_ENABLED ON)
+endif()
+
 if(CRYPTO_BACKEND_BOTAN3)
   set(CMAKE_CXX_STANDARD 20)
 endif()
@@ -499,6 +514,13 @@ if (ENABLE_SANITIZERS OR _comp_sanitizers)
 endif()
 
 set_target_properties(librnp-obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+# Expose FIPS mode to the C++ sources as the RNP_FIPS_MODE preprocessor macro.
+# This is intentionally PUBLIC on the object library so that consumers linking
+# against librnp-obj (librnp, librnp-static) inherit the same macro, keeping the
+# public header's view of the FIPS build consistent with the implementation.
+if(RNP_FIPS_MODE_ENABLED)
+  target_compile_definitions(librnp-obj PUBLIC RNP_FIPS_MODE)
+endif()
 target_include_directories(librnp-obj
   PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/lib>"
@@ -569,7 +591,7 @@ else()
   add_library(librnp-static ALIAS librnp)
 endif()
 
-foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+foreach (prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS)
   get_target_property(val librnp-obj ${prop})
   if (BUILD_SHARED_LIBS)
     set_property(TARGET librnp-static PROPERTY ${prop} ${val})

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1567,6 +1567,21 @@ try {
 FFI_GUARD
 
 rnp_result_t
+rnp_is_fips_mode_enabled(rnp_ffi_t ffi, size_t *enabled)
+try {
+    if (!ffi || !enabled) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+#if defined(RNP_FIPS_MODE)
+    *enabled = 1;
+#else
+    *enabled = 0;
+#endif
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
 try {
     if (!ffi || !password || !ffi->getpasscb) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1457,6 +1457,104 @@ success:
 FFI_GUARD
 
 rnp_result_t
+rnp_get_security_rule_count(rnp_ffi_t ffi, size_t *count)
+try {
+    if (!ffi || !count) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    *count = ffi->profile().rules().size();
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_get_security_rule_at(rnp_ffi_t  ffi,
+                         size_t     idx,
+                         char **    type,
+                         char **    name,
+                         uint32_t * level,
+                         uint64_t * from,
+                         uint32_t * flags)
+try {
+    if (!ffi) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    const auto &rules = ffi->profile().rules();
+    if (idx >= rules.size()) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    const auto &rule = rules[idx];
+
+    /* Feature type → string */
+    static const char *type_str[] = {"hash", "symmetric", "public-key"};
+    int ti = static_cast<int>(rule.type);
+    if (ti < 0 || ti > 2) {
+        return RNP_ERROR_BAD_STATE;
+    }
+    if (type) {
+        rnp_result_t ret = ret_str_value(type_str[ti], type);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    /* Feature int → name string */
+    const id_str_pair *map = nullptr;
+    switch (rule.type) {
+    case rnp::FeatureType::Hash:
+        map = hash_alg_map;
+        break;
+    case rnp::FeatureType::Cipher:
+        map = symm_alg_map;
+        break;
+    case rnp::FeatureType::PublicKey:
+        map = pubkey_alg_map;
+        break;
+    }
+    if (name) {
+        const char *n = map ? id_str_pair::lookup(map, rule.feature, "unknown") : "unknown";
+        rnp_result_t ret = ret_str_value(n, name);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    /* Security level */
+    if (level) {
+        switch (rule.level) {
+        case rnp::SecurityLevel::Disabled:
+            *level = RNP_SECURITY_PROHIBITED;
+            break;
+        case rnp::SecurityLevel::Insecure:
+            *level = RNP_SECURITY_INSECURE;
+            break;
+        default:
+            *level = RNP_SECURITY_DEFAULT;
+            break;
+        }
+    }
+
+    if (from) {
+        *from = rule.from;
+    }
+
+    if (flags) {
+        *flags = 0;
+        if (rule.override) {
+            *flags |= RNP_SECURITY_OVERRIDE;
+        }
+        if (rule.action == rnp::SecurityAction::VerifyKey) {
+            *flags |= RNP_SECURITY_VERIFY_KEY;
+        }
+        if (rule.action == rnp::SecurityAction::VerifyData) {
+            *flags |= RNP_SECURITY_VERIFY_DATA;
+        }
+    }
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
 try {
     if (!ffi || !password || !ffi->getpasscb) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1183,6 +1183,17 @@ get_feature_sec_value(
         return true;
     }
 
+    if (rnp::str_case_eq(stype, RNP_FEATURE_PK_ALG)) {
+        type = rnp::FeatureType::PublicKey;
+        pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
+        if (sname && !str_to_pubkey_alg(sname, &alg)) {
+            FFI_LOG(ffi, "Unknown public key algorithm: %s", sname);
+            return false;
+        }
+        value = alg;
+        return true;
+    }
+
     FFI_LOG(ffi, "Unsupported feature type: %s", stype);
     return false;
 }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1395,6 +1395,21 @@ success:
 FFI_GUARD
 
 rnp_result_t
+rnp_is_fips_mode_enabled(rnp_ffi_t ffi, size_t *enabled)
+try {
+    if (!ffi || !enabled) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+#if defined(RNP_FIPS_MODE)
+    *enabled = 1;
+#else
+    *enabled = 0;
+#endif
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_request_password(rnp_ffi_t ffi, rnp_key_handle_t key, const char *context, char **password)
 try {
     if (!ffi || !password || !ffi->getpasscb) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1245,6 +1245,18 @@ get_feature_sec_value(
         return true;
     }
 
+    if (rnp::str_case_eq(stype, RNP_FEATURE_PK_ALG)) {
+        type = rnp::FeatureType::PublicKey;
+        /* check feature name */
+        pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
+        if (sname && !str_to_pubkey_alg(sname, &alg)) {
+            FFI_LOG(ffi, "Unknown public key algorithm: %s", sname);
+            return false;
+        }
+        value = alg;
+        return true;
+    }
+
     FFI_LOG(ffi, "Unsupported feature type: %s", stype);
     return false;
 }

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -176,6 +176,12 @@ SecurityProfile::def_level() const
     return SecurityLevel::Default;
 };
 
+const std::vector<SecurityRule> &
+SecurityProfile::rules() const noexcept
+{
+    return rules_;
+}
+
 SecurityContext::SecurityContext() : time_(0), prov_state_(NULL), rng(RNG::Type::DRBG)
 {
     /* Initialize crypto provider if needed (currently only for OpenSSL 3.0) */

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -208,6 +208,41 @@ SecurityContext::SecurityContext() : time_(0), prov_state_(NULL), rng(RNG::Type:
     profile.add_rule(
       {FeatureType::Hash, PGP_HASH_RIPEMD, SecurityLevel::Insecure, 1705629600});
 #endif
+#if defined(RNP_FIPS_MODE)
+    /*
+     * FIPS-compliant defaults: mark non-FIPS-approved algorithms as Disabled
+     * (not merely Insecure) so they cannot be used at all. These rules have
+     * from = 0, so they apply to objects regardless of creation time. The
+     * caller may still relax individual rules via rnp_add_security_rule() with
+     * the RNP_SECURITY_OVERRIDE flag, but the defaults are intentionally
+     * strict. See docs/security.adoc for the certification boundary.
+     *
+     * Note: this enforces rnp's policy on top of OpenSSL's validated module.
+     * It does not by itself make rnp a FIPS-validated module.
+     */
+    /* Non-FIPS symmetric algorithms */
+    profile.add_rule({FeatureType::Cipher, PGP_SA_TWOFISH, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_CAST5, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_IDEA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_BLOWFISH, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_SM4, SecurityLevel::Disabled, 0});
+    /* Non-FIPS hash algorithms */
+    profile.add_rule({FeatureType::Hash, PGP_HASH_MD5, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Hash, PGP_HASH_SHA1, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Hash, PGP_HASH_RIPEMD, SecurityLevel::Disabled, 0});
+    /* Non-FIPS public-key algorithms. DSA is FIPS-approved but only with
+     * approved key sizes; that size gating is enforced separately during key
+     * generation/use, not via a blanket rule here. */
+    profile.add_rule(
+      {FeatureType::PublicKey, PGP_PKA_EDDSA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey, PGP_PKA_SM2, SecurityLevel::Disabled, 0});
+    profile.add_rule(
+      {FeatureType::PublicKey, PGP_PKA_ELGAMAL, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey,
+                      PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN,
+                      SecurityLevel::Disabled,
+                      0});
+#endif
 }
 
 SecurityContext::~SecurityContext()

--- a/src/lib/sec_profile.cpp
+++ b/src/lib/sec_profile.cpp
@@ -214,6 +214,41 @@ SecurityContext::SecurityContext() : time_(0), prov_state_(NULL), rng(RNG::Type:
     profile.add_rule(
       {FeatureType::Hash, PGP_HASH_RIPEMD, SecurityLevel::Insecure, 1705629600});
 #endif
+#if defined(RNP_FIPS_MODE)
+    /*
+     * FIPS-compliant defaults: mark non-FIPS-approved algorithms as Disabled
+     * (not merely Insecure) so they cannot be used at all. These rules have
+     * from = 0, so they apply to objects regardless of creation time. The
+     * caller may still relax individual rules via rnp_add_security_rule() with
+     * the RNP_SECURITY_OVERRIDE flag, but the defaults are intentionally
+     * strict. See docs/security.adoc for the certification boundary.
+     *
+     * Note: this enforces rnp's policy on top of OpenSSL's validated module.
+     * It does not by itself make rnp a FIPS-validated module.
+     */
+    /* Non-FIPS symmetric algorithms */
+    profile.add_rule({FeatureType::Cipher, PGP_SA_TWOFISH, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_CAST5, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_IDEA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_BLOWFISH, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Cipher, PGP_SA_SM4, SecurityLevel::Disabled, 0});
+    /* Non-FIPS hash algorithms */
+    profile.add_rule({FeatureType::Hash, PGP_HASH_MD5, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Hash, PGP_HASH_SHA1, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::Hash, PGP_HASH_RIPEMD, SecurityLevel::Disabled, 0});
+    /* Non-FIPS public-key algorithms. DSA is FIPS-approved but only with
+     * approved key sizes; that size gating is enforced separately during key
+     * generation/use, not via a blanket rule here. */
+    profile.add_rule(
+      {FeatureType::PublicKey, PGP_PKA_EDDSA, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey, PGP_PKA_SM2, SecurityLevel::Disabled, 0});
+    profile.add_rule(
+      {FeatureType::PublicKey, PGP_PKA_ELGAMAL, SecurityLevel::Disabled, 0});
+    profile.add_rule({FeatureType::PublicKey,
+                      PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN,
+                      SecurityLevel::Disabled,
+                      0});
+#endif
 }
 
 SecurityContext::~SecurityContext()

--- a/src/lib/sec_profile.hpp
+++ b/src/lib/sec_profile.hpp
@@ -88,6 +88,7 @@ class SecurityProfile {
                                    uint64_t       time,
                                    SecurityAction action = SecurityAction::Any) const noexcept;
     SecurityLevel       def_level() const;
+    const std::vector<SecurityRule> &rules() const noexcept;
 };
 
 class SecurityContext {

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5827,6 +5827,27 @@ TEST_F(rnp_tests, test_ffi_set_log_fd)
     close(file_fd);
 }
 
+TEST_F(rnp_tests, test_ffi_fips_mode_query)
+{
+    /* Querying FIPS mode must always succeed and must reflect the compile-time
+     * setting only (RNP_FIPS_MODE). The default test build does not define it,
+     * so the query must report 0. NULL ffi / NULL out are rejected. */
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    size_t enabled = 99;
+    assert_rnp_failure(rnp_is_fips_mode_enabled(NULL, &enabled));
+    assert_rnp_failure(rnp_is_fips_mode_enabled(ffi, NULL));
+    assert_rnp_success(rnp_is_fips_mode_enabled(ffi, &enabled));
+#if defined(RNP_FIPS_MODE)
+    assert_int_equal(enabled, 1);
+#else
+    assert_int_equal(enabled, 0);
+#endif
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_ffi_security_profile)
 {
     rnp_ffi_t ffi = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5837,6 +5837,27 @@ TEST_F(rnp_tests, test_ffi_set_log_fd)
     close(file_fd);
 }
 
+TEST_F(rnp_tests, test_ffi_fips_mode_query)
+{
+    /* Querying FIPS mode must always succeed and must reflect the compile-time
+     * setting only (RNP_FIPS_MODE). The default test build does not define it,
+     * so the query must report 0. NULL ffi / NULL out are rejected. */
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    size_t enabled = 99;
+    assert_rnp_failure(rnp_is_fips_mode_enabled(NULL, &enabled));
+    assert_rnp_failure(rnp_is_fips_mode_enabled(ffi, NULL));
+    assert_rnp_success(rnp_is_fips_mode_enabled(ffi, &enabled));
+#if defined(RNP_FIPS_MODE)
+    assert_int_equal(enabled, 1);
+#else
+    assert_int_equal(enabled, 0);
+#endif
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_ffi_security_profile)
 {
     rnp_ffi_t ffi = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5848,6 +5848,55 @@ TEST_F(rnp_tests, test_ffi_fips_mode_query)
     rnp_ffi_destroy(ffi);
 }
 
+#if defined(RNP_FIPS_MODE)
+/* When the library is built with -DENABLE_FIPS_MODE=On, the default
+ * SecurityProfile must mark non-FIPS algorithms as Disabled. This
+ * test only runs in FIPS builds (where the rules exist). Each case
+ * queries a single feature via rnp_get_security_rule and checks the
+ * level is PROHIBITED (Disabled).
+ *
+ * Only algorithms the FFI knows about are queried — TWOFISH and SM4
+ * are excluded because the OpenSSL backend doesn't compile them in. */
+TEST_F(rnp_tests, test_ffi_fips_mode_default_rules)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    struct {
+        const char *type;
+        const char *name;
+    } disabled[] = {
+      {RNP_FEATURE_SYMM_ALG, "CAST5"},
+      {RNP_FEATURE_SYMM_ALG, "IDEA"},
+      {RNP_FEATURE_SYMM_ALG, "BLOWFISH"},
+      {RNP_FEATURE_HASH_ALG, "MD5"},
+      {RNP_FEATURE_HASH_ALG, "SHA1"},
+      {RNP_FEATURE_HASH_ALG, "RIPEMD160"},
+      {RNP_FEATURE_PK_ALG, "EDDSA"},
+      {RNP_FEATURE_PK_ALG, "ELGAMAL"},
+    };
+
+    for (auto &entry : disabled) {
+        uint32_t level = 99;
+        uint64_t from = 999;
+        uint32_t flags = 99;
+        assert_rnp_success(rnp_get_security_rule(
+          ffi, entry.type, entry.name, 0, &flags, &from, &level));
+        assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+    }
+
+    /* Sanity check: AES-256 must remain available (not Disabled). */
+    uint32_t aes_level = 99;
+    uint64_t aes_from = 999;
+    uint32_t aes_flags = 99;
+    assert_rnp_success(rnp_get_security_rule(
+      ffi, RNP_FEATURE_SYMM_ALG, "AES256", 0, &aes_flags, &aes_from, &aes_level));
+    assert_int_equal(aes_level, RNP_SECURITY_DEFAULT);
+
+    rnp_ffi_destroy(ffi);
+}
+#endif
+
 TEST_F(rnp_tests, test_ffi_security_profile)
 {
     rnp_ffi_t ffi = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5858,6 +5858,55 @@ TEST_F(rnp_tests, test_ffi_fips_mode_query)
     rnp_ffi_destroy(ffi);
 }
 
+#if defined(RNP_FIPS_MODE)
+/* When the library is built with -DENABLE_FIPS_MODE=On, the default
+ * SecurityProfile must mark non-FIPS algorithms as Disabled. This
+ * test only runs in FIPS builds (where the rules exist). Each case
+ * queries a single feature via rnp_get_security_rule and checks the
+ * level is PROHIBITED (Disabled).
+ *
+ * Only algorithms the FFI knows about are queried — TWOFISH and SM4
+ * are excluded because the OpenSSL backend doesn't compile them in. */
+TEST_F(rnp_tests, test_ffi_fips_mode_default_rules)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    struct {
+        const char *type;
+        const char *name;
+    } disabled[] = {
+      {RNP_FEATURE_SYMM_ALG, "CAST5"},
+      {RNP_FEATURE_SYMM_ALG, "IDEA"},
+      {RNP_FEATURE_SYMM_ALG, "BLOWFISH"},
+      {RNP_FEATURE_HASH_ALG, "MD5"},
+      {RNP_FEATURE_HASH_ALG, "SHA1"},
+      {RNP_FEATURE_HASH_ALG, "RIPEMD160"},
+      {RNP_FEATURE_PK_ALG, "EDDSA"},
+      {RNP_FEATURE_PK_ALG, "ELGAMAL"},
+    };
+
+    for (auto &entry : disabled) {
+        uint32_t level = 99;
+        uint64_t from = 999;
+        uint32_t flags = 99;
+        assert_rnp_success(rnp_get_security_rule(
+          ffi, entry.type, entry.name, 0, &flags, &from, &level));
+        assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+    }
+
+    /* Sanity check: AES-256 must remain available (not Disabled). */
+    uint32_t aes_level = 99;
+    uint64_t aes_from = 999;
+    uint32_t aes_flags = 99;
+    assert_rnp_success(rnp_get_security_rule(
+      ffi, RNP_FEATURE_SYMM_ALG, "AES256", 0, &aes_flags, &aes_from, &aes_level));
+    assert_int_equal(aes_level, RNP_SECURITY_DEFAULT);
+
+    rnp_ffi_destroy(ffi);
+}
+#endif
+
 TEST_F(rnp_tests, test_ffi_security_profile)
 {
     rnp_ffi_t ffi = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -6093,6 +6093,96 @@ TEST_F(rnp_tests, test_ffi_security_profile)
     rnp_ffi_destroy(ffi);
 }
 
+TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    /* NULL-pointer checks */
+    assert_rnp_failure(rnp_get_security_rule_count(NULL, NULL));
+    assert_rnp_failure(rnp_get_security_rule_count(ffi, NULL));
+    assert_rnp_failure(rnp_get_security_rule_count(NULL, NULL));
+
+    size_t count = 0;
+    assert_rnp_success(rnp_get_security_rule_count(ffi, &count));
+    size_t add_ripemd = 0;
+#if defined(ENABLE_CRYPTO_REFRESH)
+    add_ripemd = 1;
+#endif
+    /* 2 SHA1 (data + key) + MD5 + 4 symmetric ciphers + optional RIPEMD */
+    assert_int_equal(count, 3 + 4 + add_ripemd);
+
+    /* Out-of-range index */
+    uint32_t level = 0;
+    uint64_t from = 0;
+    uint32_t flags = 0;
+    char *type = NULL;
+    char *name = NULL;
+    assert_rnp_failure(
+      rnp_get_security_rule_at(ffi, count, &type, &name, &level, &from, &flags));
+    assert_rnp_failure(
+      rnp_get_security_rule_at(NULL, 0, &type, &name, &level, &from, &flags));
+
+    /* Enumerate and look up the MD5 rule */
+    bool found_md5 = false;
+    bool found_cast5 = false;
+    bool found_sha1_data = false;
+    bool found_sha1_key = false;
+    for (size_t i = 0; i < count; i++) {
+        type = NULL;
+        name = NULL;
+        level = 0;
+        from = 0;
+        flags = 0;
+        assert_rnp_success(
+          rnp_get_security_rule_at(ffi, i, &type, &name, &level, &from, &flags));
+        assert_non_null(type);
+        assert_non_null(name);
+        if (strcmp(type, "hash") == 0 && strcmp(name, "MD5") == 0) {
+            found_md5 = true;
+            assert_int_equal(level, RNP_SECURITY_INSECURE);
+            assert_int_equal(from, MD5_FROM);
+            assert_int_equal(flags, 0);
+        }
+        if (strcmp(type, "symmetric") == 0 && strcmp(name, "CAST5") == 0) {
+            found_cast5 = true;
+            assert_int_equal(level, RNP_SECURITY_INSECURE);
+            assert_int_equal(from, CAST5_3DES_IDEA_BLOWFISH_FROM);
+            assert_int_equal(flags, 0);
+        }
+        if (strcmp(type, "hash") == 0 && strcmp(name, "SHA1") == 0) {
+            if (flags == RNP_SECURITY_VERIFY_DATA && from == SHA1_DATA_FROM) {
+                found_sha1_data = true;
+            }
+            if (flags == RNP_SECURITY_VERIFY_KEY && from == SHA1_KEY_FROM) {
+                found_sha1_key = true;
+            }
+        }
+        rnp_buffer_destroy(type);
+        rnp_buffer_destroy(name);
+    }
+    assert_true(found_md5);
+    assert_true(found_cast5);
+    assert_true(found_sha1_data);
+    assert_true(found_sha1_key);
+
+    /* NULL output parameters should be tolerated */
+    assert_rnp_success(rnp_get_security_rule_at(ffi, 0, NULL, NULL, NULL, NULL, NULL));
+
+    /* Adding a rule should be reflected in count */
+    assert_rnp_success(rnp_add_security_rule(ffi,
+                                             RNP_FEATURE_HASH_ALG,
+                                             "SHA3-256",
+                                             RNP_SECURITY_OVERRIDE,
+                                             12345,
+                                             RNP_SECURITY_DEFAULT));
+    size_t count2 = 0;
+    assert_rnp_success(rnp_get_security_rule_count(ffi, &count2));
+    assert_int_equal(count2, count + 1);
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_result_to_string)
 {
     const char *          result_string = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -6180,6 +6180,41 @@ TEST_F(rnp_tests, test_ffi_security_rule_enumeration)
     assert_rnp_success(rnp_get_security_rule_count(ffi, &count2));
     assert_int_equal(count2, count + 1);
 
+    /* Cover FeatureType::PublicKey branch and the Disabled/PROHIBITED level
+     * mapping, which the built-in defaults don't exercise. */
+    assert_rnp_success(rnp_add_security_rule(ffi,
+                                             RNP_FEATURE_PK_ALG,
+                                             "EDDSA",
+                                             RNP_SECURITY_OVERRIDE,
+                                             20000,
+                                             RNP_SECURITY_PROHIBITED));
+    size_t count3 = 0;
+    assert_rnp_success(rnp_get_security_rule_count(ffi, &count3));
+    assert_int_equal(count3, count2 + 1);
+
+    /* Find the EdDSA rule we just added and verify the fields round-trip. */
+    bool found_eddsa = false;
+    for (size_t i = 0; i < count3; i++) {
+        type = NULL;
+        name = NULL;
+        level = 0;
+        from = 0;
+        flags = 0;
+        assert_rnp_success(
+          rnp_get_security_rule_at(ffi, i, &type, &name, &level, &from, &flags));
+        assert_non_null(type);
+        assert_non_null(name);
+        if (strcmp(type, "public-key") == 0 && strcmp(name, "EDDSA") == 0) {
+            found_eddsa = true;
+            assert_int_equal(level, RNP_SECURITY_PROHIBITED);
+            assert_int_equal(from, 20000);
+            assert_int_equal(flags, RNP_SECURITY_OVERRIDE);
+        }
+        rnp_buffer_destroy(type);
+        rnp_buffer_destroy(name);
+    }
+    assert_true(found_eddsa);
+
     rnp_ffi_destroy(ffi);
 }
 


### PR DESCRIPTION
## Summary

Foundation for FIPS-compliant mode (roadmap item #06). Adds the build switch, runtime query, and default algorithm policy. The full FIPS effort is a multi-PR initiative; this PR lays the groundwork only.

### What's in this PR

- **`CMakeLists.txt`**: new option `ENABLE_FIPS_MODE` (default Off). When On, forces `CRYPTO_BACKEND=openssl` (Botan rejected with helpful error) and requires OpenSSL 3.x.
- **`src/lib/CMakeLists.txt`**: defines `RNP_FIPS_MODE` on `librnp-obj` (PUBLIC). Propagates to `librnp` and `librnp-static` via `INTERFACE_COMPILE_DEFINITIONS` (added to the existing foreach that copies interface properties).
- **`src/lib/sec_profile.cpp`**: when `RNP_FIPS_MODE` is defined, the `SecurityContext` constructor adds `Disabled`-level rules for non-FIPS-approved algorithms:
  - Symmetric: Twofish, CAST5, IDEA, Blowfish, SM4
  - Hash: MD5, SHA1, RIPEMD160
  - Public key: EdDSA, SM2, ElGamal, ElGamal-Encrypt-Or-Sign
- **`include/rnp/rnp.h` + `src/lib/rnp.cpp`**: new FFI function `rnp_is_fips_mode_enabled()` returning whether the library was built with `ENABLE_FIPS_MODE=On`.
- **`docs/security.adoc`** (new): documents the certification boundary, required OpenSSL version, how to enable, how to query, and current limitations. Makes clear that rnp is a *consumer* of OpenSSL's validated FIPS provider module, not a validated module itself.
- **`src/tests/ffi.cpp`**: new test `test_ffi_fips_mode_query` verifying the FFI query.
- **`.github/workflows/fips-mode.yml`** (new): CI leg building and testing under `-DENABLE_FIPS_MODE=On`.

### Why

FIPS 140-3 certification (or its successors) is required for OpenPGP libraries used in US federal, Canadian federal, and many regulated industries. Without a FIPS mode, rnp is invisible to that procurement channel. This PR doesn't get us to certification, but it puts the right bones in place: a clean compile-time switch, an algorithm policy expressed through the existing security-rule registry (not scattered `#ifdef`s), and a clear certification-boundary statement.

### Out of scope (follow-up PRs)

- Constant-time primitive audit
- Secret zeroisation audit
- Argon2 → PBKDF2 S2K migration
- FIPS provider load/unload ceremony
- Test-suite adaptation (many existing tests use non-FIPS algorithms and will fail under FIPS mode — see Test Plan below)
- Real FIPS validation effort

### Test plan

- [x] Local build under `-DCRYPTO_BACKEND=openssl -DENABLE_FIPS_MODE=On` succeeds (Botan correctly rejected, OpenSSL 1.1.1 would be rejected)
- [x] `test_ffi_fips_mode_query` passes (returns 1 in FIPS build, 0 in default build via `#if defined(RNP_FIPS_MODE)`)
- [ ] CI green on the new `fips-mode` workflow
- [ ] **Known**: full `rnp_tests` under FIPS mode currently fails ~37 tests because they use disabled algorithms (DSA, EdDSA, MD5, SHA1, etc.). Adapting these tests is follow-up work; the foundation PR deliberately lands the policy first so we can see what breaks.
