### PR TITLE
dump: walk multiple armored messages in --list-packets (#2036)

### DIFF
--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1653,17 +1653,32 @@ DumpContextDst::dump(bool raw_only)
 
     /* check whether source is armored */
     if (!raw_only && src.is_armored()) {
-        std::unique_ptr<Source> armor(new Source());
-        auto                    ret = init_armored_src(&armor->src(), &src);
-        if (ret) {
-            RNP_LOG("failed to parse armored data");
-            return ret;
+        /* ArmoredSource with AllowMultiple so we walk past the first
+         * -----END ...----- and continue with the next armored message
+         * in the same input (see issue #2036). */
+        rnp::ArmoredSource armor(
+          src, rnp::ArmoredSource::AllowBinary | rnp::ArmoredSource::AllowMultiple);
+        rnp_result_t ret = RNP_SUCCESS;
+        bool         first = true;
+        while (true) {
+            if (armor.eof() && armor.multiple()) {
+                armor.restart();
+            }
+            if (armor.eof()) {
+                break;
+            }
+            if (first) {
+                dst_printf(dst, ":armored input\n");
+                first = false;
+            }
+            DumpContextDst ctx(armor.src(), dst);
+            ctx.copy_params(*this);
+            ret = ctx.dump(true);
+            if (ret) {
+                break;
+            }
         }
-        dst_printf(dst, ":armored input\n");
-
-        std::unique_ptr<DumpContextDst> ctx(new DumpContextDst(armor->src(), dst));
-        ctx->copy_params(*this);
-        return ctx->dump(true);
+        return ret;
     }
 
     if (src.eof()) {
@@ -2751,15 +2766,26 @@ DumpContextJson::dump(bool raw_only)
     }
     /* check whether source is armored */
     if (!raw_only && src.is_armored()) {
-        std::unique_ptr<Source> armor(new Source());
-        rnp_result_t            ret = init_armored_src(&armor->src(), &src);
-        if (ret) {
-            RNP_LOG("failed to parse armored data");
-            return ret;
+        /* Walk all armored messages in the stream, mirroring the text
+         * dumper (see issue #2036). */
+        rnp::ArmoredSource armor(
+          src, rnp::ArmoredSource::AllowBinary | rnp::ArmoredSource::AllowMultiple);
+        rnp_result_t ret = RNP_SUCCESS;
+        while (true) {
+            if (armor.eof() && armor.multiple()) {
+                armor.restart();
+            }
+            if (armor.eof()) {
+                break;
+            }
+            DumpContextJson ctx(armor.src(), json);
+            ctx.copy_params(*this);
+            ret = ctx.dump(true);
+            if (ret) {
+                break;
+            }
         }
-        DumpContextJson ctx(armor->src(), json);
-        ctx.copy_params(*this);
-        return ctx.dump(true);
+        return ret;
     }
 
     if (src.eof()) {

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1651,19 +1651,32 @@ DumpContextDst::dump(bool raw_only)
         }
     }
 
-    /* check whether source is armored */
+    /* check whether source is armored; concatenated armored messages are all
+     * walked (see issue #2036) */
     if (!raw_only && src.is_armored()) {
-        std::unique_ptr<Source> armor(new Source());
-        auto                    ret = init_armored_src(&armor->src(), &src);
-        if (ret) {
-            RNP_LOG("failed to parse armored data");
-            return ret;
+        rnp::ArmoredSource armor(
+          src, rnp::ArmoredSource::AllowBinary | rnp::ArmoredSource::AllowMultiple);
+        rnp_result_t ret = RNP_SUCCESS;
+        bool         first = true;
+        while (true) {
+            if (armor.eof() && armor.multiple()) {
+                armor.restart();
+            }
+            if (armor.eof()) {
+                break;
+            }
+            if (first) {
+                dst_printf(dst, ":armored input\n");
+                first = false;
+            }
+            DumpContextDst ctx(armor.src(), dst);
+            ctx.copy_params(*this);
+            ret = ctx.dump(true);
+            if (ret) {
+                break;
+            }
         }
-        dst_printf(dst, ":armored input\n");
-
-        std::unique_ptr<DumpContextDst> ctx(new DumpContextDst(armor->src(), dst));
-        ctx->copy_params(*this);
-        return ctx->dump(true);
+        return ret;
     }
 
     if (src.eof()) {
@@ -2706,17 +2719,33 @@ DumpContextJson::dump(bool raw_only)
             return RNP_ERROR_BAD_FORMAT;
         }
     }
-    /* check whether source is armored */
+    /* check whether source is armored; concatenated armored messages are
+     * walked and all of their packets collected into a single array (#2036) */
     if (!raw_only && src.is_armored()) {
-        std::unique_ptr<Source> armor(new Source());
-        rnp_result_t            ret = init_armored_src(&armor->src(), &src);
-        if (ret) {
-            RNP_LOG("failed to parse armored data");
-            return ret;
+        rnp::ArmoredSource armor(
+          src, rnp::ArmoredSource::AllowBinary | rnp::ArmoredSource::AllowMultiple);
+        rnp_result_t           ret = RNP_SUCCESS;
+        nlohmann::ordered_json res = nlohmann::ordered_json::array();
+        while (true) {
+            if (armor.eof() && armor.multiple()) {
+                armor.restart();
+            }
+            if (armor.eof()) {
+                break;
+            }
+            nlohmann::ordered_json block;
+            DumpContextJson        ctx(armor.src(), &block);
+            ctx.copy_params(*this);
+            ret = ctx.dump(true);
+            if (ret) {
+                break;
+            }
+            if (block.is_array()) {
+                res.insert(res.end(), block.begin(), block.end());
+            }
         }
-        DumpContextJson ctx(armor->src(), json);
-        ctx.copy_params(*this);
-        return ctx.dump(true);
+        *json = std::move(res);
+        return ret;
     }
 
     if (src.eof()) {

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2420,6 +2420,54 @@ TEST_F(rnp_tests, test_ffi_key_dump_edge_cases)
     rnp_ffi_destroy(ffi);
 }
 
+TEST_F(rnp_tests, test_ffi_dump_multiple_armored_messages)
+{
+    /* Regression for issue #2036: a single input file containing multiple
+     * armored OpenPGP messages must dump all of them, not just the first.
+     * Fixture has public keys in the first armor block and secret keys in
+     * the second. Before the fix the secret-key packets were silently
+     * dropped from --list-packets output. */
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    rnp_input_t input = NULL;
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_stream_key_merge/key-both.asc"));
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_dump_packets_to_output(input, output, 0));
+    rnp_input_destroy(input);
+
+    uint8_t *buf = NULL;
+    size_t   len = 0;
+    assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &len, false));
+    std::string dstr(buf, buf + len);
+    rnp_output_destroy(output);
+
+    /* first armor block: public key + 2 userids + 2 public subkeys */
+    assert_true(dstr.find("Public key packet") != std::string::npos);
+    assert_true(dstr.find("Public subkey packet") != std::string::npos);
+    /* second armor block: secret key + secret subkeys -- the bit that
+     * used to be dropped because ArmoredSource without AllowMultiple stops
+     * at the first -----END...----- */
+    assert_true(dstr.find("Secret key packet") != std::string::npos);
+    assert_true(dstr.find("Secret subkey packet") != std::string::npos);
+
+    /* Same coverage via the JSON dumper, which has the same multi-armor
+     * bug class. */
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/test_stream_key_merge/key-both.asc"));
+    char *json = NULL;
+    assert_rnp_success(rnp_dump_packets_to_json(input, 0, &json));
+    rnp_input_destroy(input);
+    std::string jstr(json);
+    rnp_buffer_destroy(json);
+    assert_true(jstr.find("\"tag\":5") != std::string::npos);   /* secret key */
+    assert_true(jstr.find("\"tag\":7") != std::string::npos);   /* secret subkey */
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_ffi_key_userid_dump_has_no_special_chars)
 {
     rnp_ffi_t    ffi = NULL;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2420,6 +2420,52 @@ TEST_F(rnp_tests, test_ffi_key_dump_edge_cases)
     rnp_ffi_destroy(ffi);
 }
 
