### PR TITLE
warnings: silence Botan FFI deprecations + policy doc (#08)

### DIFF
--- a/docs/develop/compile-time-warnings.adoc
+++ b/docs/develop/compile-time-warnings.adoc
@@ -1,0 +1,68 @@
+= Compile-time warnings policy
+
+rnp's goal is a clean compile baseline so that `-Werror` can be enabled
+on the main CI matrix. New warnings introduced by a PR are blockers.
+
+== Build flags
+
+Default debug builds use `-Wall -Wextra`. We do not enable `-Wpedantic`
+or `-Wconversion` project-wide; both generate too much noise for the
+value they provide.
+
+For new code, prefer to fix a warning rather than suppress it. The
+suppression mechanisms below are reserved for cases where fixing the
+warning would either:
+
+* require breaking the public API,
+* require dropping supported toolchain versions (Botan, OpenSSL,
+  compilers), or
+* require an intrusive refactor that belongs in its own PR.
+
+== Categorisation
+
+When fixing warnings, group them by category — one PR per category:
+
+* **Real bugs** (signed/unsigned comparisons, unused variables hiding a
+  missing error path, etc.): fix the code.
+* **Stylistic / pedantic** (long lines, naming, redundant casts): fix
+  only if low-cost.
+* **Platform-specific quirks** (MSVC `C4996` for `strdup`, deprecated
+  Botan FFI accessors): suppress at the call site with a comment
+  explaining why.
+
+== Suppressing warnings
+
+Use `#pragma GCC diagnostic push/pop` pairs around the minimum scope
+needed, with an explanatory comment:
+
+[source,cpp]
+----
+/* rnp supports Botan 2.14+; botan_privkey_view_raw (the non-deprecated
+ * replacement for botan_privkey_x25519_get_privkey) was added in Botan
+ * 3.6, so we cannot migrate yet. */
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    if (botan_privkey_x25519_get_privkey(pr_key.get(), keyle.data())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+----
+
+For MSVC-specific warnings, use `__pragma(warning(push))` /
+`__pragma(warning(disable : NNNN))` / `__pragma(warning(pop))`.
+
+== Suppression lifetime
+
+Every suppression must include:
+
+* the warning being suppressed,
+* why the warning cannot be fixed today,
+* what would be required to remove the suppression (e.g. "drop Botan
+  2.x support").
+
+When the underlying blocker is removed, the suppression must be
+removed in the same PR.

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -66,9 +66,19 @@ Key::generate_x25519(rnp::RNG &rng)
 
     /* botan returns key in little-endian, while mpi is big-endian */
     rnp::secure_array<uint8_t, 32> keyle;
+    /* rnp supports Botan 2.14+; botan_privkey_view_raw (the non-deprecated
+     * replacement for botan_privkey_x25519_get_privkey) was added in Botan
+     * 3.6, so we cannot migrate yet. See docs/develop/compile-time-warnings.adoc. */
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     if (botan_privkey_x25519_get_privkey(pr_key.get(), keyle.data())) {
         return RNP_ERROR_KEY_GENERATION;
     }
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     x.resize(32);
     for (int i = 0; i < 32; i++) {
         x[31 - i] = keyle[i];
@@ -79,9 +89,17 @@ Key::generate_x25519(rnp::RNG &rng)
     }
 
     p.resize(33);
+    /* same rationale as the private-key call above */
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     if (botan_pubkey_x25519_get_pubkey(pu_key.get(), &p[1])) {
         return RNP_ERROR_KEY_GENERATION;
     }
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     p[0] = 0x40;
     return RNP_SUCCESS;
 }

--- a/src/lib/crypto/eddsa.cpp
+++ b/src/lib/crypto/eddsa.cpp
@@ -100,9 +100,19 @@ generate(rnp::RNG &rng, ec::Key &key)
     }
 
     uint8_t key_bits[64];
+    /* rnp supports Botan 2.14+; botan_privkey_view_raw (the non-deprecated
+     * replacement for botan_privkey_ed25519_get_privkey) was added in Botan
+     * 3.6, so we cannot migrate yet. See docs/develop/compile-time-warnings.adoc. */
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     if (botan_privkey_ed25519_get_privkey(eddsa.get(), key_bits)) {
         return RNP_ERROR_GENERIC;
     }
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     // First 32 bytes of key_bits are the EdDSA seed (private key)
     // Second 32 bytes are the EdDSA public key


### PR DESCRIPTION
## Summary

First PR for roadmap item #08 (compile-time warnings clean baseline). Brings the Botan debug build to zero warnings under `-Wall -Wextra` and documents the warnings policy going forward.

### What's in this PR

- **`src/lib/crypto/ec.cpp`** + **`src/lib/crypto/eddsa.cpp`**: Three call sites use Botan FFI accessors deprecated in Botan 3.6 (`botan_privkey_x25519_get_privkey`, `botan_pubkey_x25519_get_pubkey`, `botan_privkey_ed25519_get_privkey`). The non-deprecated replacement `botan_privkey_view_raw` / `botan_pubkey_view_raw` was added in Botan 3.6 — rnp supports Botan 2.14+, so we can't migrate yet. Each call is wrapped in `#pragma GCC diagnostic push/pop` with a comment explaining the constraint.
- **`docs/develop/compile-time-warnings.adoc`** (new): Policy for new code. Categorises warnings (real bug vs stylistic vs platform quirk), specifies when to fix vs when to suppress, and requires every suppression to state the warning, why it can't be fixed, and what would remove the suppression.

### Why

A clean compile baseline is the prerequisite for `-Werror` on main CI. Warnings accumulate noise that hides real bugs; the goal is "the warning you just introduced gets your PR blocked". This PR doesn't enable `-Werror` — that lands once every warning category is addressed. Following the roadmap's guidance, this PR covers exactly one category (Botan FFI deprecations); subsequent PRs will handle other categories (unused parameters, signed/unsigned, MSVC-specific).

### Current warning baseline

Built locally with `-Wall -Wextra -Wno-unused-parameter -DCMAKE_BUILD_TYPE=Debug`:

| Backend | Warnings |
| --- | --- |
| Botan 3.12 (macOS) | 0 (was 3, all Botan FFI deprecations) |
| OpenSSL 3.x (macOS) | 0 |

### Out of scope (follow-up PRs)

- Enable `-Werror` on a CI leg
- Audit warnings under gcc older versions, clang older versions, MSVC v143, ClangCL
- Other warning categories: unused-parameter (currently suppressed with `-Wno-unused-parameter`), signed/unsigned comparisons, narrowing conversions, MSVC-specific deprecations
- Migrate to `botan_privkey_view_raw` (requires dropping Botan 2.x and 3.0–3.5 support)

### Test plan

- [x] Local Botan 3.12 build with `-Wall -Wextra -Wno-unused-parameter` produces zero warnings (was 3)
- [x] Local OpenSSL 3.x build with the same flags produces zero warnings
- [x] Test suite still passes (`rnp_tests` runs)
- [ ] CI green on all platforms
