### PR TITLE
ffi: entropy encoding + backup archive building blocks

### DIFF
--- a/docs/develop/backup-format.adoc
+++ b/docs/develop/backup-format.adoc
@@ -1,0 +1,82 @@
+= Backup archive wire format
+
+The `rnp_backup_archive_create()` FFI produces a standard OpenPGP
+message containing one or more transferable secret keys, signed by a
+caller-specified key and encrypted to a caller-specified public key.
+This document describes the wire format so non-rnp implementations
+can produce and consume compatible archives.
+
+== Container structure
+
+A backup archive is an OpenPGP Signed-and-Encrypted message as
+defined by [RFC 9580]. The high-level structure is:
+
+----
+PKESK v6 (or v3)
+SEIPD v2 (or v1)
+    one-pass signature packet
+    literal data packet
+        concatenated transferable secret keys
+    signature packet
+----
+
+Where:
+
+* The PKESK encrypts a session key to the `encryption_key` parameter.
+* The SEIPD packet contains the signed message body.
+* The literal data packet carries the concatenation of one or more
+  transferable secret keys, each exported with
+  `RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS`.
+* The signature packet is produced by the `signing_key` parameter,
+  covering the literal data.
+
+== Transferable key concatenation
+
+Each transferable key is exported as the standard sequence of packets
+from [RFC 9580] §10.1 (transferable secret key). Multiple keys are
+simply concatenated; the OpenPGP literal data packet carries the
+concatenated bytes as a single payload.
+
+On load, `rnp_backup_archive_load()` decrypts the SEIPD, verifies the
+signature, then parses each transferable secret key from the literal
+data via the standard keyring import path. All keys are added to the
+FFI's secret keyring.
+
+== Decryption and verification order
+
+Load follows the standard OpenPGP decrypt-and-verify semantics:
+
+. Look up the PKESK recipient in the FFI's keyring; decrypt the
+  session key.
+. Decrypt the SEIPD payload.
+. Verify the one-pass signature against the `signing_key_public`
+  parameter. If the signer's key ID does not match, or if signature
+  verification fails, no keys are imported and the function returns
+  `RNP_ERROR_SIGNATURE_INVALID`.
+. Parse and import the recovered transferable secret keys.
+
+== Parameter defaults
+
+`rnp_backup_archive_params_t` exposes cipher, AEAD algorithm, and hash
+algorithm overrides. If any field is NULL, rnp uses the FFI defaults
+(`AES-256`, `OCB` if the recipient advertises AEAD support,
+`SHA-256`).
+
+== Security properties
+
+* The signing key SHOULD be distinct from any key in the archive.
+  Reusing a key as both the archive signer and an archive member
+  creates a circular dependency that complicates recovery flows.
+* The encryption key SHOULD be a subkey dedicated to backup
+  encryption; using the same key for email and backup means the
+  email-recipient secret material must be present to perform recovery.
+* The caller is responsible for storing the encrypted archive bytes
+  durably (file, blob, message attachment). rnp itself does not
+  dictate storage semantics.
+
+== Compatibility
+
+The wire format is a standard OpenPGP message and can be produced or
+consumed by any RFC 9580-compliant implementation. The literal data
+packet's payload (concatenated transferable secret keys) is the same
+sequence of packets that `gpg --export-secret-keys` produces.

--- a/docs/navigation.adoc
+++ b/docs/navigation.adoc
@@ -9,6 +9,8 @@ items:
   items:
   - { title: "C++ usage", path: develop/cpp-usage/ }
   - { title: "Common workflow patterns", path: develop/workflows/ }
+  - { title: "Backup archive format", path: develop/backup-format/ }
+>>>>>>> 99dd640b (ffi: add entropy encoding and backup archive building blocks)
   - { title: "Packaging", path: develop/packaging/ }
   - { title: "Release workflow", path: develop/release-workflow/ }
   # - title: "Acceptance tests"

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -4232,11 +4232,11 @@ typedef struct rnp_entropy_encoding_params_t {
  * @param flat_form on success, the flat passphrase form. May be NULL.
  * @return RNP_SUCCESS on success, RNP_ERROR_BAD_PARAMETERS for invalid params.
  */
-RNP_API rnp_result_t rnp_entropy_encode_human_readable(
-  rnp_ffi_t                              ffi,
-  const rnp_entropy_encoding_params_t *  params,
-  char **                                structured_form,
-  char **                                flat_form);
+RNP_API rnp_result_t
+rnp_entropy_encode_human_readable(rnp_ffi_t                            ffi,
+                                  const rnp_entropy_encoding_params_t *params,
+                                  char **                              structured_form,
+                                  char **                              flat_form);
 
 /**
  * @brief Parse a structured human-readable entropy encoding and return
@@ -4257,9 +4257,7 @@ RNP_API rnp_result_t rnp_entropy_encode_human_readable(
  *         input or invalid params.
  */
 RNP_API rnp_result_t rnp_entropy_decode_human_readable(
-  const char *                           structured_form,
-  const rnp_entropy_encoding_params_t *  params,
-  char **                                flat_form);
+  const char *structured_form, const rnp_entropy_encoding_params_t *params, char **flat_form);
 
 /**
  * @brief Validate the checksum of a structured human-readable entropy
@@ -4272,8 +4270,7 @@ RNP_API rnp_result_t rnp_entropy_decode_human_readable(
  *         input or invalid params.
  */
 RNP_API rnp_result_t rnp_entropy_encoding_validate(
-  const char *                           structured_form,
-  const rnp_entropy_encoding_params_t *  params);
+  const char *structured_form, const rnp_entropy_encoding_params_t *params);
 
 /**
  * @brief Parameters for backup archive creation/loading.
@@ -4308,14 +4305,13 @@ typedef struct rnp_backup_archive_params_t {
  * @param output destination for the encrypted archive.
  * @return RNP_SUCCESS on success, error code otherwise.
  */
-RNP_API rnp_result_t rnp_backup_archive_create(
-  rnp_ffi_t                            ffi,
-  rnp_key_handle_t *                   keys_to_backup,
-  size_t                               key_count,
-  rnp_key_handle_t                     signing_key,
-  rnp_key_handle_t                     encryption_key,
-  const rnp_backup_archive_params_t *  params,
-  rnp_output_t                         output);
+RNP_API rnp_result_t rnp_backup_archive_create(rnp_ffi_t         ffi,
+                                               rnp_key_handle_t *keys_to_backup,
+                                               size_t            key_count,
+                                               rnp_key_handle_t  signing_key,
+                                               rnp_key_handle_t  encryption_key,
+                                               const rnp_backup_archive_params_t *params,
+                                               rnp_output_t                       output);
 
 /**
  * @brief Decrypt and verify a backup archive, importing all recovered
@@ -4338,10 +4334,9 @@ RNP_API rnp_result_t rnp_backup_archive_create(
  * @return RNP_SUCCESS on success, RNP_ERROR_SIGNATURE_INVALID if the
  *         signature does not verify.
  */
-RNP_API rnp_result_t rnp_backup_archive_load(
-  rnp_ffi_t        ffi,
-  rnp_input_t      input,
-  rnp_key_handle_t decryption_key,
-  rnp_key_handle_t signing_key_public);
+RNP_API rnp_result_t rnp_backup_archive_load(rnp_ffi_t        ffi,
+                                             rnp_input_t      input,
+                                             rnp_key_handle_t decryption_key,
+                                             rnp_key_handle_t signing_key_public);
 
 #endif

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -4165,4 +4165,183 @@ RNP_API const char *rnp_backend_version();
 #define RNP_KEYSTORE_G10 ("G10")
 #define RNP_KEYSTORE_GPG21 ("GPG21")
 
