### PR TITLE
ffi: add rnp_uid_get_photo() for Photo ID read support (#13)

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -115,6 +115,13 @@ typedef uint32_t rnp_result_t;
 #define RNP_USER_ATTR (2U)
 
 /**
+ * Photo ID format, returned by rnp_uid_get_photo().
+ */
+#define RNP_PHOTO_FORMAT_UNKNOWN (0U)
+#define RNP_PHOTO_FORMAT_JPEG (1U)
+#define RNP_PHOTO_FORMAT_PNG (2U)
+
+/**
  * Predefined feature security levels
  */
 #define RNP_SECURITY_PROHIBITED (0U)
@@ -1493,6 +1500,32 @@ RNP_API rnp_result_t rnp_uid_get_type(rnp_uid_handle_t uid, uint32_t *type);
  * @return RNP_SUCCESS or error code if failed.
  */
 RNP_API rnp_result_t rnp_uid_get_data(rnp_uid_handle_t uid, void **data, size_t *size);
+
+/** Get the photo from a User Attribute UID. Returns just the image bytes
+ *  (no UserAttr subpacket framing), along with the detected format.
+ *
+ *  Format is detected from the image bytes' magic header (JPEG: FF D8 FF,
+ *  PNG: 89 50 4E 47), not from the UserAttr header's format byte, which
+ *  real-world keys frequently leave at 0. If the bytes don't match either
+ *  magic, RNP_PHOTO_FORMAT_UNKNOWN is returned and the bytes are still
+ *  handed back so the caller can decide what to do.
+ *
+ *  If the UID is not a User Attribute packet (rnp_uid_get_type() did not
+ *  return RNP_USER_ATTR), this returns RNP_ERROR_BAD_PARAMETERS.
+ *
+ * @param uid uid handle, cannot be NULL. Must reference a User Attribute UID.
+ * @param format cannot be NULL. On success, set to one of RNP_PHOTO_FORMAT_*.
+ * @param data cannot be NULL. On success, points to a malloc'd buffer of
+ *            image bytes. Must be deallocated by caller via rnp_buffer_destroy().
+ * @param size cannot be NULL. On success, size of data in bytes.
+ * @return RNP_SUCCESS on success. RNP_ERROR_BAD_PARAMETERS if uid is not a
+ *         User Attribute packet. RNP_ERROR_BAD_STATE if the User Attribute
+ *         body is malformed or contains no image subpacket.
+ */
+RNP_API rnp_result_t rnp_uid_get_photo(rnp_uid_handle_t uid,
+                                       uint32_t *      format,
+                                       void **          data,
+                                       size_t *         size);
 
 /** Check whether uid is marked as primary.
  *

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1523,7 +1523,7 @@ RNP_API rnp_result_t rnp_uid_get_data(rnp_uid_handle_t uid, void **data, size_t 
  *         body is malformed or contains no image subpacket.
  */
 RNP_API rnp_result_t rnp_uid_get_photo(rnp_uid_handle_t uid,
-                                       uint32_t *      format,
+                                       uint32_t *       format,
                                        void **          data,
                                        size_t *         size);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -27,6 +27,7 @@
 
 #include "crypto/common.h"
 #include "key.hpp"
+#include "userid.hpp"
 #include "defaults.h"
 #include <assert.h>
 #include <json_object.h>
@@ -5838,6 +5839,35 @@ try {
     }
     memcpy(*data, id->pkt.uid.data(), id->pkt.uid.size());
     *size = id->pkt.uid.size();
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_uid_get_photo(rnp_uid_handle_t uid, uint32_t *format, void **data, size_t *size)
+try {
+    if (!uid || !format || !data || !size) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    auto id = rnp_uid_handle_get_uid(uid);
+    if (!id) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    if (id->pkt.tag != PGP_PKT_USER_ATTR) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::PhotoFormat         fmt = rnp::PhotoFormat::Unknown;
+    std::vector<uint8_t> image;
+    if (!rnp::parse_photo_attribute(id->pkt.uid, image, fmt)) {
+        return RNP_ERROR_BAD_STATE;
+    }
+    *data = malloc(image.size());
+    if (image.size() && !*data) {
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
+    }
+    memcpy(*data, image.data(), image.size());
+    *size = image.size();
+    *format = static_cast<uint32_t>(fmt);
     return RNP_SUCCESS;
 }
 FFI_GUARD

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -27,6 +27,7 @@
 
 #include "crypto/common.h"
 #include "key.hpp"
+#include "userid.hpp"
 #include "defaults.h"
 #include <assert.h>
 #include <nlohmann/json.hpp>
@@ -5866,6 +5867,35 @@ try {
     }
     memcpy(*data, id->pkt.uid.data(), id->pkt.uid.size());
     *size = id->pkt.uid.size();
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_uid_get_photo(rnp_uid_handle_t uid, uint32_t *format, void **data, size_t *size)
+try {
+    if (!uid || !format || !data || !size) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    auto id = rnp_uid_handle_get_uid(uid);
+    if (!id) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    if (id->pkt.tag != PGP_PKT_USER_ATTR) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::PhotoFormat         fmt = rnp::PhotoFormat::Unknown;
+    std::vector<uint8_t> image;
+    if (!rnp::parse_photo_attribute(id->pkt.uid, image, fmt)) {
+        return RNP_ERROR_BAD_STATE;
+    }
+    *data = malloc(image.size());
+    if (image.size() && !*data) {
+        return RNP_ERROR_OUT_OF_MEMORY; // LCOV_EXCL_LINE
+    }
+    memcpy(*data, image.data(), image.size());
+    *size = image.size();
+    *format = static_cast<uint32_t>(fmt);
     return RNP_SUCCESS;
 }
 FFI_GUARD

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -5884,7 +5884,7 @@ try {
     if (id->pkt.tag != PGP_PKT_USER_ATTR) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    rnp::PhotoFormat         fmt = rnp::PhotoFormat::Unknown;
+    rnp::PhotoFormat     fmt = rnp::PhotoFormat::Unknown;
     std::vector<uint8_t> image;
     if (!rnp::parse_photo_attribute(id->pkt.uid, image, fmt)) {
         return RNP_ERROR_BAD_STATE;

--- a/src/lib/userid.cpp
+++ b/src/lib/userid.cpp
@@ -144,10 +144,10 @@ parse_photo_attribute(const std::vector<uint8_t> &uid,
         if (sub_len == 0 || pos + sub_len > uid.size()) {
             return false;
         }
-        size_t sub_end = pos + sub_len;
-        uint8_t     sub_type = uid[pos];
+        size_t         sub_end = pos + sub_len;
+        uint8_t        sub_type = uid[pos];
         const uint8_t *img = nullptr;
-        size_t          img_len = 0;
+        size_t         img_len = 0;
         if (sub_type == 1 && sub_len >= 2) {
             /* Image Attribute. Per RFC 4880 §5.12.1 / RFC 9580 §5.13.1,
              * the image header length byte counts ITSELF, so the remaining
@@ -162,8 +162,8 @@ parse_photo_attribute(const std::vector<uint8_t> &uid,
         if (img && img_len >= 3) {
             if (img[0] == 0xFF && img[1] == 0xD8 && img[2] == 0xFF) {
                 format = PhotoFormat::JPEG;
-            } else if (img[0] == 0x89 && img[1] == 0x50 && img[2] == 0x4E &&
-                       img_len >= 4 && img[3] == 0x47) {
+            } else if (img[0] == 0x89 && img[1] == 0x50 && img[2] == 0x4E && img_len >= 4 &&
+                       img[3] == 0x47) {
                 format = PhotoFormat::PNG;
             } else {
                 /* Unknown image format; still return the bytes and let the

--- a/src/lib/userid.cpp
+++ b/src/lib/userid.cpp
@@ -95,4 +95,87 @@ UserID::clear_sigs()
     sigs_.clear();
 }
 
+/* Decode the variable-length subpacket length prefix used by both signature
+ * and User Attribute subpackets (see RFC 4880 §5.2.3.1 / RFC 9580 §5.2.3.1).
+ * On success, returns true and advances `pos` past the length field. */
+static bool
+skip_subpacket_length(const std::vector<uint8_t> &buf, size_t &pos, size_t &len)
+{
+    if (pos >= buf.size()) {
+        return false;
+    }
+    uint8_t b0 = buf[pos++];
+    if (b0 < 192) {
+        len = b0;
+    } else if (b0 < 224) {
+        if (pos >= buf.size()) {
+            return false;
+        }
+        len = ((size_t)(b0 - 192) << 8) + buf[pos++] + 192;
+    } else if (b0 == 255) {
+        if (pos + 4 > buf.size()) {
+            return false;
+        }
+        len = ((size_t) buf[pos] << 24) | ((size_t) buf[pos + 1] << 16) |
+              ((size_t) buf[pos + 2] << 8) | (size_t) buf[pos + 3];
+        pos += 4;
+    } else {
+        /* 224-254: partial-length, not valid for UserAttr subpackets */
+        return false;
+    }
+    return true;
+}
+
+bool
+parse_photo_attribute(const std::vector<uint8_t> &uid,
+                      std::vector<uint8_t> &      image,
+                      PhotoFormat &               format)
+{
+    image.clear();
+    format = PhotoFormat::Unknown;
+
+    /* Walk attribute subpackets until we find an image (type 1). */
+    size_t pos = 0;
+    while (pos < uid.size()) {
+        size_t sub_len = 0;
+        if (!skip_subpacket_length(uid, pos, sub_len)) {
+            return false;
+        }
+        if (sub_len == 0 || pos + sub_len > uid.size()) {
+            return false;
+        }
+        size_t sub_end = pos + sub_len;
+        uint8_t     sub_type = uid[pos];
+        const uint8_t *img = nullptr;
+        size_t          img_len = 0;
+        if (sub_type == 1 && sub_len >= 2) {
+            /* Image Attribute. Per RFC 4880 §5.12.1 / RFC 9580 §5.13.1,
+             * the image header length byte counts ITSELF, so the remaining
+             * header bytes to skip are (hdr_len - 1). */
+            uint8_t hdr_len = uid[pos + 1];
+            if (hdr_len < 1 || (size_t) hdr_len + 1 > sub_len) {
+                return false;
+            }
+            img = uid.data() + pos + 1 + hdr_len;
+            img_len = sub_len - 1 - hdr_len;
+        }
+        if (img && img_len >= 3) {
+            if (img[0] == 0xFF && img[1] == 0xD8 && img[2] == 0xFF) {
+                format = PhotoFormat::JPEG;
+            } else if (img[0] == 0x89 && img[1] == 0x50 && img[2] == 0x4E &&
+                       img_len >= 4 && img[3] == 0x47) {
+                format = PhotoFormat::PNG;
+            } else {
+                /* Unknown image format; still return the bytes and let the
+                 * caller decide. */
+                format = PhotoFormat::Unknown;
+            }
+            image.assign(img, img + img_len);
+            return true;
+        }
+        pos = sub_end;
+    }
+    return false;
+}
+
 } // namespace rnp

--- a/src/lib/userid.hpp
+++ b/src/lib/userid.hpp
@@ -65,6 +65,21 @@ class UserID {
     static const uint32_t Any = (uint32_t) -3;
 };
 
+/* Photo ID format constants — mirror RNP_PHOTO_FORMAT_* in rnp.h. */
+enum class PhotoFormat : uint8_t { Unknown = 0, JPEG = 1, PNG = 2 };
+
+/* Parse the body of a User Attribute packet (tag 17) and extract the first
+ * image attribute subpacket's image bytes plus its detected format.
+ *
+ * Returns false if the body is malformed or does not contain an image
+ * attribute. The format is detected from the image bytes' magic header
+ * (FF D8 FF for JPEG, 89 50 4E 47 for PNG) rather than the header's
+ * format byte, since real-world keys frequently leave the format byte
+ * at 0 even when the data is a valid JPEG. */
+bool parse_photo_attribute(const std::vector<uint8_t> &uid,
+                           std::vector<uint8_t> &      image,
+                           PhotoFormat &               format);
+
 } // namespace rnp
 
 #endif

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -1156,13 +1156,13 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
      * independently of the cli_tests fixture set. */
     using namespace rnp;
 
-    auto build_userattr = [](uint8_t                 subpacket_type,
-                             uint8_t                 header_len,
+    auto build_userattr = [](uint8_t                     subpacket_type,
+                             uint8_t                     header_len,
                              const std::vector<uint8_t> &header_tail,
                              const std::vector<uint8_t> &image) -> std::vector<uint8_t> {
         /* Build a UserAttr body containing exactly one subpacket of the
          * requested shape. Subpacket body = type + hdr_len + header_tail + image. */
-        size_t sub_body = 1 + 1 + header_tail.size() + image.size();
+        size_t               sub_body = 1 + 1 + header_tail.size() + image.size();
         std::vector<uint8_t> body;
         if (sub_body < 192) {
             body.push_back((uint8_t) sub_body);
@@ -1179,10 +1179,10 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
 
     /* JPEG happy path: 16-byte header, magic FF D8 FF E0 ... */
     {
-        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10,
-                                      'J', 'F', 'I', 'F', 0x00, 0x01};
+        std::vector<uint8_t> image = {
+          0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01};
         std::vector<uint8_t> header_tail(15, 0x00);
-        auto body = build_userattr(1, 16, header_tail, image);
+        auto                 body = build_userattr(1, 16, header_tail, image);
         std::vector<uint8_t> out;
         PhotoFormat          fmt = PhotoFormat::Unknown;
         assert_true(parse_photo_attribute(body, out, fmt));
@@ -1193,10 +1193,10 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
 
     /* PNG happy path: magic 89 50 4E 47 0D 0A 1A 0A */
     {
-        std::vector<uint8_t> image = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-                                      'P', 'N', 'G'};
+        std::vector<uint8_t> image = {
+          0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 'P', 'N', 'G'};
         std::vector<uint8_t> header_tail(15, 0x00);
-        auto body = build_userattr(1, 16, header_tail, image);
+        auto                 body = build_userattr(1, 16, header_tail, image);
         std::vector<uint8_t> out;
         PhotoFormat          fmt = PhotoFormat::Unknown;
         assert_true(parse_photo_attribute(body, out, fmt));
@@ -1208,7 +1208,7 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
     {
         std::vector<uint8_t> image = {0x42, 0x4D, 0x00, 0x00, 'B', 'M'}; // BMP magic
         std::vector<uint8_t> header_tail(15, 0x00);
-        auto body = build_userattr(1, 16, header_tail, image);
+        auto                 body = build_userattr(1, 16, header_tail, image);
         std::vector<uint8_t> out;
         PhotoFormat          fmt = PhotoFormat::JPEG;
         assert_true(parse_photo_attribute(body, out, fmt));
@@ -1229,7 +1229,7 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
     {
         std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0};
         std::vector<uint8_t> header_tail(15, 0x00);
-        auto body = build_userattr(2 /*unknown type*/, 16, header_tail, image);
+        auto                 body = build_userattr(2 /*unknown type*/, 16, header_tail, image);
         std::vector<uint8_t> out;
         PhotoFormat          fmt = PhotoFormat::Unknown;
         assert_false(parse_photo_attribute(body, out, fmt));
@@ -1248,7 +1248,7 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
     {
         std::vector<uint8_t> image = {0xFF, 0xD8};
         std::vector<uint8_t> header_tail(15, 0x00);
-        auto body = build_userattr(1, 16, header_tail, image);
+        auto                 body = build_userattr(1, 16, header_tail, image);
         std::vector<uint8_t> out;
         PhotoFormat          fmt = PhotoFormat::Unknown;
         assert_false(parse_photo_attribute(body, out, fmt));
@@ -1257,12 +1257,13 @@ TEST_F(rnp_tests, test_parse_photo_attribute)
     /* 5-byte subpacket length form (b0 == 255) — exercised separately from
      * the 2-byte form, which is what the existing fixture happens to use. */
     {
-        std::vector<uint8_t> image(400, 0xAA); // > 192 to force 5-byte form? actually need >8383
+        std::vector<uint8_t> image(400,
+                                   0xAA); // > 192 to force 5-byte form? actually need >8383
         image[0] = 0xFF;
         image[1] = 0xD8;
         image[2] = 0xFF;
         std::vector<uint8_t> header_tail(15, 0x00);
-        size_t                sub_body = 1 + 1 + header_tail.size() + image.size();
+        size_t               sub_body = 1 + 1 + header_tail.size() + image.size();
         std::vector<uint8_t> body = {0xFF,
                                      (uint8_t)((sub_body >> 24) & 0xff),
                                      (uint8_t)((sub_body >> 16) & 0xff),

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -33,6 +33,7 @@
 #include "support.h"
 #include "fingerprint.hpp"
 #include "keygen.hpp"
+#include "userid.hpp"
 
 TEST_F(rnp_tests, hash_test_success)
 {
@@ -1144,6 +1145,177 @@ TEST_F(rnp_tests, test_validate_key_material)
     assert_false(ehkey.valid());
     ehkey.ec().p[0] -= 2;
     key = pgp_key_pkt_t();
+}
+
+TEST_F(rnp_tests, test_parse_photo_attribute)
+{
+    /* Direct unit tests for rnp::parse_photo_attribute. The FFI path
+     * (test_ffi_load_userattr) only exercises one fixture; here we cover
+     * each branch of the parser directly so codecov sees every code path
+     * and so regressions in length decoding or magic-byte detection surface
+     * independently of the cli_tests fixture set. */
+    using namespace rnp;
+
+    auto build_userattr = [](uint8_t                 subpacket_type,
+                             uint8_t                 header_len,
+                             const std::vector<uint8_t> &header_tail,
+                             const std::vector<uint8_t> &image) -> std::vector<uint8_t> {
+        /* Build a UserAttr body containing exactly one subpacket of the
+         * requested shape. Subpacket body = type + hdr_len + header_tail + image. */
+        size_t sub_body = 1 + 1 + header_tail.size() + image.size();
+        std::vector<uint8_t> body;
+        if (sub_body < 192) {
+            body.push_back((uint8_t) sub_body);
+        } else {
+            body.push_back((uint8_t)(((sub_body - 192) >> 8) + 192));
+            body.push_back((uint8_t)((sub_body - 192) & 0xff));
+        }
+        body.push_back(subpacket_type);
+        body.push_back(header_len);
+        body.insert(body.end(), header_tail.begin(), header_tail.end());
+        body.insert(body.end(), image.begin(), image.end());
+        return body;
+    };
+
+    /* JPEG happy path: 16-byte header, magic FF D8 FF E0 ... */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10,
+                                      'J', 'F', 'I', 'F', 0x00, 0x01};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::JPEG);
+        assert_int_equal(out.size(), image.size());
+        assert_true(memcmp(out.data(), image.data(), image.size()) == 0);
+    }
+
+    /* PNG happy path: magic 89 50 4E 47 0D 0A 1A 0A */
+    {
+        std::vector<uint8_t> image = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+                                      'P', 'N', 'G'};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::PNG);
+        assert_int_equal(out.size(), image.size());
+    }
+
+    /* Unknown image format — bytes returned, format = Unknown */
+    {
+        std::vector<uint8_t> image = {0x42, 0x4D, 0x00, 0x00, 'B', 'M'}; // BMP magic
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::JPEG;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::Unknown);
+        assert_int_equal(out.size(), image.size());
+    }
+
+    /* Empty body — must fail cleanly */
+    {
+        std::vector<uint8_t> empty;
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(empty, out, fmt));
+    }
+
+    /* Subpacket type != 1 — must skip past it, then EOF without an image,
+     * so return false. */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(2 /*unknown type*/, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* Image header length 0 — must reject (RFC says it must be >= 16) */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF};
+        auto                 body = build_userattr(1, 0, {}, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* Image too small (< 3 bytes) — must fail since magic can't be checked */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* 5-byte subpacket length form (b0 == 255) — exercised separately from
+     * the 2-byte form, which is what the existing fixture happens to use. */
+    {
+        std::vector<uint8_t> image(400, 0xAA); // > 192 to force 5-byte form? actually need >8383
+        image[0] = 0xFF;
+        image[1] = 0xD8;
+        image[2] = 0xFF;
+        std::vector<uint8_t> header_tail(15, 0x00);
+        size_t                sub_body = 1 + 1 + header_tail.size() + image.size();
+        std::vector<uint8_t> body = {0xFF,
+                                     (uint8_t)((sub_body >> 24) & 0xff),
+                                     (uint8_t)((sub_body >> 16) & 0xff),
+                                     (uint8_t)((sub_body >> 8) & 0xff),
+                                     (uint8_t)(sub_body & 0xff)};
+        body.push_back(1); // subpacket type
+        body.push_back(16);
+        body.insert(body.end(), header_tail.begin(), header_tail.end());
+        body.insert(body.end(), image.begin(), image.end());
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::JPEG);
+    }
+
+    /* Partial-length encoding (b0 in 224-254) — not valid for UserAttr
+     * subpackets, must reject. */
+    {
+        std::vector<uint8_t> body = {0xE0, 0x01, 0x10, 0xFF, 0xD8, 0xFF};
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* Multiple subpackets: first one is unknown type, second is the image.
+     * The walker must skip past the first and find the image. */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0, 'J', 'F', 'I', 'F'};
+        std::vector<uint8_t> header_tail(15, 0x00);
+
+        /* First subpacket: type 99, body just 4 bytes of filler */
+        std::vector<uint8_t> body;
+        body.push_back(5); // length = 5 (1 type + 4 filler)
+        body.push_back(99);
+        body.push_back(1);
+        body.push_back(2);
+        body.push_back(3);
+        body.push_back(4);
+
+        /* Second subpacket: real image */
+        size_t sub_body = 1 + 1 + header_tail.size() + image.size();
+        body.push_back((uint8_t) sub_body);
+        body.push_back(1);
+        body.push_back(16);
+        body.insert(body.end(), header_tail.begin(), header_tail.end());
+        body.insert(body.end(), image.begin(), image.end());
+
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::JPEG);
+        assert_int_equal(out.size(), image.size());
+    }
 }
 
 TEST_F(rnp_tests, test_sm2_enabled)

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -33,6 +33,7 @@
 #include "support.h"
 #include "fingerprint.hpp"
 #include "keygen.hpp"
+#include "userid.hpp"
 
 TEST_F(rnp_tests, hash_test_success)
 {
@@ -1079,6 +1080,177 @@ TEST_F(rnp_tests, test_validate_key_material)
     assert_false(ehkey.valid());
     ehkey.ec().p[0] -= 2;
     key = pgp_key_pkt_t();
+}
+
+TEST_F(rnp_tests, test_parse_photo_attribute)
+{
+    /* Direct unit tests for rnp::parse_photo_attribute. The FFI path
+     * (test_ffi_load_userattr) only exercises one fixture; here we cover
+     * each branch of the parser directly so codecov sees every code path
+     * and so regressions in length decoding or magic-byte detection surface
+     * independently of the cli_tests fixture set. */
+    using namespace rnp;
+
+    auto build_userattr = [](uint8_t                 subpacket_type,
+                             uint8_t                 header_len,
+                             const std::vector<uint8_t> &header_tail,
+                             const std::vector<uint8_t> &image) -> std::vector<uint8_t> {
+        /* Build a UserAttr body containing exactly one subpacket of the
+         * requested shape. Subpacket body = type + hdr_len + header_tail + image. */
+        size_t sub_body = 1 + 1 + header_tail.size() + image.size();
+        std::vector<uint8_t> body;
+        if (sub_body < 192) {
+            body.push_back((uint8_t) sub_body);
+        } else {
+            body.push_back((uint8_t)(((sub_body - 192) >> 8) + 192));
+            body.push_back((uint8_t)((sub_body - 192) & 0xff));
+        }
+        body.push_back(subpacket_type);
+        body.push_back(header_len);
+        body.insert(body.end(), header_tail.begin(), header_tail.end());
+        body.insert(body.end(), image.begin(), image.end());
+        return body;
+    };
+
+    /* JPEG happy path: 16-byte header, magic FF D8 FF E0 ... */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10,
+                                      'J', 'F', 'I', 'F', 0x00, 0x01};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::JPEG);
+        assert_int_equal(out.size(), image.size());
+        assert_true(memcmp(out.data(), image.data(), image.size()) == 0);
+    }
+
+    /* PNG happy path: magic 89 50 4E 47 0D 0A 1A 0A */
+    {
+        std::vector<uint8_t> image = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+                                      'P', 'N', 'G'};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::PNG);
+        assert_int_equal(out.size(), image.size());
+    }
+
+    /* Unknown image format — bytes returned, format = Unknown */
+    {
+        std::vector<uint8_t> image = {0x42, 0x4D, 0x00, 0x00, 'B', 'M'}; // BMP magic
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::JPEG;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::Unknown);
+        assert_int_equal(out.size(), image.size());
+    }
+
+    /* Empty body — must fail cleanly */
+    {
+        std::vector<uint8_t> empty;
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(empty, out, fmt));
+    }
+
+    /* Subpacket type != 1 — must skip past it, then EOF without an image,
+     * so return false. */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(2 /*unknown type*/, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* Image header length 0 — must reject (RFC says it must be >= 16) */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF};
+        auto                 body = build_userattr(1, 0, {}, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* Image too small (< 3 bytes) — must fail since magic can't be checked */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8};
+        std::vector<uint8_t> header_tail(15, 0x00);
+        auto body = build_userattr(1, 16, header_tail, image);
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* 5-byte subpacket length form (b0 == 255) — exercised separately from
+     * the 2-byte form, which is what the existing fixture happens to use. */
+    {
+        std::vector<uint8_t> image(400, 0xAA); // > 192 to force 5-byte form? actually need >8383
+        image[0] = 0xFF;
+        image[1] = 0xD8;
+        image[2] = 0xFF;
+        std::vector<uint8_t> header_tail(15, 0x00);
+        size_t                sub_body = 1 + 1 + header_tail.size() + image.size();
+        std::vector<uint8_t> body = {0xFF,
+                                     (uint8_t)((sub_body >> 24) & 0xff),
+                                     (uint8_t)((sub_body >> 16) & 0xff),
+                                     (uint8_t)((sub_body >> 8) & 0xff),
+                                     (uint8_t)(sub_body & 0xff)};
+        body.push_back(1); // subpacket type
+        body.push_back(16);
+        body.insert(body.end(), header_tail.begin(), header_tail.end());
+        body.insert(body.end(), image.begin(), image.end());
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::JPEG);
+    }
+
+    /* Partial-length encoding (b0 in 224-254) — not valid for UserAttr
+     * subpackets, must reject. */
+    {
+        std::vector<uint8_t> body = {0xE0, 0x01, 0x10, 0xFF, 0xD8, 0xFF};
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_false(parse_photo_attribute(body, out, fmt));
+    }
+
+    /* Multiple subpackets: first one is unknown type, second is the image.
+     * The walker must skip past the first and find the image. */
+    {
+        std::vector<uint8_t> image = {0xFF, 0xD8, 0xFF, 0xE0, 'J', 'F', 'I', 'F'};
+        std::vector<uint8_t> header_tail(15, 0x00);
+
+        /* First subpacket: type 99, body just 4 bytes of filler */
+        std::vector<uint8_t> body;
+        body.push_back(5); // length = 5 (1 type + 4 filler)
+        body.push_back(99);
+        body.push_back(1);
+        body.push_back(2);
+        body.push_back(3);
+        body.push_back(4);
+
+        /* Second subpacket: real image */
+        size_t sub_body = 1 + 1 + header_tail.size() + image.size();
+        body.push_back((uint8_t) sub_body);
+        body.push_back(1);
+        body.push_back(16);
+        body.insert(body.end(), header_tail.begin(), header_tail.end());
+        body.insert(body.end(), image.begin(), image.end());
+
+        std::vector<uint8_t> out;
+        PhotoFormat          fmt = PhotoFormat::Unknown;
+        assert_true(parse_photo_attribute(body, out, fmt));
+        assert_int_equal((int) fmt, (int) PhotoFormat::JPEG);
+        assert_int_equal(out.size(), image.size());
+    }
 }
 
 TEST_F(rnp_tests, test_sm2_enabled)

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2681,8 +2681,8 @@ TEST_F(rnp_tests, test_ffi_load_userattr)
     rnp_uid_handle_t text_uid = NULL;
     assert_rnp_success(rnp_key_get_uid_handle_at(key, 0, &text_uid));
     uint32_t format = 99;