+TEST_F(rnp_tests, test_ffi_dump_multiple_armored_messages)
+{
+    /* Regression for issue #2036: a single input file containing multiple
+     * armored OpenPGP messages must dump all of them, not just the first.
+     * Fixture has public keys in the first armor block and secret keys in
+     * the second. Before the fix the secret-key packets were silently
+     * dropped from --list-packets output. */
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    rnp_input_t input = NULL;
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_key_merge/key-both.asc"));
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_dump_packets_to_output(input, output, 0));
+    rnp_input_destroy(input);
+
+    uint8_t *buf = NULL;
+    size_t   len = 0;
+    assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &len, false));
+    std::string dstr(buf, buf + len);
+    rnp_output_destroy(output);
+
+    /* first armor block: public key + 2 userids + 2 public subkeys */
+    assert_true(dstr.find("Public key packet") != std::string::npos);
+    assert_true(dstr.find("Public subkey packet") != std::string::npos);
+    /* second armor block: secret key + secret subkeys -- the bit that
+     * used to be dropped because ArmoredSource without AllowMultiple stops
+     * at the first -----END...----- */
+    assert_true(dstr.find("Secret key packet") != std::string::npos);
+    assert_true(dstr.find("Secret subkey packet") != std::string::npos);
+
+    /* Same coverage via the JSON dumper, which has the same multi-armor
+     * bug class. */
+    assert_rnp_success(rnp_input_from_path(&input, "data/test_stream_key_merge/key-both.asc"));
+    char *json = NULL;
+    assert_rnp_success(rnp_dump_packets_to_json(input, 0, &json));
+    rnp_input_destroy(input);
+    std::string jstr(json);
+    rnp_buffer_destroy(json);
+    assert_true(jstr.find("\"tag\":5") != std::string::npos); /* secret key */
+    assert_true(jstr.find("\"tag\":7") != std::string::npos); /* secret subkey */
+
+    rnp_ffi_destroy(ffi);
+}
+
 TEST_F(rnp_tests, test_ffi_key_userid_dump_has_no_special_chars)
 {
     rnp_ffi_t              ffi = NULL;


### PR DESCRIPTION
## Summary

Fixes #2036. The packet dumper now walks all armored messages in inputs that contain more than one, instead of stopping after the first.

### Root cause

`DumpContextDst::dump()` and `DumpContextJson::dump()` used `init_armored_src()` which reads exactly one armor block and reports EOF at the `-----END ...-----` line. Inputs like `data/test_stream_key_merge/key-both.asc` (public keys in the first block, secret keys in the second) silently dropped everything after the first block.

The fix is the same pattern already used by `process_pgp_signatures()` and the key loader: `rnp::ArmoredSource` constructed with `AllowBinary | AllowMultiple`, then loop on `armor.eof() && armor.multiple()` → `armor.restart()`.

### Behaviour change

Before:
```
:armored input
:off 0: packet header 0x99... (tag 6, len 397)    ← public key only
...                                                 ← secret-key block silently dropped
```

After:
```
:armored input
:off 0: packet header 0x99... (tag 6, len 397)     ← public key
...
:off 0: packet header 0x95... (tag 5, len 1414)    ← secret key now dumped
:off 1417: packet header 0xb4... (tag 13, len 15)  ← secret-block UID
...
```

Output now matches `gpg --list-packets` on the same fixture (modulo intentional formatting differences).

### Test plan

- [x] `test_ffi_dump_multiple_armored_messages` (new) — covers both the text and JSON dumpers; asserts `Secret key packet` / `Secret subkey packet` appear in the output and `"tag":5` / `"tag":7` appear in the JSON
- [x] `test_ffi_key_dump`, `test_ffi_key_dump_edge_cases`, `test_ffi_signatures_dump` — no regression
- [x] Manually compared `./rnp --list-packets src/tests/data/test_stream_key_merge/key-both.asc` to the `gpg` dump attached to issue #2036 — same number of packets, same types
- [ ] CI green

### Out of scope

Issue #2036 also mentions a broader audit (vendor subpackets, partial-length packets, PQC messages). This PR is scoped to the specific bug the maintainer identified in the issue thread (multiple armored messages). The broader audit belongs in follow-up PRs and intersects with #13 (Photo ID) for one of the gap categories.
