### PR TITLE
ffi: rnp_key_protect_ex() with Argon2 + AEAD, and PQC/Argon2 negative tests

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2837,21 +2837,21 @@ RNP_API rnp_result_t rnp_key_protect(rnp_key_handle_t handle,
 #ifndef RNP_PROTECTION_PARAMS_T_DEFINED
 #define RNP_PROTECTION_PARAMS_T_DEFINED
 typedef struct rnp_protection_params_t {
-    const char *cipher;        /**< Symmetric cipher, e.g. "AES256". NULL = default. */
-    const char *cipher_mode;   /**< Block cipher mode, e.g. "CFB". NULL = default.
-                                    Ignored when aead_alg is set. */
-    const char *hash;          /**< Hash for S2K, e.g. "SHA256". NULL = default.
-                                    Not used with Argon2. */
-    size_t      iterations;    /**< Iteration count for iterated-and-salted S2K.
-                                    0 = lib default. Ignored for Argon2. */
-    const char *s2k_type;      /**< "Simple", "Salted", "Iterated and salted",
-                                    "Argon2". NULL = "Iterated and salted". */
-    const char *aead_alg;      /**< AEAD algorithm for v6 secret keys, e.g. "OCB",
-                                    "EAX". NULL = no AEAD (CFB instead). Required
-                                    when s2k_type = "Argon2". */
-    size_t      argon2_t;      /**< Argon2 time parameter (1-4 typical). 0 = default. */
-    size_t      argon2_p;      /**< Argon2 parallelism (lanes). 0 = default. */
-    size_t      argon2_m_kib;  /**< Argon2 memory in KiB. 0 = default. */
+    const char *cipher;      /**< Symmetric cipher, e.g. "AES256". NULL = default. */
+    const char *cipher_mode; /**< Block cipher mode, e.g. "CFB". NULL = default.
+                                  Ignored when aead_alg is set. */
+    const char *hash;        /**< Hash for S2K, e.g. "SHA256". NULL = default.
+                                  Not used with Argon2. */
+    size_t iterations;       /**< Iteration count for iterated-and-salted S2K.
+                                  0 = lib default. Ignored for Argon2. */
+    const char *s2k_type;    /**< "Simple", "Salted", "Iterated and salted",
+                                  "Argon2". NULL = "Iterated and salted". */
+    const char *aead_alg;    /**< AEAD algorithm for v6 secret keys, e.g. "OCB",
+                                  "EAX". NULL = no AEAD (CFB instead). Required
+                                  when s2k_type = "Argon2". */
+    size_t argon2_t;         /**< Argon2 time parameter (1-4 typical). 0 = default. */
+    size_t argon2_p;         /**< Argon2 parallelism (lanes). 0 = default. */
+    size_t argon2_m_kib;     /**< Argon2 memory in KiB. 0 = default. */
 } rnp_protection_params_t;
 #endif
 

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -2821,6 +2821,64 @@ RNP_API rnp_result_t rnp_key_protect(rnp_key_handle_t handle,
                                      const char *     hash,
                                      size_t           iterations);
 
+/**
+ * @brief Extended key protection parameters, allowing the caller to opt into
+ *        Argon2 S2K and AEAD encryption of the secret key material.
+ *
+ *  Pass a pointer to this struct to rnp_key_protect_ex(). Any field may be
+ *  NULL / 0 to take the default, except that selecting "Argon2" for s2k_type
+ *  implies AEAD usage (per RFC 9580 §5.13.2 / the OpenPGP crypto refresh),
+ *  so aead_alg must also be set or defaulted.
+ *
+ *  S2K type strings: "Simple", "Salted", "Iterated and salted" (default),
+ *  "Argon2". Argon2 requires ENABLE_CRYPTO_REFRESH at build time; on builds
+ *  without it, rnp_key_protect_ex() returns RNP_ERROR_NOT_SUPPORTED.
+ */
+#ifndef RNP_PROTECTION_PARAMS_T_DEFINED
+#define RNP_PROTECTION_PARAMS_T_DEFINED
+typedef struct rnp_protection_params_t {
+    const char *cipher;        /**< Symmetric cipher, e.g. "AES256". NULL = default. */
+    const char *cipher_mode;   /**< Block cipher mode, e.g. "CFB". NULL = default.
+                                    Ignored when aead_alg is set. */
+    const char *hash;          /**< Hash for S2K, e.g. "SHA256". NULL = default.
+                                    Not used with Argon2. */
+    size_t      iterations;    /**< Iteration count for iterated-and-salted S2K.
+                                    0 = lib default. Ignored for Argon2. */
+    const char *s2k_type;      /**< "Simple", "Salted", "Iterated and salted",
+                                    "Argon2". NULL = "Iterated and salted". */
+    const char *aead_alg;      /**< AEAD algorithm for v6 secret keys, e.g. "OCB",
+                                    "EAX". NULL = no AEAD (CFB instead). Required
+                                    when s2k_type = "Argon2". */
+    size_t      argon2_t;      /**< Argon2 time parameter (1-4 typical). 0 = default. */
+    size_t      argon2_p;      /**< Argon2 parallelism (lanes). 0 = default. */
+    size_t      argon2_m_kib;  /**< Argon2 memory in KiB. 0 = default. */
+} rnp_protection_params_t;
+#endif
+
+/**
+ * @brief Protect (encrypt) a secret key with the extended parameter set.
+ *
+ *  Like rnp_key_protect(), but allows selecting Argon2 S2K and AEAD
+ *  encryption of the secret-key material (RFC 9580 crypto refresh).
+ *  Callers who want the defaults of rnp_key_protect() should keep using it;
+ *  this function is for callers that need fine-grained control.
+ *
+ *  If the key is currently encrypted, it is first decrypted using the
+ *  FFI password provider. If params is NULL, behaves like rnp_key_protect()
+ *  with all-NULL string parameters.
+ *
+ *  @param handle secret key handle, cannot be NULL.
+ *  @param password new password, cannot be NULL.
+ *  @param params protection parameters, may be NULL for defaults.
+ *  @return RNP_SUCCESS on success. RNP_ERROR_NOT_SUPPORTED if Argon2 was
+ *          requested but the library was built without ENABLE_CRYPTO_REFRESH.
+ *          RNP_ERROR_BAD_PARAMETERS for invalid algorithm names or
+ *          inconsistent parameter combinations.
+ */
+RNP_API rnp_result_t rnp_key_protect_ex(rnp_key_handle_t               handle,
+                                        const char *                   password,
+                                        const rnp_protection_params_t *params);
+
 /** unprotect the key
  *
  *  This removes the encryption from the key.

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7923,9 +7923,167 @@ try {
 FFI_GUARD
 
 rnp_result_t
+rnp_key_protect_ex(rnp_key_handle_t handle, const char *password, const rnp_protection_params_t *params)
+try {
+    if (!handle || !password) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    /* Resolve FFI strings into enums. Defaults mirror rnp_key_protect. */
+    pgp_symm_alg_t    symm_alg = DEFAULT_PGP_SYMM_ALG;
+    pgp_cipher_mode_t cipher_mode = DEFAULT_PGP_CIPHER_MODE;
+    pgp_hash_alg_t    hash_alg = DEFAULT_PGP_HASH_ALG;
+    unsigned          iterations = 0;
+    pgp_s2k_specifier_t s2k_specifier = PGP_S2KS_ITERATED_AND_SALTED;
+    pgp_s2k_usage_t     s2k_usage = PGP_S2KU_ENCRYPTED_AND_HASHED;
+    pgp_aead_alg_t      aead_alg = PGP_AEAD_NONE;
+    uint8_t             argon2_t = 0;
+    uint8_t             argon2_p = 0;
+    uint8_t             argon2_m = 0;
+    bool                want_argon2 = false;
+
+    if (params) {
+        if (params->cipher && !str_to_cipher(params->cipher, &symm_alg)) {
+            FFI_LOG(handle->ffi, "Invalid cipher: %s", params->cipher);
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        if (params->cipher_mode && !str_to_cipher_mode(params->cipher_mode, &cipher_mode)) {
+            FFI_LOG(handle->ffi, "Invalid cipher mode: %s", params->cipher_mode);
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        if (params->hash && !str_to_hash_alg(params->hash, &hash_alg)) {
+            FFI_LOG(handle->ffi, "Invalid hash: %s", params->hash);
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        iterations = params->iterations;
+
+        const char *stype = params->s2k_type ? params->s2k_type : "Iterated and salted";
+        if (rnp::str_case_eq(stype, "Simple")) {
+            s2k_specifier = PGP_S2KS_SIMPLE;
+        } else if (rnp::str_case_eq(stype, "Salted")) {
+            s2k_specifier = PGP_S2KS_SALTED;
+        } else if (rnp::str_case_eq(stype, "Iterated and salted")) {
+            s2k_specifier = PGP_S2KS_ITERATED_AND_SALTED;
+        } else if (rnp::str_case_eq(stype, "Argon2")) {
+#if !defined(ENABLE_CRYPTO_REFRESH)
+            FFI_LOG(handle->ffi, "Argon2 S2K requires a build with ENABLE_CRYPTO_REFRESH");
+            return RNP_ERROR_NOT_SUPPORTED;
+#else
+            want_argon2 = true;
+            s2k_specifier = PGP_S2KS_ARGON2;
+            s2k_usage = PGP_S2KU_AEAD;
+            aead_alg = params->aead_alg ? PGP_AEAD_NONE /* set below */ : PGP_AEAD_OCB;
+            if (params->aead_alg) {
+                if (!str_to_aead_alg(params->aead_alg, &aead_alg) ||
+                    aead_alg == PGP_AEAD_NONE) {
+                    FFI_LOG(handle->ffi, "Invalid AEAD algorithm: %s", params->aead_alg);
+                    return RNP_ERROR_BAD_PARAMETERS;
+                }
+            }
+            /* Default Argon2 params follow RFC 9100 §4: t=1, p=4, m=2^21 on
+             * 64-bit; t=3, p=4, m=2^16 on memory-constrained 32-bit. */
+            argon2_t = params->argon2_t ? (uint8_t) params->argon2_t :
+                       (uint8_t)(sizeof(size_t) > 4 ? 1 : 3);
+            argon2_p = params->argon2_p ? (uint8_t) params->argon2_p : (uint8_t) 4;
+            if (params->argon2_m_kib) {
+                /* User gives KiB; on-wire field is log2(bytes). */
+                size_t m_bytes = params->argon2_m_kib * 1024;
+                uint8_t  log = 0;
+                while (m_bytes > 1) {
+                    m_bytes >>= 1;
+                    log++;
+                }
+                argon2_m = log;
+            } else {
+                argon2_m = (uint8_t)(sizeof(size_t) > 4 ? 21 : 16);
+            }
+#endif
+        } else {
+            FFI_LOG(handle->ffi, "Unknown S2K type: %s", stype);
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        /* Non-Argon2 AEAD: caller may request AEAD explicitly */
+        if (!want_argon2 && params->aead_alg) {
+#if !defined(ENABLE_CRYPTO_REFRESH)
+            FFI_LOG(handle->ffi, "AEAD secret-key protection requires ENABLE_CRYPTO_REFRESH");
+            return RNP_ERROR_NOT_SUPPORTED;
+#else
+            if (!str_to_aead_alg(params->aead_alg, &aead_alg) || aead_alg == PGP_AEAD_NONE) {
+                FFI_LOG(handle->ffi, "Invalid AEAD algorithm: %s", params->aead_alg);
+                return RNP_ERROR_BAD_PARAMETERS;
+            }
+            s2k_usage = PGP_S2KU_AEAD;
+#endif
+        }
+    }
+
+    /* Get the key; decrypt if currently encrypted (same as rnp_key_protect) */
+    auto *key = get_key_require_secret(handle);
+    if (!key) {
+        return RNP_ERROR_NO_SUITABLE_KEY;
+    }
+    pgp_key_pkt_t *decrypted_key = NULL;
+    const std::string pass = password;
+    if (key->encrypted()) {
+        pgp_password_ctx_t ctx(PGP_OP_PROTECT, key);
+        decrypted_key = pgp_decrypt_seckey(*key, handle->ffi->pass_provider, ctx);
+        if (!decrypted_key) {
+            return RNP_ERROR_GENERIC;
+        }
+    }
+    pgp_key_pkt_t &target = decrypted_key ? *decrypted_key : key->pkt();
+    if (!target.material || !target.material->secret()) {
+        delete decrypted_key;
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    /* Populate sec_protection directly so we have full control over the
+     * Argon2 / AEAD fields that Key::protect() does not expose. */
+    auto &sp = target.sec_protection;
+    sp = {};
+    sp.s2k.usage = s2k_usage;
+    sp.s2k.specifier = s2k_specifier;
+    sp.symm_alg = symm_alg;
+#if defined(ENABLE_CRYPTO_REFRESH)
+    sp.cipher_mode = (s2k_usage == PGP_S2KU_AEAD) ? PGP_CIPHER_MODE_NONE : cipher_mode;
+#else
+    sp.cipher_mode = cipher_mode;
+#endif
+    sp.s2k.hash_alg = hash_alg;
+#if defined(ENABLE_CRYPTO_REFRESH)
+    sp.aead_alg = aead_alg;
+    if (want_argon2) {
+        sp.s2k.argon2_t = argon2_t;
+        sp.s2k.argon2_p = argon2_p;
+        sp.s2k.argon2_encoded_m = argon2_m;
+    }
+#endif
+    /* Iteration count: for iterated-and-salted, derive a sane default if 0 */
+    if (s2k_specifier == PGP_S2KS_ITERATED_AND_SALTED) {
+        unsigned iter = iterations;
+        if (!iter) {
+            iter = handle->ffi->context.s2k_iterations(hash_alg);
+        }
+        sp.s2k.iterations = pgp_s2k_round_iterations(iter);
+    } else {
+        sp.s2k.iterations = 0;
+    }
+
+    /* encrypt_secret_key operates on the target packet in-place. Key::protect
+     * also copies the result back to pkt(); we mirror that here. */
+    rnp_result_t ret = encrypt_secret_key(&target, password, handle->ffi->context.rng);
+    if (ret == RNP_SUCCESS) {
+        if (decrypted_key) {
+            key->pkt() = std::move(target);
+        }
+    }
+    delete decrypted_key;
+    return ret;
+}
+FFI_GUARD
+
+rnp_result_t
 rnp_key_unprotect(rnp_key_handle_t handle, const char *password)
 try {
-    // checks
     if (!handle) {
         return RNP_ERROR_NULL_POINTER;
     }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7937,11 +7937,15 @@ try {
     unsigned            iterations = 0;
     pgp_s2k_specifier_t s2k_specifier = PGP_S2KS_ITERATED_AND_SALTED;
     pgp_s2k_usage_t     s2k_usage = PGP_S2KU_ENCRYPTED_AND_HASHED;
-    pgp_aead_alg_t      aead_alg = PGP_AEAD_NONE;
-    uint8_t             argon2_t = 0;
-    uint8_t             argon2_p = 0;
-    uint8_t             argon2_m = 0;
-    bool                want_argon2 = false;
+#if defined(ENABLE_CRYPTO_REFRESH)
+    /* only read on AEAD/Argon2 paths, all of which require the
+     * crypto-refresh build */
+    pgp_aead_alg_t aead_alg = PGP_AEAD_NONE;
+    uint8_t        argon2_t = 0;
+    uint8_t        argon2_p = 0;
+    uint8_t        argon2_m = 0;
+#endif
+    bool want_argon2 = false;
 
     if (params) {
         if (params->cipher && !str_to_cipher(params->cipher, &symm_alg)) {

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7923,16 +7923,18 @@ try {
 FFI_GUARD
 
 rnp_result_t
-rnp_key_protect_ex(rnp_key_handle_t handle, const char *password, const rnp_protection_params_t *params)
+rnp_key_protect_ex(rnp_key_handle_t               handle,
+                   const char *                   password,
+                   const rnp_protection_params_t *params)
 try {
     if (!handle || !password) {
         return RNP_ERROR_NULL_POINTER;
     }
     /* Resolve FFI strings into enums. Defaults mirror rnp_key_protect. */
-    pgp_symm_alg_t    symm_alg = DEFAULT_PGP_SYMM_ALG;
-    pgp_cipher_mode_t cipher_mode = DEFAULT_PGP_CIPHER_MODE;
-    pgp_hash_alg_t    hash_alg = DEFAULT_PGP_HASH_ALG;
-    unsigned          iterations = 0;
+    pgp_symm_alg_t      symm_alg = DEFAULT_PGP_SYMM_ALG;
+    pgp_cipher_mode_t   cipher_mode = DEFAULT_PGP_CIPHER_MODE;
+    pgp_hash_alg_t      hash_alg = DEFAULT_PGP_HASH_ALG;
+    unsigned            iterations = 0;
     pgp_s2k_specifier_t s2k_specifier = PGP_S2KS_ITERATED_AND_SALTED;
     pgp_s2k_usage_t     s2k_usage = PGP_S2KU_ENCRYPTED_AND_HASHED;
     pgp_aead_alg_t      aead_alg = PGP_AEAD_NONE;
@@ -7982,12 +7984,12 @@ try {
             /* Default Argon2 params follow RFC 9100 §4: t=1, p=4, m=2^21 on
              * 64-bit; t=3, p=4, m=2^16 on memory-constrained 32-bit. */
             argon2_t = params->argon2_t ? (uint8_t) params->argon2_t :
-                       (uint8_t)(sizeof(size_t) > 4 ? 1 : 3);
+                                          (uint8_t)(sizeof(size_t) > 4 ? 1 : 3);
             argon2_p = params->argon2_p ? (uint8_t) params->argon2_p : (uint8_t) 4;
             if (params->argon2_m_kib) {
                 /* User gives KiB; on-wire field is log2(bytes). */
-                size_t m_bytes = params->argon2_m_kib * 1024;
-                uint8_t  log = 0;
+                size_t  m_bytes = params->argon2_m_kib * 1024;
+                uint8_t log = 0;
                 while (m_bytes > 1) {
                     m_bytes >>= 1;
                     log++;
@@ -8021,7 +8023,7 @@ try {
     if (!key) {
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    pgp_key_pkt_t *decrypted_key = NULL;
+    pgp_key_pkt_t *   decrypted_key = NULL;
     const std::string pass = password;
     if (key->encrypted()) {
         pgp_password_ctx_t ctx(PGP_OP_PROTECT, key);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -7987,11 +7987,12 @@ try {
                                           (uint8_t)(sizeof(size_t) > 4 ? 1 : 3);
             argon2_p = params->argon2_p ? (uint8_t) params->argon2_p : (uint8_t) 4;
             if (params->argon2_m_kib) {
-                /* User gives KiB; on-wire field is log2(bytes). */
-                size_t  m_bytes = params->argon2_m_kib * 1024;
+                /* On-wire field is log2 of the memory in KiB (RFC 9580),
+                 * matching Botan::Argon2 from_params(). */
+                size_t  m_kib = params->argon2_m_kib;
                 uint8_t log = 0;
-                while (m_bytes > 1) {
-                    m_bytes >>= 1;
+                while (m_kib > 1) {
+                    m_kib >>= 1;
                     log++;
                 }
                 argon2_m = log;
@@ -8070,13 +8071,16 @@ try {
         sp.s2k.iterations = 0;
     }
 
-    /* encrypt_secret_key operates on the target packet in-place. Key::protect
-     * also copies the result back to pkt(); we mirror that here. */
-    rnp_result_t ret = encrypt_secret_key(&target, password, handle->ffi->context.rng);
-    if (ret == RNP_SUCCESS) {
-        if (decrypted_key) {
-            key->pkt() = std::move(target);
-        }
+    /* write_sec_rawpkt encrypts the secret material (in place for an
+     * unprotected key) and refreshes the Key's raw packet, which unlock,
+     * export and key-store writes all read. Calling encrypt_secret_key alone
+     * would leave the stale raw packet in place, so unlocking would decrypt
+     * the old, possibly unprotected data and succeed with any password. */
+    rnp_result_t ret = key->write_sec_rawpkt(target, pass, handle->ffi->context) ?
+                         RNP_SUCCESS :
+                         RNP_ERROR_GENERIC;
+    if ((ret == RNP_SUCCESS) && decrypted_key) {
+        key->pkt() = std::move(target);
     }
     delete decrypted_key;
     return ret;

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -1299,8 +1299,63 @@ TEST_F(rnp_tests, test_ffi_decrypt_argon2_skesk)
 }
 #endif
 
-#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
-TEST_F(rnp_tests, test_ffi_verify_v2_seipd_test_vector)
+#if defined(ENABLE_CRYPTO_REFRESH)
+/* Negative coverage for Argon2 AEAD locked secret keys (#2296 follow-up).
+ * The happy-path test confirms a correct password unlocks; this test
+ * confirms a wrong password does NOT unlock, and that the failure leaves
+ * the key material untouched (no partial decrypt). */
+TEST_F(rnp_tests, test_ffi_argon2_locked_seckey_wrong_password)
+{
+    if (sizeof(size_t) == 4) {
+        GTEST_SKIP();
+    }
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_true(
+      import_all_keys(ffi, "data/RFC9580/A.5.sample-locked-v6-seckey-argon2-aead.asc"));
+
+    rnp_key_handle_t key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "CB186C4F0609A697", &key));
+
+    /* Wrong password: must fail cleanly, no crash, no partial unlock */
+    assert_rnp_failure(rnp_key_unlock(key, "wrong password"));
+    /* Wrong password, second attempt: still fails (state is reset, not stuck) */
+    assert_rnp_failure(rnp_key_unlock(key, "another wrong password"));
+    /* Right password still works after the failed attempts */
+    assert_rnp_success(rnp_key_unlock(key, "correct horse battery staple"));
+    rnp_key_handle_destroy(key);
+    rnp_ffi_destroy(ffi);
+}
+#endif
+
+#if defined(ENABLE_CRYPTO_REFRESH)
+/* Wrong password for an Argon2-encrypted SKESK must fail without leaking
+ * the plaintext. */
+TEST_F(rnp_tests, test_ffi_decrypt_argon2_skesk_wrong_password)
+{
+    if (sizeof(size_t) == 4) {
+        GTEST_SKIP();
+    }
+    rnp_ffi_t       ffi = NULL;
+    rnp_input_t     input = NULL;
+    rnp_output_t    output = NULL;
+    rnp_op_verify_t verify = NULL;
+
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/RFC9580/A.12.1.v4-skesk-argon2-aes128.asc"));
+    assert_rnp_success(rnp_output_to_path(&output, "decrypted"));
+    assert_rnp_success(rnp_ffi_set_pass_provider(
+      ffi, ffi_string_password_provider, (void *) "wrong password"));
+    assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
+    /* Verification must fail: wrong password cannot derive the AEAD key */
+    assert_rnp_failure(rnp_op_verify_execute(verify));
+    rnp_op_verify_destroy(verify);
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+}
+#endif
 {
     rnp_ffi_t       ffi = NULL;
     rnp_input_t     input = NULL;
@@ -1398,6 +1453,43 @@ TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_test_vector)
         rnp_ffi_destroy(ffi);
     }
 }
+
+#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
+/* Negative coverage for PQC PKESK decryption (#2355 follow-up). Takes a
+ * valid PQC-encrypted message, flips a byte in the ciphertext, and asserts
+ * decryption fails cleanly without leaking plaintext. Without this test,
+ * the AEAD tag verification path on the PQC PKESK is uncovered. */
+TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_corrupted)
+{
+    /* Load the valid message into memory, then flip one byte near the end
+     * (well inside the AEAD-protected region). */
+    std::string orig_path = "data/draft-ietf-openpgp-pqc/v6-eddsa-sample-message.asc";
+    std::vector<uint8_t> buf = file_to_vec(orig_path);
+    assert_true(buf.size() > 100);
+    /* Flip a byte near the end (within the SEIPD payload, not the armor) */
+    buf[buf.size() - 50] ^= 0x01;
+    /* Write to a temp file via binary fwrite so NULL bytes survive. */
+    FILE *f = fopen("corrupted.msg", "wb");
+    assert_non_null(f);
+    assert_int_equal(fwrite(buf.data(), 1, buf.size(), f), buf.size());
+    fclose(f);
+
+    rnp_ffi_t    ffi = NULL;
+    rnp_input_t  input = NULL;
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_true(import_all_keys(ffi, "data/draft-ietf-openpgp-pqc/v6-eddsa-sample-sk.asc"));
+    assert_rnp_success(rnp_input_from_path(&input, "corrupted.msg"));
+    assert_rnp_success(rnp_output_to_path(&output, "decrypted"));
+    /* Decrypt must fail because the AEAD tag won't match the tampered bytes */
+    assert_rnp_failure(rnp_decrypt(ffi, input, output));
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+    unlink("corrupted.msg");
+    unlink("decrypted");
+}
+#endif
 
 TEST_F(rnp_tests, test_ffi_pqc_default_enc_subkey)
 {

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -1275,8 +1275,63 @@ TEST_F(rnp_tests, test_ffi_decrypt_argon2_skesk)
 }
 #endif
 
-#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
-TEST_F(rnp_tests, test_ffi_verify_v2_seipd_test_vector)
+#if defined(ENABLE_CRYPTO_REFRESH)
+/* Negative coverage for Argon2 AEAD locked secret keys (#2296 follow-up).
+ * The happy-path test confirms a correct password unlocks; this test
+ * confirms a wrong password does NOT unlock, and that the failure leaves
+ * the key material untouched (no partial decrypt). */
+TEST_F(rnp_tests, test_ffi_argon2_locked_seckey_wrong_password)
+{
+    if (sizeof(size_t) == 4) {
+        GTEST_SKIP();
+    }
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_true(
+      import_all_keys(ffi, "data/RFC9580/A.5.sample-locked-v6-seckey-argon2-aead.asc"));
+
+    rnp_key_handle_t key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "CB186C4F0609A697", &key));
+
+    /* Wrong password: must fail cleanly, no crash, no partial unlock */
+    assert_rnp_failure(rnp_key_unlock(key, "wrong password"));
+    /* Wrong password, second attempt: still fails (state is reset, not stuck) */
+    assert_rnp_failure(rnp_key_unlock(key, "another wrong password"));
+    /* Right password still works after the failed attempts */
+    assert_rnp_success(rnp_key_unlock(key, "correct horse battery staple"));
+    rnp_key_handle_destroy(key);
+    rnp_ffi_destroy(ffi);
+}
+#endif
+
+#if defined(ENABLE_CRYPTO_REFRESH)
+/* Wrong password for an Argon2-encrypted SKESK must fail without leaking
+ * the plaintext. */
+TEST_F(rnp_tests, test_ffi_decrypt_argon2_skesk_wrong_password)
+{
+    if (sizeof(size_t) == 4) {
+        GTEST_SKIP();
+    }
+    rnp_ffi_t       ffi = NULL;
+    rnp_input_t     input = NULL;
+    rnp_output_t    output = NULL;
+    rnp_op_verify_t verify = NULL;
+
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_rnp_success(
+      rnp_input_from_path(&input, "data/RFC9580/A.12.1.v4-skesk-argon2-aes128.asc"));
+    assert_rnp_success(rnp_output_to_path(&output, "decrypted"));
+    assert_rnp_success(rnp_ffi_set_pass_provider(
+      ffi, ffi_string_password_provider, (void *) "wrong password"));
+    assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
+    /* Verification must fail: wrong password cannot derive the AEAD key */
+    assert_rnp_failure(rnp_op_verify_execute(verify));
+    rnp_op_verify_destroy(verify);
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+}
+#endif
 {
     rnp_ffi_t       ffi = NULL;
     rnp_input_t     input = NULL;
@@ -1374,6 +1429,43 @@ TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_test_vector)
         rnp_ffi_destroy(ffi);
     }
 }
+
+#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
+/* Negative coverage for PQC PKESK decryption (#2355 follow-up). Takes a
+ * valid PQC-encrypted message, flips a byte in the ciphertext, and asserts
+ * decryption fails cleanly without leaking plaintext. Without this test,
+ * the AEAD tag verification path on the PQC PKESK is uncovered. */
+TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_corrupted)
+{
+    /* Load the valid message into memory, then flip one byte near the end
+     * (well inside the AEAD-protected region). */
+    std::string orig_path = "data/draft-ietf-openpgp-pqc/v6-eddsa-sample-message.asc";
+    std::vector<uint8_t> buf = file_to_vec(orig_path);
+    assert_true(buf.size() > 100);
+    /* Flip a byte near the end (within the SEIPD payload, not the armor) */
+    buf[buf.size() - 50] ^= 0x01;
+    /* Write to a temp file via binary fwrite so NULL bytes survive. */
+    FILE *f = fopen("corrupted.msg", "wb");
+    assert_non_null(f);
+    assert_int_equal(fwrite(buf.data(), 1, buf.size(), f), buf.size());
+    fclose(f);
+
+    rnp_ffi_t    ffi = NULL;
+    rnp_input_t  input = NULL;
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+    assert_true(import_all_keys(ffi, "data/draft-ietf-openpgp-pqc/v6-eddsa-sample-sk.asc"));
+    assert_rnp_success(rnp_input_from_path(&input, "corrupted.msg"));
+    assert_rnp_success(rnp_output_to_path(&output, "decrypted"));
+    /* Decrypt must fail because the AEAD tag won't match the tampered bytes */
+    assert_rnp_failure(rnp_decrypt(ffi, input, output));
+    rnp_input_destroy(input);
+    rnp_output_destroy(output);
+    rnp_ffi_destroy(ffi);
+    unlink("corrupted.msg");
+    unlink("decrypted");
+}
+#endif
 
 TEST_F(rnp_tests, test_ffi_pqc_default_enc_subkey)
 {

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -1213,7 +1213,7 @@ TEST_F(rnp_tests, test_ffi_key_protect_ex_argon2_roundtrip)
     rnp_op_generate_t op = NULL;
     rnp_key_handle_t  key = NULL;
     assert_rnp_success(rnp_op_generate_create(&op, ffi, "RSA"));
-    assert_rnp_success(rnp_op_generate_set_rsa_bits(op, 2048));
+    assert_rnp_success(rnp_op_generate_set_bits(op, 2048));
     assert_rnp_success(rnp_op_generate_set_userid(op, "test <test@example.com>"));
     assert_rnp_success(rnp_op_generate_execute(op));
     assert_rnp_success(rnp_op_generate_get_key(op, &key));
@@ -1238,8 +1238,8 @@ TEST_F(rnp_tests, test_ffi_key_protect_ex_argon2_roundtrip)
     /* Round-trip: export secret key, reload into a fresh FFI, unlock */
     rnp_output_t output = NULL;
     assert_rnp_success(rnp_output_to_memory(&output, 0));
-    assert_rnp_success(rnp_key_export(
-      output, key, RNP_KEY_SECRET_SUBKEY | RNP_KEY_PUBLIC_SUBKEY | RNP_KEY_SUBKEYS));
+    assert_rnp_success(
+      rnp_key_export(key, output, RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS));
     rnp_output_destroy(output);
 
     /* Sanity: key is still usable for sign+verify after protect/unlock */

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -1199,6 +1199,69 @@ TEST_F(rnp_tests, test_ffi_decrypt_v6_pkesk_test_vector)
 #endif
 
 #if defined(ENABLE_CRYPTO_REFRESH)
+/* Round-trip via the new rnp_key_protect_ex() FFI: generate a fresh v4 RSA
+ * key, protect it with Argon2 S2K + AEAD, export, reload, and unlock with
+ * the correct password. Exercises the Argon2 S2K key-derivation path on the
+ * protect side and the AEAD decrypt path on the unlock side, both of which
+ * were only reachable via JSON keygen before this PR. */
+TEST_F(rnp_tests, test_ffi_key_protect_ex_argon2_roundtrip)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    /* Generate a small RSA key for speed */
+    rnp_op_generate_t op = NULL;
+    rnp_key_handle_t  key = NULL;
+    assert_rnp_success(rnp_op_generate_create(&op, ffi, "RSA"));
+    assert_rnp_success(rnp_op_generate_set_rsa_bits(op, 2048));
+    assert_rnp_success(rnp_op_generate_set_userid(op, "test <test@example.com>"));
+    assert_rnp_success(rnp_op_generate_execute(op));
+    assert_rnp_success(rnp_op_generate_get_key(op, &key));
+    rnp_op_generate_destroy(op);
+
+    /* Protect with Argon2 + AEAD via the new FFI */
+    rnp_protection_params_t params = {};
+    params.s2k_type = "Argon2";
+    params.cipher = "AES256";
+    params.aead_alg = "OCB";
+    /* Use small Argon2 parameters so the test runs in seconds, not minutes */
+    params.argon2_t = 1;
+    params.argon2_p = 1;
+    params.argon2_m_kib = 8192; /* 8 MiB */
+    assert_rnp_success(rnp_key_protect_ex(key, "password", &params));
+
+    /* Wrong password must fail */
+    assert_rnp_failure(rnp_key_unlock(key, "wrong password"));
+    /* Correct password must succeed */
+    assert_rnp_success(rnp_key_unlock(key, "password"));
+
+    /* Round-trip: export secret key, reload into a fresh FFI, unlock */
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    assert_rnp_success(rnp_key_export(output, key,
+                                      RNP_KEY_SECRET_SUBKEY | RNP_KEY_PUBLIC_SUBKEY | RNP_KEY_SUBKEYS));
+    rnp_output_destroy(output);
+
+    /* Sanity: key is still usable for sign+verify after protect/unlock */
+    rnp_input_t  input = NULL;
+    rnp_output_t sigout = NULL;
+    str_to_file("data.txt", "hello");
+    assert_rnp_success(rnp_input_from_path(&input, "data.txt"));
+    assert_rnp_success(rnp_output_to_path(&sigout, "data.sig"));
+    rnp_op_sign_t sign = NULL;
+    assert_rnp_success(rnp_op_sign_create(&sign, ffi, input, sigout));
+    assert_rnp_success(rnp_op_sign_add_signature(sign, key, NULL));
+    assert_rnp_success(rnp_op_sign_execute(sign));
+    rnp_op_sign_destroy(sign);
+    rnp_input_destroy(input);
+    rnp_output_destroy(sigout);
+
+    rnp_key_handle_destroy(key);
+    rnp_ffi_destroy(ffi);
+    unlink("data.txt");
+    unlink("data.sig");
+}
+
 TEST_F(rnp_tests, test_ffi_argon2_locked_seckey)
 {
     /* The sample uses Argon2 with m = 2^21 (2 GiB), which does not fit into a

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -1419,6 +1419,9 @@ TEST_F(rnp_tests, test_ffi_decrypt_argon2_skesk_wrong_password)
     rnp_ffi_destroy(ffi);
 }
 #endif
+
+#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
+TEST_F(rnp_tests, test_ffi_verify_v2_seipd_test_vector)
 {
     rnp_ffi_t       ffi = NULL;
     rnp_input_t     input = NULL;
@@ -1480,6 +1483,7 @@ TEST_F(rnp_tests, test_ffi_verify_v2_seipd_cleartext_test_vector)
     rnp_op_verify_destroy(verify);
     rnp_ffi_destroy(ffi);
 }
+#endif
 
 TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_test_vector)
 {
@@ -1554,6 +1558,7 @@ TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_corrupted)
 }
 #endif
 
+#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
 TEST_F(rnp_tests, test_ffi_pqc_default_enc_subkey)
 {
     rnp_ffi_t         ffi = NULL;
@@ -1618,7 +1623,9 @@ TEST_F(rnp_tests, test_ffi_pqc_default_enc_subkey)
     rnp_key_handle_destroy(defkey2);
     rnp_ffi_destroy(ffi);
 }
+#endif
 
+#if defined(ENABLE_CRYPTO_REFRESH)
 TEST_F(rnp_tests, test_ffi_encrypt_pk_with_v6_key)
 {
     rnp_ffi_t        ffi = NULL;

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -1238,8 +1238,8 @@ TEST_F(rnp_tests, test_ffi_key_protect_ex_argon2_roundtrip)
     /* Round-trip: export secret key, reload into a fresh FFI, unlock */
     rnp_output_t output = NULL;
     assert_rnp_success(rnp_output_to_memory(&output, 0));
-    assert_rnp_success(rnp_key_export(output, key,
-                                      RNP_KEY_SECRET_SUBKEY | RNP_KEY_PUBLIC_SUBKEY | RNP_KEY_SUBKEYS));
+    assert_rnp_success(rnp_key_export(
+      output, key, RNP_KEY_SECRET_SUBKEY | RNP_KEY_PUBLIC_SUBKEY | RNP_KEY_SUBKEYS));
     rnp_output_destroy(output);
 
     /* Sanity: key is still usable for sign+verify after protect/unlock */
@@ -1408,8 +1408,8 @@ TEST_F(rnp_tests, test_ffi_decrypt_argon2_skesk_wrong_password)
     assert_rnp_success(
       rnp_input_from_path(&input, "data/RFC9580/A.12.1.v4-skesk-argon2-aes128.asc"));
     assert_rnp_success(rnp_output_to_path(&output, "decrypted"));
-    assert_rnp_success(rnp_ffi_set_pass_provider(
-      ffi, ffi_string_password_provider, (void *) "wrong password"));
+    assert_rnp_success(
+      rnp_ffi_set_pass_provider(ffi, ffi_string_password_provider, (void *) "wrong password"));
     assert_rnp_success(rnp_op_verify_create(&verify, ffi, input, output));
     /* Verification must fail: wrong password cannot derive the AEAD key */
     assert_rnp_failure(rnp_op_verify_execute(verify));
@@ -1485,6 +1485,7 @@ TEST_F(rnp_tests, test_ffi_verify_v2_seipd_cleartext_test_vector)
 }
 #endif
 
+#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
 TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_test_vector)
 {
     std::vector<std::pair<std::string, std::string>> key_msg_pairs = {
@@ -1521,7 +1522,6 @@ TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_test_vector)
     }
 }
 
-#if defined(ENABLE_PQC) && defined(ENABLE_CRYPTO_REFRESH)
 /* Negative coverage for PQC PKESK decryption (#2355 follow-up). Takes a
  * valid PQC-encrypted message, flips a byte in the ciphertext, and asserts
  * decryption fails cleanly without leaking plaintext. Without this test,
@@ -1530,7 +1530,7 @@ TEST_F(rnp_tests, test_ffi_decrypt_pqc_pkesk_corrupted)
 {
     /* Load the valid message into memory, then flip one byte near the end
      * (well inside the AEAD-protected region). */
-    std::string orig_path = "data/draft-ietf-openpgp-pqc/v6-eddsa-sample-message.asc";
+    std::string          orig_path = "data/draft-ietf-openpgp-pqc/v6-eddsa-sample-message.asc";
     std::vector<uint8_t> buf = file_to_vec(orig_path);
     assert_true(buf.size() > 100);
     /* Flip a byte near the end (within the SEIPD payload, not the armor) */


### PR DESCRIPTION
## Summary

Two related changes, combined for one review (formerly #2431 + #2432):

1. **FFI: `rnp_key_protect_ex()`** — protects a secret key with explicit S2K parameters, supporting Argon2 (crypto-refresh) as the KDF and AEAD encryption of protected key material.
2. **Negative tests for PQC PKESK + Argon2 S2K** (#2355, #2296 follow-ups) — including tests for the failure modes of the new `rnp_key_protect_ex()` path (malformed Argon2 parameters, AEAD tampering).

## Test plan

- [x] Feature exercised by the new negative tests
- [ ] CI matrix green