-    void *  photo = NULL;
-    size_t  photo_size = 0;
+    void *   photo = NULL;
+    size_t   photo_size = 0;
     assert_rnp_failure(rnp_uid_get_photo(text_uid, &format, &photo, &photo_size));
     rnp_uid_handle_destroy(text_uid);
 

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2621,6 +2621,38 @@ TEST_F(rnp_tests, test_ffi_load_userattr)
     assert_rnp_success(rnp_key_get_uid_at(key, 1, &uid));
     assert_string_equal(uid, "(photo)");
     rnp_buffer_destroy(uid);
+
+    // get the UID handle so we can exercise the photo API
+    rnp_uid_handle_t uid_handle = NULL;
+    assert_rnp_success(rnp_key_get_uid_handle_at(key, 1, &uid_handle));
+    uint32_t uid_type = 0;
+    assert_rnp_success(rnp_uid_get_type(uid_handle, &uid_type));
+    assert_int_equal(uid_type, RNP_USER_ATTR);
+
+    // rnp_uid_get_photo on a non-photo UID must be rejected
+    rnp_uid_handle_t text_uid = NULL;
+    assert_rnp_success(rnp_key_get_uid_handle_at(key, 0, &text_uid));
+    uint32_t format = 99;
+    void *  photo = NULL;
+    size_t  photo_size = 0;
+    assert_rnp_failure(rnp_uid_get_photo(text_uid, &format, &photo, &photo_size));
+    rnp_uid_handle_destroy(text_uid);
+
+    // rnp_uid_get_photo on the photo UID must return JPEG bytes
+    format = 99;
+    photo = NULL;
+    photo_size = 0;
+    assert_rnp_success(rnp_uid_get_photo(uid_handle, &format, &photo, &photo_size));
+    assert_int_equal(format, RNP_PHOTO_FORMAT_JPEG);
+    assert_non_null(photo);
+    // JPEG magic bytes
+    assert_true(photo_size >= 3);
+    assert_int_equal(((uint8_t *) photo)[0], 0xFF);
+    assert_int_equal(((uint8_t *) photo)[1], 0xD8);
+    assert_int_equal(((uint8_t *) photo)[2], 0xFF);
+    rnp_buffer_destroy(photo);
+    rnp_uid_handle_destroy(uid_handle);
+
     assert_rnp_success(rnp_key_handle_destroy(key));
     // cleanup
     rnp_ffi_destroy(ffi);

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2669,6 +2669,38 @@ TEST_F(rnp_tests, test_ffi_load_userattr)
     assert_rnp_success(rnp_key_get_uid_at(key, 1, &uid));
     assert_string_equal(uid, "(photo)");
     rnp_buffer_destroy(uid);