+/**
+ * @brief Parameters for the human-readable entropy encoding utility
+ *        (rnp_entropy_encode_human_readable and friends).
+ *
+ *  This is a generic encoding for representing random entropy in a form
+ *  that a human can transcribe accurately (e.g. from a printout). The
+ *  caller chooses the alphabet, group size, and whether to include
+ *  a checksum line and/or group identifiers for order-independent entry.
+ *
+ *  The flat form is just the entropy characters concatenated, suitable
+ *  for use as a passphrase (e.g. for symmetric OpenPGP encryption).
+ *  The structured form is the same characters split into groups with
+ *  optional identifiers and checksum, suitable for display to the user.
+ */
+typedef struct rnp_entropy_encoding_params_t {
+    /** Alphabet for the entropy characters. NULL = "0123456789ABCDEF" (hex).
+     *  Must be a power of two in length and at most 256 entries. Each
+     *  character must be unique. */
+    const char *alphabet;
+    /** Number of entropy bits to encode. 0 = 256. Must be an exact
+     *  multiple of (log2(alphabet_size) * group_size). */
+    size_t entropy_bits;
+    /** Number of entropy characters per data group. 0 = 4. */
+    size_t group_size;
+    /** If true, OMIT group identifiers from the structured form. Default
+     *  (false) includes identifiers so the user can enter groups in any
+     *  order. The checksum line uses a separate identifier
+     *  (see checksum_id). */
+    bool disable_group_ids;
+    /** If true, OMIT the checksum line. Default (false) includes a
+     *  checksum line consisting of the first checksum_bits bits of
+     *  SHA-256(entropy), encoded as one data group. */
+    bool disable_checksum;
+    /** Number of bits in the checksum. 0 = 16. Must produce an integer
+     *  number of alphabet characters when divided by log2(alphabet_size). */
+    size_t checksum_bits;
+    /** Identifier for the checksum line. Must NOT be a character in the
+     *  alphabet. 0 (NUL) = auto-pick the first printable ASCII character
+     *  not in the alphabet. */
+    char checksum_id;
+    /** Separator between groups in the structured form. NULL = " "
+     *  (single space). */
+    const char *separator;
+} rnp_entropy_encoding_params_t;
+
+/**
+ * @brief Generate fresh entropy and encode it as a human-readable string.
+ *
+ *  Generates `entropy_bits` worth of cryptographically random bytes via
+ *  the FFI's RNG, encodes them according to `params`, and returns two
+ *  strings:
+ *
+ *  - `structured_form`: the human-readable form with groups, identifiers,
+ *    and checksum (for display).
+ *  - `flat_form`: the entropy characters concatenated without structure
+ *    (for use as a passphrase, e.g. for `rnp_op_encrypt_add_password`).
+ *
+ *  Either output pointer may be NULL if the caller only needs one form.
+ *  Non-NULL output pointers must be freed via `rnp_buffer_destroy()`.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param params encoding parameters. May be NULL for all-defaults.
+ * @param structured_form on success, the structured human-readable form.
+ *        May be NULL.
+ * @param flat_form on success, the flat passphrase form. May be NULL.
+ * @return RNP_SUCCESS on success, RNP_ERROR_BAD_PARAMETERS for invalid params.
+ */
+RNP_API rnp_result_t rnp_entropy_encode_human_readable(
+  rnp_ffi_t                              ffi,
+  const rnp_entropy_encoding_params_t *  params,
+  char **                                structured_form,
+  char **                                flat_form);
+
+/**
+ * @brief Parse a structured human-readable entropy encoding and return
+ *        the flat passphrase form.
+ *
+ *  Validates the checksum (if `params->include_checksum` is true), then
+ *  returns the flat form suitable for use as a passphrase.
+ *
+ *  Groups may appear in any order if `params->include_group_ids` is true.
+ *  The checksum line is identified by its `checksum_id` character.
+ *
+ * @param structured_form the structured form, cannot be NULL.
+ * @param params encoding parameters. May be NULL for all-defaults.
+ * @param flat_form on success, the flat passphrase form. Caller must
+ *        free via `rnp_buffer_destroy()`.
+ * @return RNP_SUCCESS on success. RNP_ERROR_SIGNATURE_INVALID if the
+ *         checksum does not match. RNP_ERROR_BAD_PARAMETERS for malformed
+ *         input or invalid params.
+ */
+RNP_API rnp_result_t rnp_entropy_decode_human_readable(
+  const char *                           structured_form,
+  const rnp_entropy_encoding_params_t *  params,
+  char **                                flat_form);
+
+/**
+ * @brief Validate the checksum of a structured human-readable entropy
+ *        encoding without extracting the flat form.
+ *
+ * @param structured_form the structured form, cannot be NULL.
+ * @param params encoding parameters. May be NULL for all-defaults.
+ * @return RNP_SUCCESS if valid. RNP_ERROR_SIGNATURE_INVALID if the
+ *         checksum does not match. RNP_ERROR_BAD_PARAMETERS for malformed
+ *         input or invalid params.
+ */
+RNP_API rnp_result_t rnp_entropy_encoding_validate(
+  const char *                           structured_form,
+  const rnp_entropy_encoding_params_t *  params);
+
+/**
+ * @brief Parameters for backup archive creation/loading.
+ */
+typedef struct rnp_backup_archive_params_t {
+    /** Hash algorithm for the signature, e.g. "SHA256". NULL = default. */
+    const char *hash;
+    /** Cipher for encryption, e.g. "AES256". NULL = default. */
+    const char *cipher;
+    /** AEAD algorithm, e.g. "OCB". NULL = no AEAD preference. */
+    const char *aead;
+} rnp_backup_archive_params_t;
+
+/**
+ * @brief Create a signed and encrypted backup archive of one or more
+ *        secret keys.
+ *
+ *  Each key in `keys_to_backup` is exported as a transferable secret key
+ *  (with subkeys) and concatenated into a single literal data block.
+ *  The block is signed with `signing_key`, then encrypted to
+ *  `encryption_key`. The result is a standard OpenPGP message that can
+ *  be stored anywhere (file, blob, message attachment).
+ *
+ *  See `docs/develop/backup-format.adoc` for the wire format.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param keys_to_backup array of secret key handles to include.
+ * @param key_count number of entries in keys_to_backup.
+ * @param signing_key secret key to sign the archive. Must have sign flag.
+ * @param encryption_key public key to encrypt the archive to.
+ * @param params optional parameters (cipher, hash, AEAD). May be NULL.
+ * @param output destination for the encrypted archive.
+ * @return RNP_SUCCESS on success, error code otherwise.
+ */
+RNP_API rnp_result_t rnp_backup_archive_create(
+  rnp_ffi_t                            ffi,
+  rnp_key_handle_t *                   keys_to_backup,
+  size_t                               key_count,
+  rnp_key_handle_t                     signing_key,
+  rnp_key_handle_t                     encryption_key,
+  const rnp_backup_archive_params_t *  params,
+  rnp_output_t                         output);
+
+/**
+ * @brief Decrypt and verify a backup archive, importing all recovered
+ *        secret keys into the FFI.
+ *
+ *  Decrypts the archive using `decryption_key` (the secret pair of the
+ *  encryption_key used at create time), verifies the signature against
+ *  the public component of `signing_key_public`, and imports all
+ *  recovered transferable secret keys into the FFI's secret keyring.
+ *
+ *  If the signature does not verify, no keys are imported and the
+ *  function returns RNP_ERROR_SIGNATURE_INVALID.
+ *
+ * @param ffi populated FFI structure, cannot be NULL.
+ * @param input source containing the encrypted archive.
+ * @param decryption_key secret key matching the encryption_key used at
+ *        create time.
+ * @param signing_key_public public component of the signing_key used at
+ *        create time.
+ * @return RNP_SUCCESS on success, RNP_ERROR_SIGNATURE_INVALID if the
+ *         signature does not verify.
+ */
+RNP_API rnp_result_t rnp_backup_archive_load(
+  rnp_ffi_t        ffi,
+  rnp_input_t      input,
+  rnp_key_handle_t decryption_key,
+  rnp_key_handle_t signing_key_public);
+
 #endif

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -519,6 +519,7 @@ add_library(librnp-obj OBJECT
   logging.cpp
   json-utils.cpp
   utils.cpp
+  entropy_encoding.cpp
   pass-provider.cpp
   rawpacket.cpp
   sig_subpacket.cpp

--- a/src/lib/entropy_encoding.cpp
+++ b/src/lib/entropy_encoding.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "entropy_encoding.hpp"
+#include "crypto/hash.hpp"
+#include "logging.h"
+#include <algorithm>
+#include <set>
+
+namespace rnp {
+
+size_t
+EntropyEncodingConfig::bits_per_char() const noexcept
+{
+    size_t n = alphabet.size();
+    size_t bits = 0;
+    while ((1ULL << bits) < n) {
+        bits++;
+    }
+    return bits;
+}
+
+size_t
+EntropyEncodingConfig::entropy_bytes() const noexcept
+{
+    return (entropy_bits + 7) / 8;
+}
+
+size_t
+EntropyEncodingConfig::entropy_chars() const noexcept
+{
+    return entropy_bits / bits_per_char();
+}
+
+size_t
+EntropyEncodingConfig::data_group_count() const noexcept
+{
+    return entropy_chars() / group_size;
+}
+
+size_t
+EntropyEncodingConfig::checksum_chars() const noexcept
+{
+    return checksum_bits / bits_per_char();
+}
+
+bool
+EntropyEncodingConfig::validate(std::string &error) const
+{
+    /* Alphabet size must be a power of two, >= 2, <= 256. */
+    size_t n = alphabet.size();
+    if (n < 2 || n > 256) {
+        error = "alphabet size must be 2..256";
+        return false;
+    }
+    size_t bpc = 0;
+    while ((1ULL << bpc) < n) {
+        bpc++;
+    }
+    if ((1ULL << bpc) != n) {
+        error = "alphabet size must be a power of two";
+        return false;
+    }
+    /* Unique characters. */
+    std::set<char> seen;
+    for (char c : alphabet) {
+        if (!isprint(static_cast<unsigned char>(c))) {
+            error = "alphabet must contain only printable characters";
+            return false;
+        }
+        if (!seen.insert(c).second) {
+            error = "alphabet must contain unique characters";
+            return false;
+        }
+    }
+    if (entropy_bits == 0 || entropy_bits % 8 != 0) {
+        error = "entropy_bits must be a positive multiple of 8";
+        return false;
+    }
+    if (entropy_bits % bpc != 0) {
+        error = "entropy_bits must be a multiple of bits_per_char";
+        return false;
+    }
+    if (group_size == 0) {
+        error = "group_size must be > 0";
+        return false;
+    }
+    if (entropy_chars() % group_size != 0) {
+        error = "entropy_chars must divide evenly by group_size";
+        return false;
+    }
+    if (!disable_checksum) {
+        if (checksum_bits == 0) {
+            error = "checksum_bits must be > 0 when checksum is enabled";
+            return false;
+        }
+        if (checksum_bits % bpc != 0) {
+            error = "checksum_bits must be a multiple of bits_per_char";
+            return false;
+        }
+        if (checksum_chars() > group_size) {
+            error = "checksum must fit in one group";
+            return false;
+        }
+    }
+    if (!disable_group_ids && !disable_checksum) {
+        /* checksum_id must NOT be in the alphabet */
+        if (checksum_id != 0) {
+            if (alphabet.find(checksum_id) != std::string::npos) {
+                error = "checksum_id must not be in the alphabet";
+                return false;
+            }
+            if (!isprint(static_cast<unsigned char>(checksum_id))) {
+                error = "checksum_id must be printable";
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool
+entropy_to_flat_string(const std::vector<uint8_t> &entropy,
+                        const EntropyEncodingConfig &cfg,
+                        std::string &out)
+{
+    size_t bpc = cfg.bits_per_char();
+    size_t total_chars = cfg.entropy_chars();
+    out.assign(total_chars, cfg.alphabet[0]);
+    /* Process bits MSB-first within each byte. */
+    size_t bit_pos = 0;
+    for (size_t i = 0; i < total_chars; i++) {
+        size_t value = 0;
+        for (size_t b = 0; b < bpc; b++) {
+            size_t bp = bit_pos++;
+            size_t byte_idx = bp / 8;
+            size_t bit_in_byte = 7 - (bp % 8);
+            if (byte_idx < entropy.size() && (entropy[byte_idx] >> bit_in_byte) & 1) {
+                value |= (1ULL << (bpc - 1 - b));
+            }
+        }
+        out[i] = cfg.alphabet[value];
+    }
+    return true;
+}
+
+bool
+flat_string_to_entropy(const std::string &flat,
+                        const EntropyEncodingConfig &cfg,
+                        std::vector<uint8_t> &out)
+{
+    size_t bpc = cfg.bits_per_char();
+    if (flat.size() != cfg.entropy_chars()) {
+        return false;
+    }
+    out.assign(cfg.entropy_bytes(), 0);
+    size_t bit_pos = 0;
+    for (size_t i = 0; i < flat.size(); i++) {
+        auto pos = cfg.alphabet.find(flat[i]);
+        if (pos == std::string::npos) {
+            return false;
+        }
+        size_t value = pos;
+        for (size_t b = 0; b < bpc; b++) {
+            size_t bp = bit_pos++;
+            size_t byte_idx = bp / 8;
+            size_t bit_in_byte = 7 - (bp % 8);
+            if ((value >> (bpc - 1 - b)) & 1) {
+                if (byte_idx < out.size()) {
+                    out[byte_idx] |= (1ULL << bit_in_byte);
+                }
+            }
+        }
+    }
+    return true;
+}
+
+bool
+compute_checksum(const std::vector<uint8_t> &entropy,
+                  const EntropyEncodingConfig &cfg,
+                  std::string &out)
+{
+    auto hash = rnp::Hash::create(PGP_HASH_SHA256);
+    hash->add(entropy);
+    std::vector<uint8_t> digest(hash->size());
+    hash->finish(digest.data());
+    /* Take first checksum_bits bits of the digest, encode as chars. */
+    EntropyEncodingConfig cksum_cfg = cfg;
+    cksum_cfg.entropy_bits = cfg.checksum_bits;
+    /* Pad the digest to entropy_bytes() */
+    std::vector<uint8_t> trimmed(digest.begin(),
+                                  digest.begin() + cksum_cfg.entropy_bytes());
+    return entropy_to_flat_string(trimmed, cksum_cfg, out);
+}
+
+bool
+encode_structured(const std::vector<uint8_t> &entropy,
+                   const EntropyEncodingConfig &cfg,
+                   std::string &out)
+{
+    std::string flat;
+    if (!entropy_to_flat_string(entropy, cfg, flat)) {
+        return false;
+    }
+    /* Determine the separator. */
+    std::string sep = cfg.separator.empty() ? " " : cfg.separator;
+
+    out.clear();
+    /* Checksum line first (for visual recognisability). */
+    if (!cfg.disable_checksum) {
+        std::string checksum_flat;
+        if (!compute_checksum(entropy, cfg, checksum_flat)) {
+            return false;
+        }
+        char id = cfg.checksum_id;
+        if (id == 0) {
+            /* Auto-pick the first printable ASCII char not in the alphabet. */
+            id = '!';
+            while (cfg.alphabet.find(id) != std::string::npos && id < '~') {
+                id++;
+            }
+        }
+        /* Pad checksum_flat to group_size if shorter. */
+        while (checksum_flat.size() < cfg.group_size) {
+            checksum_flat += cfg.alphabet[0];
+        }
+        out += id;
+        out += checksum_flat;
+    }
+    /* Data groups. */
+    size_t group_count = cfg.data_group_count();
+    for (size_t g = 0; g < group_count; g++) {
+        if (!out.empty()) {
+            out += sep;
+        }
+        if (!cfg.disable_group_ids) {
+            /* Use alphabet[g % alphabet.size()] as the identifier. */
+            out += cfg.alphabet[g % cfg.alphabet.size()];
+        }
+        out += flat.substr(g * cfg.group_size, cfg.group_size);
+    }
+    return true;
+}
+
+bool
+decode_structured(const std::string &structured,
+                   const EntropyEncodingConfig &cfg,
+                   std::string &flat,
+                   bool &checksum_ok)
+{
+    checksum_ok = true;
+    /* Split by separator. */
+    std::string sep = cfg.separator.empty() ? " " : cfg.separator;
+    std::vector<std::string> groups;
+    size_t start = 0;
+    while (start <= structured.size()) {
+        size_t pos = structured.find(sep, start);
+        if (pos == std::string::npos) {
+            groups.push_back(structured.substr(start));
+            break;
+        }
+        groups.push_back(structured.substr(start, pos - start));
+        start = pos + sep.size();
+    }
+
+    std::string flat_chars;
+    flat_chars.reserve(cfg.entropy_chars());
+    std::string checksum_chars;
+    size_t expected_data_groups = cfg.data_group_count();
+    std::vector<bool> seen_group(expected_data_groups, false);
+    std::vector<std::string> group_payloads(expected_data_groups);
+    bool found_checksum = cfg.disable_checksum; /* if disabled, "found" trivially */
+    size_t data_group_seq = 0;
+
+    for (auto &grp : groups) {
+        if (grp.empty()) {
+            continue;
+        }
+        char first = grp[0];
+        /* Check if this is the checksum line. */
+        if (!cfg.disable_checksum) {
+            char expected_id = cfg.checksum_id;
+            if (expected_id == 0) {
+                expected_id = '!';
+                while (cfg.alphabet.find(expected_id) != std::string::npos &&
+                       expected_id < '~') {
+                    expected_id++;
+                }
+            }
+            if (first == expected_id) {
+                checksum_chars = grp.substr(1);
+                found_checksum = true;
+                continue;
+            }
+        }
+        /* Data group. */
+        std::string payload;
+        size_t      idx = data_group_seq;
+        if (!cfg.disable_group_ids) {
+            payload = grp.substr(1);
+            auto id_pos = cfg.alphabet.find(first);
+            if (id_pos == std::string::npos) {
+                return false;
+            }
+            idx = id_pos;
+            if (idx >= expected_data_groups) {
+                return false;
+            }
+            if (seen_group[idx]) {
+                return false;
+            }
+            seen_group[idx] = true;
+            group_payloads[idx] = payload;
+        } else {
+            payload = grp;
+            if (data_group_seq >= expected_data_groups) {
+                return false;
+            }
+            group_payloads[data_group_seq] = payload;
+            data_group_seq++;
+        }
+    }
+
+    if (!found_checksum) {
+        return false;
+    }
+    /* Verify all data groups were present and assemble flat in group order. */
+    for (size_t i = 0; i < expected_data_groups; i++) {
+        if (!cfg.disable_group_ids && !seen_group[i]) {
+            return false;
+        }
+        flat_chars += group_payloads[i];
+    }
+    flat = flat_chars;
+    /* Verify checksum. */
+    if (!cfg.disable_checksum) {
+        std::vector<uint8_t> entropy;
+        if (!flat_string_to_entropy(flat, cfg, entropy)) {
+            return false;
+        }
+        std::string expected;
+        if (!compute_checksum(entropy, cfg, expected)) {
+            return false;
+        }
+        /* Compare up to checksum_chars() length (padding may extend). */
+        if (expected.size() > checksum_chars.size()) {
+            expected = expected.substr(0, checksum_chars.size());
+        }
+        checksum_ok = (expected == checksum_chars.substr(0, expected.size()));
+    }
+    return true;
+}
+
+} // namespace rnp

--- a/src/lib/entropy_encoding.cpp
+++ b/src/lib/entropy_encoding.cpp
@@ -143,9 +143,9 @@ EntropyEncodingConfig::validate(std::string &error) const
 }
 
 bool
-entropy_to_flat_string(const std::vector<uint8_t> &entropy,
-                        const EntropyEncodingConfig &cfg,
-                        std::string &out)
+entropy_to_flat_string(const std::vector<uint8_t> & entropy,
+                       const EntropyEncodingConfig &cfg,
+                       std::string &                out)
 {
     size_t bpc = cfg.bits_per_char();
     size_t total_chars = cfg.entropy_chars();
@@ -168,9 +168,9 @@ entropy_to_flat_string(const std::vector<uint8_t> &entropy,
 }
 
 bool
-flat_string_to_entropy(const std::string &flat,
-                        const EntropyEncodingConfig &cfg,
-                        std::vector<uint8_t> &out)
+flat_string_to_entropy(const std::string &          flat,
+                       const EntropyEncodingConfig &cfg,
+                       std::vector<uint8_t> &       out)
 {
     size_t bpc = cfg.bits_per_char();
     if (flat.size() != cfg.entropy_chars()) {
@@ -199,9 +199,9 @@ flat_string_to_entropy(const std::string &flat,
 }
 
 bool
-compute_checksum(const std::vector<uint8_t> &entropy,
-                  const EntropyEncodingConfig &cfg,
-                  std::string &out)
+compute_checksum(const std::vector<uint8_t> & entropy,
+                 const EntropyEncodingConfig &cfg,
+                 std::string &                out)
 {
     auto hash = rnp::Hash::create(PGP_HASH_SHA256);
     hash->add(entropy);
@@ -211,15 +211,14 @@ compute_checksum(const std::vector<uint8_t> &entropy,
     EntropyEncodingConfig cksum_cfg = cfg;
     cksum_cfg.entropy_bits = cfg.checksum_bits;
     /* Pad the digest to entropy_bytes() */
-    std::vector<uint8_t> trimmed(digest.begin(),
-                                  digest.begin() + cksum_cfg.entropy_bytes());
+    std::vector<uint8_t> trimmed(digest.begin(), digest.begin() + cksum_cfg.entropy_bytes());
     return entropy_to_flat_string(trimmed, cksum_cfg, out);
 }
 
 bool
-encode_structured(const std::vector<uint8_t> &entropy,
-                   const EntropyEncodingConfig &cfg,
-                   std::string &out)
+encode_structured(const std::vector<uint8_t> & entropy,
+                  const EntropyEncodingConfig &cfg,
+                  std::string &                out)
 {
     std::string flat;
     if (!entropy_to_flat_string(entropy, cfg, flat)) {
@@ -266,16 +265,16 @@ encode_structured(const std::vector<uint8_t> &entropy,
 }
 
 bool
-decode_structured(const std::string &structured,
-                   const EntropyEncodingConfig &cfg,
-                   std::string &flat,
-                   bool &checksum_ok)
+decode_structured(const std::string &          structured,
+                  const EntropyEncodingConfig &cfg,
+                  std::string &                flat,
+                  bool &                       checksum_ok)
 {
     checksum_ok = true;
     /* Split by separator. */
-    std::string sep = cfg.separator.empty() ? " " : cfg.separator;
+    std::string              sep = cfg.separator.empty() ? " " : cfg.separator;
     std::vector<std::string> groups;
-    size_t start = 0;
+    size_t                   start = 0;
     while (start <= structured.size()) {
         size_t pos = structured.find(sep, start);
         if (pos == std::string::npos) {
@@ -288,11 +287,11 @@ decode_structured(const std::string &structured,
 
     std::string flat_chars;
     flat_chars.reserve(cfg.entropy_chars());
-    std::string checksum_chars;
-    size_t expected_data_groups = cfg.data_group_count();
-    std::vector<bool> seen_group(expected_data_groups, false);
+    std::string              checksum_chars;
+    size_t                   expected_data_groups = cfg.data_group_count();
+    std::vector<bool>        seen_group(expected_data_groups, false);
     std::vector<std::string> group_payloads(expected_data_groups);
-    bool found_checksum = cfg.disable_checksum; /* if disabled, "found" trivially */
+    bool   found_checksum = cfg.disable_checksum; /* if disabled, "found" trivially */
     size_t data_group_seq = 0;
 
     for (auto &grp : groups) {

--- a/src/lib/entropy_encoding.hpp
+++ b/src/lib/entropy_encoding.hpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ENTROPY_ENCODING_HPP_
+#define ENTROPY_ENCODING_HPP_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "repgp/repgp_def.h"
+
+namespace rnp {
+
+/**
+ * Configuration for the human-readable entropy encoding, parsed from
+ * the FFI-facing rnp_entropy_encoding_params_t struct.
+ */
+struct EntropyEncodingConfig {
+    std::string alphabet;       /* power-of-two size, unique chars */
+    size_t      entropy_bits;   /* multiple of bits_per_char * group_size */
+    size_t      group_size;     /* payload chars per group */
+    bool        disable_group_ids;
+    bool        disable_checksum;
+    size_t      checksum_bits;
+    char        checksum_id;
+    std::string separator;
+
+    /* Derived: log2(alphabet.size()) */
+    size_t bits_per_char() const noexcept;
+    /* Derived: ceil(entropy_bits / 8) */
+    size_t entropy_bytes() const noexcept;
+    /* Derived: entropy_bits / bits_per_char */
+    size_t entropy_chars() const noexcept;
+    /* Derived: entropy_chars / group_size */
+    size_t data_group_count() const noexcept;
+    /* Derived: checksum_bits / bits_per_char */
+    size_t checksum_chars() const noexcept;
+
+    /* Validate the config; return false with an error message on failure. */
+    bool validate(std::string &error) const;
+};
+
+/**
+ * Convert raw entropy bytes to a flat string of alphabet characters.
+ * Returns false if the config is invalid.
+ */
+bool entropy_to_flat_string(const std::vector<uint8_t> &entropy,
+                             const EntropyEncodingConfig &cfg,
+                             std::string &out);
+
+/**
+ * Inverse: decode a flat string of alphabet characters to raw bytes.
+ * Returns false if the string contains characters outside the alphabet
+ * or the wrong number of characters.
+ */
+bool flat_string_to_entropy(const std::string &flat,
+                             const EntropyEncodingConfig &cfg,
+                             std::vector<uint8_t> &out);
+
+/**
+ * Compute the first `cfg.checksum_bits` bits of SHA-256(entropy),
+ * encoded as alphabet characters. Returns false on failure.
+ */
+bool compute_checksum(const std::vector<uint8_t> &entropy,
+                       const EntropyEncodingConfig &cfg,
+                       std::string &out);
+
+/**
+ * Encode raw entropy as a structured human-readable string per the
+ * config. Returns false on failure.
+ */
+bool encode_structured(const std::vector<uint8_t> &entropy,
+                        const EntropyEncodingConfig &cfg,
+                        std::string &out);
+
+/**
+ * Parse a structured human-readable string per the config. Populates
+ * `flat` with the entropy characters concatenated (no groups, no IDs,
+ * no checksum). Returns false if malformed; sets checksum_ok=false if
+ * the checksum does not verify.
+ */
+bool decode_structured(const std::string &structured,
+                        const EntropyEncodingConfig &cfg,
+                        std::string &flat,
+                        bool &checksum_ok);
+
+} // namespace rnp
+
+#endif

--- a/src/lib/entropy_encoding.hpp
+++ b/src/lib/entropy_encoding.hpp
@@ -39,9 +39,9 @@ namespace rnp {
  * the FFI-facing rnp_entropy_encoding_params_t struct.
  */
 struct EntropyEncodingConfig {
-    std::string alphabet;       /* power-of-two size, unique chars */
-    size_t      entropy_bits;   /* multiple of bits_per_char * group_size */
-    size_t      group_size;     /* payload chars per group */
+    std::string alphabet;     /* power-of-two size, unique chars */
+    size_t      entropy_bits; /* multiple of bits_per_char * group_size */
+    size_t      group_size;   /* payload chars per group */
     bool        disable_group_ids;
     bool        disable_checksum;
     size_t      checksum_bits;
@@ -67,34 +67,34 @@ struct EntropyEncodingConfig {
  * Convert raw entropy bytes to a flat string of alphabet characters.
  * Returns false if the config is invalid.
  */
-bool entropy_to_flat_string(const std::vector<uint8_t> &entropy,
-                             const EntropyEncodingConfig &cfg,
-                             std::string &out);
+bool entropy_to_flat_string(const std::vector<uint8_t> & entropy,
+                            const EntropyEncodingConfig &cfg,
+                            std::string &                out);
 
 /**
  * Inverse: decode a flat string of alphabet characters to raw bytes.
  * Returns false if the string contains characters outside the alphabet
  * or the wrong number of characters.
  */
-bool flat_string_to_entropy(const std::string &flat,
-                             const EntropyEncodingConfig &cfg,
-                             std::vector<uint8_t> &out);
+bool flat_string_to_entropy(const std::string &          flat,
+                            const EntropyEncodingConfig &cfg,
+                            std::vector<uint8_t> &       out);
 
 /**
  * Compute the first `cfg.checksum_bits` bits of SHA-256(entropy),
  * encoded as alphabet characters. Returns false on failure.
  */
-bool compute_checksum(const std::vector<uint8_t> &entropy,
-                       const EntropyEncodingConfig &cfg,
-                       std::string &out);
+bool compute_checksum(const std::vector<uint8_t> & entropy,
+                      const EntropyEncodingConfig &cfg,
+                      std::string &                out);
 
 /**
  * Encode raw entropy as a structured human-readable string per the
  * config. Returns false on failure.
  */
-bool encode_structured(const std::vector<uint8_t> &entropy,
-                        const EntropyEncodingConfig &cfg,
-                        std::string &out);
+bool encode_structured(const std::vector<uint8_t> & entropy,
+                       const EntropyEncodingConfig &cfg,
+                       std::string &                out);
 
 /**
  * Parse a structured human-readable string per the config. Populates
@@ -102,10 +102,10 @@ bool encode_structured(const std::vector<uint8_t> &entropy,
  * no checksum). Returns false if malformed; sets checksum_ok=false if
  * the checksum does not verify.
  */
-bool decode_structured(const std::string &structured,
-                        const EntropyEncodingConfig &cfg,
-                        std::string &flat,
-                        bool &checksum_ok);
+bool decode_structured(const std::string &          structured,
+                       const EntropyEncodingConfig &cfg,
+                       std::string &                flat,
+                       bool &                       checksum_ok);
 
 } // namespace rnp
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -27,6 +27,7 @@
 
 #include "crypto/common.h"
 #include "key.hpp"
+#include "entropy_encoding.hpp"
 #include "defaults.h"
 #include <assert.h>
 #include <nlohmann/json.hpp>
@@ -8982,3 +8983,374 @@ rnp_backend_version()
 {
     return rnp::backend_version();
 }
+
+/* ===================== Entropy encoding ===================== */
+
+static void
+normalize_entropy_params(const rnp_entropy_encoding_params_t *in,
+                          rnp_entropy_encoding_params_t &out)
+{
+    out = {};
+    if (in) {
+        out = *in;
+    }
+    if (!out.alphabet) {
+        out.alphabet = "0123456789ABCDEF";
+    }
+    if (out.entropy_bits == 0) {
+        out.entropy_bits = 256;
+    }
+    if (out.group_size == 0) {
+        out.group_size = 4;
+    }
+    /* disable_* fields are bool; user-supplied value stands. NULL params
+     * defaults to "include" (false). */
+    out.disable_group_ids = in ? in->disable_group_ids : false;
+    out.disable_checksum = in ? in->disable_checksum : false;
+    if (out.checksum_bits == 0) {
+        out.checksum_bits = 16;
+    }
+    if (!out.separator) {
+        out.separator = " ";
+    }
+}
+
+static bool
+params_to_cfg(const rnp_entropy_encoding_params_t *params,
+               rnp::EntropyEncodingConfig &cfg,
+               std::string &                error)
+{
+    rnp_entropy_encoding_params_t norm;
+    normalize_entropy_params(params, norm);
+    cfg.alphabet = norm.alphabet;
+    cfg.entropy_bits = norm.entropy_bits;
+    cfg.group_size = norm.group_size;
+    cfg.disable_group_ids = norm.disable_group_ids;
+    cfg.disable_checksum = norm.disable_checksum;
+    cfg.checksum_bits = norm.checksum_bits;
+    cfg.checksum_id = norm.checksum_id;
+    cfg.separator = norm.separator;
+    return cfg.validate(error);
+}
+
+static char *
+alloc_cstr(const std::string &s)
+{
+    char *out = static_cast<char *>(malloc(s.size() + 1));
+    if (!out) {
+        return nullptr;
+    }
+    memcpy(out, s.data(), s.size());
+    out[s.size()] = '\0';
+    return out;
+}
+
+rnp_result_t
+rnp_entropy_encode_human_readable(rnp_ffi_t                             ffi,
+                                   const rnp_entropy_encoding_params_t * params,
+                                   char **                               structured_form,
+                                   char **                               flat_form)
+try {
+    if (!ffi || (!structured_form && !flat_form)) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    rnp::EntropyEncodingConfig cfg;
+    std::string                error;
+    if (!params_to_cfg(params, cfg, error)) {
+        FFI_LOG(ffi, "entropy encoding params invalid: %s", error.c_str());
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    /* Generate entropy via the FFI RNG. */
+    std::vector<uint8_t> entropy(cfg.entropy_bytes());
+    ffi->context.rng.get(entropy.data(), entropy.size());
+    std::string flat;
+    if (!rnp::entropy_to_flat_string(entropy, cfg, flat)) {
+        return RNP_ERROR_GENERIC;
+    }
+    if (flat_form) {
+        *flat_form = alloc_cstr(flat);
+        if (!*flat_form) {
+            return RNP_ERROR_OUT_OF_MEMORY;
+        }
+    }
+    if (structured_form) {
+        std::string structured;
+        if (!rnp::encode_structured(entropy, cfg, structured)) {
+            if (flat_form) {
+                free(*flat_form);
+                *flat_form = nullptr;
+            }
+            return RNP_ERROR_GENERIC;
+        }
+        *structured_form = alloc_cstr(structured);
+        if (!*structured_form) {
+            if (flat_form) {
+                free(*flat_form);
+                *flat_form = nullptr;
+            }
+            return RNP_ERROR_OUT_OF_MEMORY;
+        }
+    }
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_entropy_decode_human_readable(const char *                          structured_form,
+                                   const rnp_entropy_encoding_params_t * params,
+                                   char **                               flat_form)
+try {
+    if (!structured_form || !flat_form) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    rnp::EntropyEncodingConfig cfg;
+    std::string                error;
+    if (!params_to_cfg(params, cfg, error)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    std::string flat;
+    bool        checksum_ok = true;
+    if (!rnp::decode_structured(std::string(structured_form), cfg, flat, checksum_ok)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    if (!checksum_ok) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    char *out = alloc_cstr(flat);
+    if (!out) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    *flat_form = out;
+    return RNP_SUCCESS;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_entropy_encoding_validate(const char *                          structured_form,
+                               const rnp_entropy_encoding_params_t * params)
+try {
+    if (!structured_form) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    rnp::EntropyEncodingConfig cfg;
+    std::string                error;
+    if (!params_to_cfg(params, cfg, error)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    std::string flat;
+    bool        checksum_ok = true;
+    if (!rnp::decode_structured(std::string(structured_form), cfg, flat, checksum_ok)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    return checksum_ok ? RNP_SUCCESS : RNP_ERROR_SIGNATURE_INVALID;
+}
+FFI_GUARD
+
+/* ===================== Backup archive ===================== */
+
+rnp_result_t
+rnp_backup_archive_create(rnp_ffi_t                            ffi,
+                           rnp_key_handle_t *                   keys_to_backup,
+                           size_t                               key_count,
+                           rnp_key_handle_t                     signing_key,
+                           rnp_key_handle_t                     encryption_key,
+                           const rnp_backup_archive_params_t *  params,
+                           rnp_output_t                         output)
+try {
+    if (!ffi || !keys_to_backup || !signing_key || !encryption_key || !output) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    if (key_count == 0) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    /* Step 1: export each key as a transferable secret key into a single
+     * memory buffer. */
+    rnp_output_t keys_output = NULL;
+    if (rnp_output_to_memory(&keys_output, 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    for (size_t i = 0; i < key_count; i++) {
+        if (!keys_to_backup[i]) {
+            rnp_output_destroy(keys_output);
+            return RNP_ERROR_NULL_POINTER;
+        }
+        uint32_t flags = RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS;
+        rnp_result_t r = rnp_key_export(keys_to_backup[i], keys_output, flags);
+        if (r) {
+            rnp_output_destroy(keys_output);
+            return r;
+        }
+    }
+    uint8_t *keys_buf = NULL;
+    size_t   keys_len = 0;
+    if (rnp_output_memory_get_buf(keys_output, &keys_buf, &keys_len, false)) {
+        rnp_output_destroy(keys_output);
+        return RNP_ERROR_GENERIC;
+    }
+
+    /* Step 2: build a signed, encrypted OpenPGP message containing the
+     * concatenated transferable keys as the literal data. */
+    rnp_input_t payload_input = NULL;
+    rnp_result_t r =
+      rnp_input_from_memory(&payload_input, keys_buf, keys_len, true);
+    rnp_output_destroy(keys_output);
+    if (r) {
+        return r;
+    }
+
+    rnp_op_encrypt_t op = NULL;
+    r = rnp_op_encrypt_create(&op, ffi, payload_input, output);
+    if (r) {
+        rnp_input_destroy(payload_input);
+        return r;
+    }
+    /* Add recipient (the encryption_key). */
+    r = rnp_op_encrypt_add_recipient(op, encryption_key);
+    if (r) {
+        rnp_op_encrypt_destroy(op);
+        rnp_input_destroy(payload_input);
+        return r;
+    }
+    /* Add signature with signing_key. */
+    r = rnp_op_encrypt_add_signature(op, signing_key, NULL);
+    if (r) {
+        rnp_op_encrypt_destroy(op);
+        rnp_input_destroy(payload_input);
+        return r;
+    }
+    if (params) {
+        if (params->cipher) {
+            r = rnp_op_encrypt_set_cipher(op, params->cipher);
+            if (r) {
+                goto enc_cleanup;
+            }
+        }
+        if (params->aead) {
+            r = rnp_op_encrypt_set_aead(op, params->aead);
+            if (r) {
+                goto enc_cleanup;
+            }
+        }
+        if (params->hash) {
+            r = rnp_op_encrypt_set_hash(op, params->hash);
+            if (r) {
+                goto enc_cleanup;
+            }
+        }
+    }
+    r = rnp_op_encrypt_execute(op);
+enc_cleanup:
+    rnp_op_encrypt_destroy(op);
+    rnp_input_destroy(payload_input);
+    output->keep = (r == RNP_SUCCESS);
+    return r;
+}
+FFI_GUARD
+
+rnp_result_t
+rnp_backup_archive_load(rnp_ffi_t        ffi,
+                         rnp_input_t      input,
+                         rnp_key_handle_t decryption_key,
+                         rnp_key_handle_t signing_key_public)
+try {
+    if (!ffi || !input || !decryption_key || !signing_key_public) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    /* Unlock the decryption key (caller may have already unlocked it). */
+    bool locked = false;
+    {
+        bool is_locked = false;
+        if (rnp_key_is_locked(decryption_key, &is_locked) == RNP_SUCCESS && is_locked) {
+            locked = true;
+        }
+    }
+    (void) locked; /* The caller is responsible for unlocking. */
+
+    /* Decrypt via rnp_op_verify, which returns both the plaintext and
+     * signature verification status. */
+    rnp_output_t plaintext_output = NULL;
+    if (rnp_output_to_memory(&plaintext_output, 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    rnp_op_verify_t verify = NULL;
+    rnp_result_t    r = rnp_op_verify_create(&verify, ffi, input, plaintext_output);
+    if (r) {
+        rnp_output_destroy(plaintext_output);
+        return r;
+    }
+    r = rnp_op_verify_execute(verify);
+    if (r) {
+        rnp_op_verify_destroy(verify);
+        rnp_output_destroy(plaintext_output);
+        return r;
+    }
+    /* Verify the signature using the signing key's public component. */
+    size_t sig_count = 0;
+    rnp_op_verify_get_signature_count(verify, &sig_count);
+    if (sig_count == 0) {
+        rnp_op_verify_destroy(verify);
+        rnp_output_destroy(plaintext_output);
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    bool any_good = false;
+    for (size_t i = 0; i < sig_count; i++) {
+        rnp_op_verify_signature_t sig = NULL;
+        if (rnp_op_verify_get_signature_at(verify, i, &sig)) {
+            continue;
+        }
+        rnp_signature_handle_t sig_handle = NULL;
+        if (rnp_op_verify_signature_get_handle(sig, &sig_handle)) {
+            continue;
+        }
+        rnp_key_handle_t sig_key = NULL;
+        rnp_result_t     sig_r = rnp_signature_get_signer(sig_handle, &sig_key);
+        rnp_signature_handle_destroy(sig_handle);
+        if (sig_r) {
+            continue;
+        }
+        char *keyid = NULL;
+        rnp_key_get_keyid(sig_key, &keyid);
+        char *expected_keyid = NULL;
+        rnp_key_get_keyid(signing_key_public, &expected_keyid);
+        bool match = keyid && expected_keyid && strcmp(keyid, expected_keyid) == 0;
+        free(keyid);
+        free(expected_keyid);
+        rnp_key_handle_destroy(sig_key);
+        if (match) {
+            rnp_result_t status = rnp_op_verify_signature_get_status(sig);
+            if (status == RNP_SUCCESS) {
+                any_good = true;
+                break;
+            }
+        }
+    }
+    if (!any_good) {
+        rnp_op_verify_destroy(verify);
+        rnp_output_destroy(plaintext_output);
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    /* Import the recovered keys from the decrypted plaintext. */
+    uint8_t *keys_buf = NULL;
+    size_t   keys_len = 0;
+    r = rnp_output_memory_get_buf(plaintext_output, &keys_buf, &keys_len, false);
+    if (r) {
+        rnp_op_verify_destroy(verify);
+        rnp_output_destroy(plaintext_output);
+        return r;
+    }
+    rnp_input_t keys_input = NULL;
+    r = rnp_input_from_memory(&keys_input, keys_buf, keys_len, true);
+    if (r) {
+        rnp_op_verify_destroy(verify);
+        rnp_output_destroy(plaintext_output);
+        return r;
+    }
+    char *results = NULL;
+    r = rnp_import_keys(ffi, keys_input, RNP_LOAD_SAVE_SECRET_KEYS, &results);
+    free(results);
+    rnp_input_destroy(keys_input);
+    rnp_op_verify_destroy(verify);
+    rnp_output_destroy(plaintext_output);
+    return r;
+}
+FFI_GUARD

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -9274,11 +9274,13 @@ try {
     rnp_op_verify_t verify = NULL;
     rnp_result_t    r = rnp_op_verify_create(&verify, ffi, input, plaintext_output);
     if (r) {
+        FFI_LOG(ffi, "backup archive: failed to create verify op: %d", (int) r);
         rnp_output_destroy(plaintext_output);
         return r;
     }
     r = rnp_op_verify_execute(verify);
     if (r) {
+        FFI_LOG(ffi, "backup archive: decrypt/verify failed: %d", (int) r);
         rnp_op_verify_destroy(verify);
         rnp_output_destroy(plaintext_output);
         return r;
@@ -9287,6 +9289,7 @@ try {
     size_t sig_count = 0;
     rnp_op_verify_get_signature_count(verify, &sig_count);
     if (sig_count == 0) {
+        FFI_LOG(ffi, "backup archive: no signatures");
         rnp_op_verify_destroy(verify);
         rnp_output_destroy(plaintext_output);
         return RNP_ERROR_SIGNATURE_INVALID;
@@ -9324,6 +9327,7 @@ try {
         }
     }
     if (!any_good) {
+        FFI_LOG(ffi, "backup archive: signing key signature missing or invalid");
         rnp_op_verify_destroy(verify);
         rnp_output_destroy(plaintext_output);
         return RNP_ERROR_SIGNATURE_INVALID;
@@ -9333,6 +9337,7 @@ try {
     size_t   keys_len = 0;
     r = rnp_output_memory_get_buf(plaintext_output, &keys_buf, &keys_len, false);
     if (r) {
+        FFI_LOG(ffi, "backup archive: failed to get plaintext: %d", (int) r);
         rnp_op_verify_destroy(verify);
         rnp_output_destroy(plaintext_output);
         return r;
@@ -9346,6 +9351,12 @@ try {
     }
     char *results = NULL;
     r = rnp_import_keys(ffi, keys_input, RNP_LOAD_SAVE_SECRET_KEYS, &results);
+    if (r) {
+        FFI_LOG(ffi,
+                "backup archive: key import failed: %d (plaintext %zu bytes)",
+                (int) r,
+                keys_len);
+    }
     free(results);
     rnp_input_destroy(keys_input);
     rnp_op_verify_destroy(verify);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -8988,7 +8988,7 @@ rnp_backend_version()
 
 static void
 normalize_entropy_params(const rnp_entropy_encoding_params_t *in,
-                          rnp_entropy_encoding_params_t &out)
+                         rnp_entropy_encoding_params_t &      out)
 {
     out = {};
     if (in) {
@@ -9017,8 +9017,8 @@ normalize_entropy_params(const rnp_entropy_encoding_params_t *in,
 
 static bool
 params_to_cfg(const rnp_entropy_encoding_params_t *params,
-               rnp::EntropyEncodingConfig &cfg,
-               std::string &                error)
+              rnp::EntropyEncodingConfig &         cfg,
+              std::string &                        error)
 {
     rnp_entropy_encoding_params_t norm;
     normalize_entropy_params(params, norm);
@@ -9046,10 +9046,10 @@ alloc_cstr(const std::string &s)
 }
 
 rnp_result_t
-rnp_entropy_encode_human_readable(rnp_ffi_t                             ffi,
-                                   const rnp_entropy_encoding_params_t * params,
-                                   char **                               structured_form,
-                                   char **                               flat_form)
+rnp_entropy_encode_human_readable(rnp_ffi_t                            ffi,
+                                  const rnp_entropy_encoding_params_t *params,
+                                  char **                              structured_form,
+                                  char **                              flat_form)
 try {
     if (!ffi || (!structured_form && !flat_form)) {
         return RNP_ERROR_NULL_POINTER;
@@ -9096,9 +9096,9 @@ try {
 FFI_GUARD
 
 rnp_result_t
-rnp_entropy_decode_human_readable(const char *                          structured_form,
-                                   const rnp_entropy_encoding_params_t * params,
-                                   char **                               flat_form)
+rnp_entropy_decode_human_readable(const char *                         structured_form,
+                                  const rnp_entropy_encoding_params_t *params,
+                                  char **                              flat_form)
 try {
     if (!structured_form || !flat_form) {
         return RNP_ERROR_NULL_POINTER;
@@ -9126,8 +9126,8 @@ try {
 FFI_GUARD
 
 rnp_result_t
-rnp_entropy_encoding_validate(const char *                          structured_form,
-                               const rnp_entropy_encoding_params_t * params)
+rnp_entropy_encoding_validate(const char *                         structured_form,
+                              const rnp_entropy_encoding_params_t *params)
 try {
     if (!structured_form) {
         return RNP_ERROR_NULL_POINTER;
@@ -9149,13 +9149,13 @@ FFI_GUARD
 /* ===================== Backup archive ===================== */
 
 rnp_result_t
-rnp_backup_archive_create(rnp_ffi_t                            ffi,
-                           rnp_key_handle_t *                   keys_to_backup,
-                           size_t                               key_count,
-                           rnp_key_handle_t                     signing_key,
-                           rnp_key_handle_t                     encryption_key,
-                           const rnp_backup_archive_params_t *  params,
-                           rnp_output_t                         output)
+rnp_backup_archive_create(rnp_ffi_t                          ffi,
+                          rnp_key_handle_t *                 keys_to_backup,
+                          size_t                             key_count,
+                          rnp_key_handle_t                   signing_key,
+                          rnp_key_handle_t                   encryption_key,
+                          const rnp_backup_archive_params_t *params,
+                          rnp_output_t                       output)
 try {
     if (!ffi || !keys_to_backup || !signing_key || !encryption_key || !output) {
         return RNP_ERROR_NULL_POINTER;
@@ -9174,7 +9174,7 @@ try {
             rnp_output_destroy(keys_output);
             return RNP_ERROR_NULL_POINTER;
         }
-        uint32_t flags = RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS;
+        uint32_t     flags = RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS;
         rnp_result_t r = rnp_key_export(keys_to_backup[i], keys_output, flags);
         if (r) {
             rnp_output_destroy(keys_output);
@@ -9190,9 +9190,8 @@ try {
 
     /* Step 2: build a signed, encrypted OpenPGP message containing the
      * concatenated transferable keys as the literal data. */
-    rnp_input_t payload_input = NULL;
-    rnp_result_t r =
-      rnp_input_from_memory(&payload_input, keys_buf, keys_len, true);
+    rnp_input_t  payload_input = NULL;
+    rnp_result_t r = rnp_input_from_memory(&payload_input, keys_buf, keys_len, true);
     rnp_output_destroy(keys_output);
     if (r) {
         return r;
@@ -9249,9 +9248,9 @@ FFI_GUARD
 
 rnp_result_t
 rnp_backup_archive_load(rnp_ffi_t        ffi,
-                         rnp_input_t      input,
-                         rnp_key_handle_t decryption_key,
-                         rnp_key_handle_t signing_key_public)
+                        rnp_input_t      input,
+                        rnp_key_handle_t decryption_key,
+                        rnp_key_handle_t signing_key_public)
 try {
     if (!ffi || !input || !decryption_key || !signing_key_public) {
         return RNP_ERROR_NULL_POINTER;

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -33,6 +33,7 @@
 #include <rnp/rnp.h>
 #include "rnp_tests.h"
 #include "support.h"
+#include "logging.h"
 #include "librepgp/stream-common.h"
 #include "librepgp/stream-packet.h"
 #include "librepgp/stream-sig.h"
@@ -2724,6 +2725,13 @@ TEST_F(rnp_tests, test_ffi_entropy_encoding_roundtrip)
 
 TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
 {
+    /* Release CI builds disable logging unless RNP_LOG_CONSOLE is set;
+     * surface it for this test so failures report which step broke. */
+    struct LogGuard {
+        LogGuard() { set_rnp_log_switch(1); }
+        ~LogGuard() { set_rnp_log_switch(-1); }
+    } logguard;
+
     rnp_ffi_t ffi = NULL;
     assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
 

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -24,7 +24,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <fcntl.h>
 #include <fstream>
 #include <vector>
 #include <string>
@@ -2728,8 +2727,14 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
     /* Release CI builds disable logging unless RNP_LOG_CONSOLE is set;
      * surface it for this test so failures report which step broke. */
     struct LogGuard {
-        LogGuard() { set_rnp_log_switch(1); }
-        ~LogGuard() { set_rnp_log_switch(-1); }
+        LogGuard()
+        {
+            set_rnp_log_switch(1);
+        }
+        ~LogGuard()
+        {
+            set_rnp_log_switch(-1);
+        }
     } logguard;
 
     rnp_ffi_t ffi = NULL;
@@ -2773,13 +2778,14 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
     assert_true(archive_len > 0);
 
     /* Save to a file for re-input. The archive contains secret key material;
-     * create it owner-only rather than world-writable. */
-    int archive_fd = open("backup.archive", O_WRONLY | O_CREAT | O_TRUNC, 0600);
-    assert_true(archive_fd >= 0);
-    FILE *f = fdopen(archive_fd, "wb");
-    assert_non_null(f);
-    assert_int_equal(fwrite(archive_bytes, 1, archive_len, f), archive_len);
-    fclose(f);
+     * rnp's file output creates it owner-only and works portably (raw open()
+     * mode bits do not: 0600 lacks _S_IWRITE on MSVC, so fwrite fails). */
+    rnp_output_t archive_file = NULL;
+    assert_rnp_success(rnp_output_to_path(&archive_file, "backup.archive"));
+    size_t written = 0;
+    assert_rnp_success(rnp_output_write(archive_file, archive_bytes, archive_len, &written));
+    assert_int_equal(written, archive_len);
+    rnp_output_destroy(archive_file);
     rnp_output_destroy(archive_out);
 
     /* Load the archive into a fresh FFI (simulating device loss).

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -2678,7 +2678,7 @@ TEST_F(rnp_tests, test_ffi_entropy_encoding_roundtrip)
     flat = NULL;
     assert_rnp_success(rnp_entropy_encode_human_readable(ffi, &params, &structured, &flat));
     /* The structured form has 17 groups: 1 checksum + 16 data, separated by spaces. */
-    std::string original(structured);
+    std::string              original(structured);
     std::vector<std::string> groups;
     {
         size_t start = 0;
@@ -2753,18 +2753,14 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
     rnp_output_t archive_out = NULL;
     assert_rnp_success(rnp_output_to_memory(&archive_out, 0));
     rnp_key_handle_t keys_to_backup[] = {backup_key};
-    assert_rnp_success(rnp_backup_archive_create(ffi,
-                                                  keys_to_backup,
-                                                  1,
-                                                  signing_key,
-                                                  encryption_key,
-                                                  NULL,
-                                                  archive_out));
+    assert_rnp_success(rnp_backup_archive_create(
+      ffi, keys_to_backup, 1, signing_key, encryption_key, NULL, archive_out));
 
     /* Read the archive bytes. */
     uint8_t *archive_bytes = NULL;
     size_t   archive_len = 0;
-    assert_rnp_success(rnp_output_memory_get_buf(archive_out, &archive_bytes, &archive_len, false));
+    assert_rnp_success(
+      rnp_output_memory_get_buf(archive_out, &archive_bytes, &archive_len, false));
     assert_true(archive_len > 0);
 
     /* Save to a file for re-input. */
@@ -2780,13 +2776,15 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
     rnp_output_t enc_sec_out = NULL;
     assert_rnp_success(rnp_output_to_path(&enc_sec_out, "enc_sec.asc"));
     assert_rnp_success(
-      rnp_key_export(encryption_key, enc_sec_out,
+      rnp_key_export(encryption_key,
+                     enc_sec_out,
                      RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS | RNP_KEY_EXPORT_ARMORED));
     rnp_output_destroy(enc_sec_out);
     rnp_output_t sign_pub_out = NULL;
     assert_rnp_success(rnp_output_to_path(&sign_pub_out, "sign_pub.asc"));
     assert_rnp_success(
-      rnp_key_export(signing_key, sign_pub_out,
+      rnp_key_export(signing_key,
+                     sign_pub_out,
                      RNP_KEY_EXPORT_PUBLIC | RNP_KEY_EXPORT_SUBKEYS | RNP_KEY_EXPORT_ARMORED));
     rnp_output_destroy(sign_pub_out);
 
@@ -2803,10 +2801,12 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
 
     /* Locate the loaded keys by userid. */
     rnp_key_handle_t decryption_key2 = NULL;
-    assert_rnp_success(rnp_locate_key(ffi2, "userid", "encryptor <enc@example.com>", &decryption_key2));
+    assert_rnp_success(
+      rnp_locate_key(ffi2, "userid", "encryptor <enc@example.com>", &decryption_key2));
     assert_non_null(decryption_key2);
     rnp_key_handle_t signing_pub2 = NULL;
-    assert_rnp_success(rnp_locate_key(ffi2, "userid", "signer <signer@example.com>", &signing_pub2));
+    assert_rnp_success(
+      rnp_locate_key(ffi2, "userid", "signer <signer@example.com>", &signing_pub2));
     assert_non_null(signing_pub2);
 
     /* Load the archive. */
@@ -2818,7 +2818,8 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
 
     /* Verify the backed-up key is now present in ffi2. */
     rnp_key_handle_t recovered = NULL;
-    assert_rnp_success(rnp_locate_key(ffi2, "userid", "backed-up <bu@example.com>", &recovered));
+    assert_rnp_success(
+      rnp_locate_key(ffi2, "userid", "backed-up <bu@example.com>", &recovered));
     assert_non_null(recovered);
     bool is_secret = false;
     assert_rnp_success(rnp_key_have_secret(recovered, &is_secret));

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -24,6 +24,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <fcntl.h>
 #include <fstream>
 #include <vector>
 #include <string>
@@ -2763,8 +2764,11 @@ TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
       rnp_output_memory_get_buf(archive_out, &archive_bytes, &archive_len, false));
     assert_true(archive_len > 0);
 
-    /* Save to a file for re-input. */
-    FILE *f = fopen("backup.archive", "wb");
+    /* Save to a file for re-input. The archive contains secret key material;
+     * create it owner-only rather than world-writable. */
+    int archive_fd = open("backup.archive", O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    assert_true(archive_fd >= 0);
+    FILE *f = fdopen(archive_fd, "wb");
     assert_non_null(f);
     assert_int_equal(fwrite(archive_bytes, 1, archive_len, f), archive_len);
     fclose(f);

--- a/src/tests/ffi-enc.cpp
+++ b/src/tests/ffi-enc.cpp
@@ -2597,3 +2597,244 @@ TEST_F(rnp_tests, test_no_plaintext_leakage)
 
     rnp_ffi_destroy(ffi);
 }
+TEST_F(rnp_tests, test_ffi_entropy_encoding_roundtrip)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    /* Round-trip with all defaults: 256-bit entropy, hex alphabet,
+     * 16 data groups of 4 chars + 1 checksum line. */
+    char *structured = NULL;
+    char *flat = NULL;
+    assert_rnp_success(rnp_entropy_encode_human_readable(ffi, NULL, &structured, &flat));
+    assert_non_null(structured);
+    assert_non_null(flat);
+    /* Flat form is 64 hex chars (256 bits / 4 bits per char) */
+    assert_int_equal(strlen(flat), 64);
+
+    /* Decode and check the flat form round-trips exactly. */
+    char *decoded_flat = NULL;
+    assert_rnp_success(rnp_entropy_decode_human_readable(structured, NULL, &decoded_flat));
+    assert_non_null(decoded_flat);
+    assert_string_equal(decoded_flat, flat);
+    rnp_buffer_destroy(decoded_flat);
+
+    /* Validate the checksum. */
+    assert_rnp_success(rnp_entropy_encoding_validate(structured, NULL));
+
+    /* Tamper with the structured form: flip one alphabet character
+     * in a data group's payload. The checksum must catch it. */
+    std::string tampered(structured);
+    for (size_t i = 1; i < tampered.size(); i++) {
+        if (tampered[i] == '0') {
+            tampered[i] = '1';
+            break;
+        }
+        if (tampered[i] == '1') {
+            tampered[i] = '0';
+            break;
+        }
+    }
+    assert_rnp_failure(
+      rnp_entropy_decode_human_readable(tampered.c_str(), NULL, &decoded_flat));
+    assert_rnp_failure(rnp_entropy_encoding_validate(tampered.c_str(), NULL));
+
+    rnp_buffer_destroy(structured);
+    rnp_buffer_destroy(flat);
+
+    /* Custom alphabet: handwriting-friendly hex (0-9, then 6 distinct letters) */
+    rnp_entropy_encoding_params_t params = {};
+    params.alphabet = "0123456789HKNPWX";
+    params.entropy_bits = 256;
+    params.group_size = 4;
+    structured = NULL;
+    flat = NULL;
+    assert_rnp_success(rnp_entropy_encode_human_readable(ffi, &params, &structured, &flat));
+    assert_non_null(structured);
+    assert_non_null(flat);
+    /* All chars in the flat form must be from the custom alphabet. */
+    std::string fstr(flat);
+    for (char c : fstr) {
+        bool in_alpha = false;
+        for (char a : std::string("0123456789HKNPWX")) {
+            if (c == a) {
+                in_alpha = true;
+                break;
+            }
+        }
+        assert_true(in_alpha);
+    }
+    decoded_flat = NULL;
+    assert_rnp_success(rnp_entropy_decode_human_readable(structured, &params, &decoded_flat));
+    assert_string_equal(decoded_flat, flat);
+    rnp_buffer_destroy(structured);
+    rnp_buffer_destroy(flat);
+    rnp_buffer_destroy(decoded_flat);
+
+    /* Re-enter groups out of order; should still decode correctly via group IDs. */
+    /* Build a new structured form, then shuffle it. */
+    params.alphabet = "0123456789HKNPWX";
+    structured = NULL;
+    flat = NULL;
+    assert_rnp_success(rnp_entropy_encode_human_readable(ffi, &params, &structured, &flat));
+    /* The structured form has 17 groups: 1 checksum + 16 data, separated by spaces. */
+    std::string original(structured);
+    std::vector<std::string> groups;
+    {
+        size_t start = 0;
+        while (start <= original.size()) {
+            size_t pos = original.find(' ', start);
+            if (pos == std::string::npos) {
+                groups.push_back(original.substr(start));
+                break;
+            }
+            groups.push_back(original.substr(start, pos - start));
+            start = pos + 1;
+        }
+    }
+    /* Keep the checksum (first group) in place, swap two data groups. */
+    if (groups.size() >= 3) {
+        std::swap(groups[1], groups[2]);
+    }
+    std::string reordered;
+    for (size_t i = 0; i < groups.size(); i++) {
+        if (i > 0) {
+            reordered += ' ';
+        }
+        reordered += groups[i];
+    }
+    decoded_flat = NULL;
+    assert_rnp_success(
+      rnp_entropy_decode_human_readable(reordered.c_str(), &params, &decoded_flat));
+    assert_string_equal(decoded_flat, flat);
+    rnp_buffer_destroy(structured);
+    rnp_buffer_destroy(flat);
+    rnp_buffer_destroy(decoded_flat);
+
+    /* Invalid params: alphabet with non-power-of-2 size. */
+    rnp_entropy_encoding_params_t bad = {};
+    bad.alphabet = "ABC"; /* 3 chars, not a power of 2 */
+    bad.entropy_bits = 256;
+    bad.group_size = 4;
+    assert_rnp_failure(rnp_entropy_encode_human_readable(ffi, &bad, &structured, &flat));
+
+    rnp_ffi_destroy(ffi);
+}
+
+TEST_F(rnp_tests, test_ffi_backup_archive_roundtrip)
+{
+    rnp_ffi_t ffi = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    /* Generate an RSA keypair for the keys-to-backup, and a separate
+     * signing keypair + encryption keypair for the archive envelope. */
+    auto gen_key = [&](const char *userid, const char *usage) -> rnp_key_handle_t {
+        rnp_op_generate_t op = NULL;
+        rnp_key_handle_t  key = NULL;
+        EXPECT_EQ(RNP_SUCCESS, rnp_op_generate_create(&op, ffi, "RSA"));
+        EXPECT_EQ(RNP_SUCCESS, rnp_op_generate_set_bits(op, 2048));
+        if (userid) {
+            EXPECT_EQ(RNP_SUCCESS, rnp_op_generate_set_userid(op, userid));
+        }
+        if (usage) {
+            EXPECT_EQ(RNP_SUCCESS, rnp_op_generate_add_usage(op, usage));
+        }
+        EXPECT_EQ(RNP_SUCCESS, rnp_op_generate_execute(op));
+        EXPECT_EQ(RNP_SUCCESS, rnp_op_generate_get_key(op, &key));
+        rnp_op_generate_destroy(op);
+        return key;
+    };
+
+    rnp_key_handle_t backup_key = gen_key("backed-up <bu@example.com>", "sign");
+    rnp_key_handle_t signing_key = gen_key("signer <signer@example.com>", "sign");
+    rnp_key_handle_t encryption_key = gen_key("encryptor <enc@example.com>", "encrypt");
+
+    /* Create the backup archive. */
+    rnp_output_t archive_out = NULL;
+    assert_rnp_success(rnp_output_to_memory(&archive_out, 0));
+    rnp_key_handle_t keys_to_backup[] = {backup_key};
+    assert_rnp_success(rnp_backup_archive_create(ffi,
+                                                  keys_to_backup,
+                                                  1,
+                                                  signing_key,
+                                                  encryption_key,
+                                                  NULL,
+                                                  archive_out));
+
+    /* Read the archive bytes. */
+    uint8_t *archive_bytes = NULL;
+    size_t   archive_len = 0;
+    assert_rnp_success(rnp_output_memory_get_buf(archive_out, &archive_bytes, &archive_len, false));
+    assert_true(archive_len > 0);
+
+    /* Save to a file for re-input. */
+    FILE *f = fopen("backup.archive", "wb");
+    assert_non_null(f);
+    assert_int_equal(fwrite(archive_bytes, 1, archive_len, f), archive_len);
+    fclose(f);
+    rnp_output_destroy(archive_out);
+
+    /* Load the archive into a fresh FFI (simulating device loss).
+     * The signing key's PUBLIC component and the encryption key's SECRET
+     * component are needed. First export them. */
+    rnp_output_t enc_sec_out = NULL;
+    assert_rnp_success(rnp_output_to_path(&enc_sec_out, "enc_sec.asc"));
+    assert_rnp_success(
+      rnp_key_export(encryption_key, enc_sec_out,
+                     RNP_KEY_EXPORT_SECRET | RNP_KEY_EXPORT_SUBKEYS | RNP_KEY_EXPORT_ARMORED));
+    rnp_output_destroy(enc_sec_out);
+    rnp_output_t sign_pub_out = NULL;
+    assert_rnp_success(rnp_output_to_path(&sign_pub_out, "sign_pub.asc"));
+    assert_rnp_success(
+      rnp_key_export(signing_key, sign_pub_out,
+                     RNP_KEY_EXPORT_PUBLIC | RNP_KEY_EXPORT_SUBKEYS | RNP_KEY_EXPORT_ARMORED));
+    rnp_output_destroy(sign_pub_out);
+
+    rnp_ffi_t ffi2 = NULL;
+    assert_rnp_success(rnp_ffi_create(&ffi2, "GPG", "GPG"));
+    /* Import the encryption secret key and signing public key. */
+    rnp_input_t in = NULL;
+    assert_rnp_success(rnp_input_from_path(&in, "enc_sec.asc"));
+    assert_rnp_success(rnp_import_keys(ffi2, in, RNP_LOAD_SAVE_SECRET_KEYS, NULL));
+    rnp_input_destroy(in);
+    assert_rnp_success(rnp_input_from_path(&in, "sign_pub.asc"));
+    assert_rnp_success(rnp_import_keys(ffi2, in, RNP_LOAD_SAVE_PUBLIC_KEYS, NULL));
+    rnp_input_destroy(in);
+
+    /* Locate the loaded keys by userid. */
+    rnp_key_handle_t decryption_key2 = NULL;
+    assert_rnp_success(rnp_locate_key(ffi2, "userid", "encryptor <enc@example.com>", &decryption_key2));
+    assert_non_null(decryption_key2);
+    rnp_key_handle_t signing_pub2 = NULL;
+    assert_rnp_success(rnp_locate_key(ffi2, "userid", "signer <signer@example.com>", &signing_pub2));
+    assert_non_null(signing_pub2);
+
+    /* Load the archive. */
+    rnp_input_t archive_in = NULL;
+    assert_rnp_success(rnp_input_from_path(&archive_in, "backup.archive"));
+    assert_rnp_success(
+      rnp_backup_archive_load(ffi2, archive_in, decryption_key2, signing_pub2));
+    rnp_input_destroy(archive_in);
+
+    /* Verify the backed-up key is now present in ffi2. */
+    rnp_key_handle_t recovered = NULL;
+    assert_rnp_success(rnp_locate_key(ffi2, "userid", "backed-up <bu@example.com>", &recovered));
+    assert_non_null(recovered);
+    bool is_secret = false;
+    assert_rnp_success(rnp_key_have_secret(recovered, &is_secret));
+    assert_true(is_secret);
+
+    rnp_key_handle_destroy(recovered);
+    rnp_key_handle_destroy(signing_pub2);
+    rnp_key_handle_destroy(decryption_key2);
+    rnp_ffi_destroy(ffi2);
+
+    rnp_key_handle_destroy(backup_key);
+    rnp_key_handle_destroy(signing_key);
+    rnp_key_handle_destroy(encryption_key);
+    rnp_ffi_destroy(ffi);
+
+    unlink("backup.archive");
+    unlink("enc_sec.asc");
+    unlink("sign_pub.asc");
+}


### PR DESCRIPTION
## Summary

Adds two general-purpose building-block APIs that clients can compose into backup, sync, and escrow workflows. Each is self-contained and parameterised; rnp deliberately does not bake in any specific application's workflow.

### What's in this PR

**Entropy encoding utility** (`rnp_entropy_encode_human_readable`, `_decode`, `_validate`):
- Generates cryptographically random entropy via the FFI RNG.
- Encodes it in a caller-specified alphabet, split into groups with optional identifiers and optional SHA-256-based checksum.
- Useful whenever random bytes need to be transcribed by humans (paper backup, manual entry).
- Default alphabet is hex; callers supply their own alphabet via the params struct (e.g. handwriting-friendly variants).
- `disable_*` bool fields follow C convention: `false` (zero-init default) = include feature, `true` = omit. This lets callers pass an all-zero params struct for the common default case.

**Backup archive format** (`rnp_backup_archive_create`, `_load`):
- Wraps a sequence of secret-key exports in a standard OpenPGP signed-and-encrypted message.
- Wire format is a literal-data packet containing concatenated transferable secret keys, signed by a caller-specified key, encrypted to a caller-specified public key.
- Format is RFC 9580-compliant; any OpenPGP library can produce or consume it.
- Documented in `docs/develop/backup-format.adoc`.

**Tests**:
- `test_ffi_entropy_encoding_roundtrip` covers default-alphabet round-trip, custom-alphabet round-trip, order-independent group entry, tampered-checksum rejection, invalid-params rejection.
- `test_ffi_backup_archive_roundtrip` covers generate-keys → create archive → fresh FFI → load archive → verify recovered key present and secret.

### Why

These two building blocks come up in many real-world workflows:
- Enterprise key escrow
- Personal offline backups
- Multi-device key synchronisation
- Application-specific recovery flows

Previously each client would re-implement the entropy encoding and the signed+encrypted container pattern from scratch, with attendant correctness risk (checksum bugs, signature-then-encrypt ordering bugs, etc.). This PR gives them a tested, canonical implementation in the rnp library itself.

### Architectural decision

rnp is intentionally a crypto library, not a workflow framework. The APIs in this PR expose **building blocks** that clients compose on their own; they do NOT prescribe a specific workflow. Naming (`encryption_key`, `decryption_key`, `signing_key`) is intentionally generic so multiple applications can adopt the same primitives without coupling.

### What's NOT in this PR

- No mention of any specific application or external proposal.
- No CLI surface for these APIs (callers use the FFI directly).
- No "recovery keypair" or "data-signkey" pattern baked in; callers compose their own key structure as they see fit.

### Test plan

- [x] Build clean on default config (no warnings)
- [x] `test_ffi_entropy_encoding_roundtrip` passes locally (5 cases covered)
- [x] `test_ffi_backup_archive_roundtrip` passes locally (full round-trip with separate FFIs)
- [x] No regression in `test_ffi_encrypt_pass`, `test_ffi_argon2_locked_seckey`, `test_ffi_encrypt_pk_with_v6_key`
- [ ] CI green on all platforms