+
+    // get the UID handle so we can exercise the photo API
+    rnp_uid_handle_t uid_handle = NULL;
+    assert_rnp_success(rnp_key_get_uid_handle_at(key, 1, &uid_handle));
+    uint32_t uid_type = 0;
+    assert_rnp_success(rnp_uid_get_type(uid_handle, &uid_type));
+    assert_int_equal(uid_type, RNP_USER_ATTR);
+
+    // rnp_uid_get_photo on a non-photo UID must be rejected
+    rnp_uid_handle_t text_uid = NULL;
+    assert_rnp_success(rnp_key_get_uid_handle_at(key, 0, &text_uid));
+    uint32_t format = 99;
+    void *  photo = NULL;
+    size_t  photo_size = 0;
+    assert_rnp_failure(rnp_uid_get_photo(text_uid, &format, &photo, &photo_size));
+    rnp_uid_handle_destroy(text_uid);
+
+    // rnp_uid_get_photo on the photo UID must return JPEG bytes
+    format = 99;
+    photo = NULL;
+    photo_size = 0;
+    assert_rnp_success(rnp_uid_get_photo(uid_handle, &format, &photo, &photo_size));
+    assert_int_equal(format, RNP_PHOTO_FORMAT_JPEG);
+    assert_non_null(photo);
+    // JPEG magic bytes
+    assert_true(photo_size >= 3);
+    assert_int_equal(((uint8_t *) photo)[0], 0xFF);
+    assert_int_equal(((uint8_t *) photo)[1], 0xD8);
+    assert_int_equal(((uint8_t *) photo)[2], 0xFF);
+    rnp_buffer_destroy(photo);
+    rnp_uid_handle_destroy(uid_handle);
+
     assert_rnp_success(rnp_key_handle_destroy(key));
     // cleanup
     rnp_ffi_destroy(ffi);


### PR DESCRIPTION
## Summary

Foundation for issue #1947 (Photo ID support). Adds an FFI function that parses the User Attribute packet body and returns just the image bytes plus the detected format, so callers don't have to implement the subpacket length decoding and image-header walk themselves.

### What's in this PR

- **`include/rnp/rnp.h`**: new constants `RNP_PHOTO_FORMAT_{UNKNOWN,JPEG,PNG}` and new FFI function `rnp_uid_get_photo(uid, &format, &data, &size)` with thorough Doxygen.
- **`src/lib/userid.{hpp,cpp}`**: new helper `rnp::parse_photo_attribute(uid_body, image, format)` that walks the variable-length subpacket prefix, finds the first Image Attribute subpacket (type 1), and returns its image bytes plus detected format. The image header length byte counts itself (RFC 4880 §5.12.1 / RFC 9580 §5.13.1), so the remaining header bytes to skip are `hdr_len - 1`, not `hdr_len`. Format is detected from magic bytes (JPEG: FF D8 FF, PNG: 89 50 4E 47), not from the UserAttr header's format byte — real-world keys frequently leave that byte at 0 even when the image data is a valid JPEG.
- **`src/lib/rnp.cpp`**: FFI implementation. Returns `RNP_ERROR_BAD_PARAMETERS` if the UID is not a User Attribute packet, `RNP_ERROR_BAD_STATE` if the UserAttr body is malformed or contains no image subpacket.
- **`src/tests/ffi.cpp`**: extends the existing `test_ffi_load_userattr` to exercise the new API: asserts the photo UID returns JPEG bytes with the correct magic header, and that calling `rnp_uid_get_photo()` on a non-photo UID is rejected.

### Why

The "gpg can, rnp can't" feature gap is most visible to end users — Thunderbird users with photo IDs on their keys see them silently dropped when their keyring is read by rnp. The UserAttr packet was already loaded as an opaque UID with `type=RNP_USER_ATTR` and the raw bytes retrievable via `rnp_uid_get_data()`, but parsing those bytes was the caller's job. This PR makes the common case (a JPEG photo) one FFI call.

### Out of scope (follow-up PRs)

- `rnp_key_add_photo()` to attach a new photo to a key (needs serialiser work)
- CLI: `--show-photo` flag, `[photo]` indicator in `--list-keys`
- Negative tests with crafted malformed UserAttr bodies
- PNG photo round-trip test (would need a PNG fixture)

### Test plan

- [x] `test_ffi_load_userattr` (extended) passes: verifies JPEG magic, JPEG format constant, rejection of non-photo UID
- [x] Manual verification against `data/test_stream_key_load/ecc-25519-photo-pub.asc` — image bytes form a valid JPEG (starts with `FF D8 FF E0`, ends with `FF D9`)
- [x] No regressions in `test_ffi_add_userid`, `test_ffi_key_userid_dump_has_no_special_chars`, `test_ffi_key_dump_edge_cases`
- [ ] CI green
