### PR TITLE
cmake: first-class cross-compile support (OHOS, Android, etc.)

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of rnp
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Smoke test: cross-compile librnp + dependencies to aarch64-linux-ohos
+# (OpenHarmony). No test execution -- OHOS binaries cannot run on Linux CI
+# runners without QEMU, which is out of scope. The check is "did the static
+# archive link cleanly with the OHOS sysroot, and does 'file' confirm the
+# expected target architecture?"
+
+name: ohos
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths-ignore:
+      - '/*.sh'
+      - '/.*'
+      - '/_*'
+      - 'Brewfile'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - '**.nix'
+      - 'flake.lock'
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/ohos.yml'
+  pull_request:
+    paths:
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'src/lib/CMakeLists.txt'
+      - 'src/libsexpp/CMakeLists.txt'
+      - '.github/workflows/ohos.yml'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  aarch64-ohos-smoke:
+    name: aarch64-linux-ohos cross-compile (Botan backend)
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    timeout-minutes: 45
+    env:
+      OHOS_NDK_VERSION: "5.0.13.2"
+      BOTAN_VERSION: "3.6.1"
+      JSONC_VERSION: "0.18-20240915"
+    steps:
+      - name: Checkout rnp
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install host build deps
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install cmake ninja-build python3 bzip2 libbz2-dev zlib1g-dev
+
+      - name: Cache OHOS NDK
+        id: cache-ndk
+        uses: actions/cache@v4
+        with:
+          path: ~/ohos-ndk
+          key: ohos-ndk-${{ env.OHOS_NDK_VERSION }}-linux-x64
+
+      - name: Download OHOS NDK (commandline-tools)
+        if: steps.cache-ndk.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/ohos-ndk
+          # Huawei's commandline-tools-linux download. The URL pattern is
+          # versioned; if it changes, see
+          # https://developer.huawei.com/consumer/cn/download/ for the
+          # current SDK URL (CN portal; sign-in not required for the
+          # commandline-tools zip).
+          curl -L --retry 3 -o ~/ohos-ndk/ndk.zip \
+            "https://contentcenter-vali-drcn.dbankcdn.cn/pub_11/Download_CDN/local_chrun/Downloads/$(echo $OHOS_NDK_VERSION | tr -d .)/ohos-sdk-commandline-tools-linux-x64.zip"
+          cd ~/ohos-ndk && unzip -q ndk.zip
+          # Move the unzipped top dir to a stable path
+          find ~/ohos-ndk -maxdepth 1 -type d -name 'ohos-sdk-commandline-*' -exec mv {} ~/ohos-ndk/cmdtools \; || true
+          ls ~/ohos-ndk
+
+      - name: Locate OHOS toolchain & sysroot
+        id: ohos-paths
+        run: |
+          NDK_ROOT="$HOME/ohos-ndk/cmdtools/sdk"
+          echo "NDK_ROOT=$NDK_ROOT" >> $GITHUB_ENV
+          TOOLCHAIN=$(find "$NDK_ROOT" -name 'ohos.toolchain.cmake' | head -1)
+          SYSROOT=$(find "$NDK_ROOT" -type d -name 'aarch64-linux-ohos' -path '*sysroot*' | head -1)
+          echo "TOOLCHAIN=$TOOLCHAIN" >> $GITHUB_ENV
+          echo "SYSROOT=$SYSROOT" >> $GITHUB_ENV
+          echo "OHOS_NDK_HOME=$NDK_ROOT" >> $GITHUB_ENV
+          test -n "$TOOLCHAIN" && test -n "$SYSROOT"
+
+      - name: Cache cross-built Botan
+        id: cache-botan
+        uses: actions/cache@v4
+        with:
+          path: ~/ohos-deps/botan
+          key: ohos-botan-${{ env.BOTAN_VERSION }}-${{ env.OHOS_NDK_VERSION }}
+
+      - name: Cross-build Botan 3 for aarch64-linux-ohos
+        if: steps.cache-botan.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/ohos-deps && cd ~/ohos-deps
+          curl -L --retry 3 -o botan.tgz \
+            "https://botan.randombit.net/releases/Botan-${BOTAN_VERSION}.tar.xz"
+          tar xf botan.tgz
+          cd "Botan-${BOTAN_VERSION}"
+          python3 ./configure.py \
+            --cc=clang \
+            --cc-abi-flags="--target=aarch64-linux-ohos --sysroot=${SYSROOT}" \
+            --cc-bin="${OHOS_NDK_HOME}/native/llvm/bin/clang++ --target=aarch64-linux-ohos --sysroot=${SYSROOT}" \
+            --build-targets=static \
+            --without-documentation \
+            --disable-shared-library \
+            --minimized-build \
+            --enable-modules="aes,aes_ni,auto_rng,bigint,block,blowfish,camellia,cast128,cbc,cfb,chacha,chacha20poly1305,checksum,crc24,des,dl_group,dsa,ecc_group,ecdh,ecdsa,eddsa,ed25519,elgamal,eme_pkcs1,emsa_pkcs1,gcm,getentropy,ghash,hash,hex,hmac,hmac_drbg,idea,kdf,md5,mem_pool,ocb,pgp_s2k,pk_pad,pkcs_enc,rfc3394,rsa,sha1,sha2_32,sha2_64,sha3,sm2,sm3,sm4,sp800_56a,system_rng,twofish,x25519,x448,ed448,hkdf,kyber,dilithium,sphincsplus,sha3_512" \
+            --prefix="$HOME/ohos-deps/botan"
+          make -j"$(nproc)"
+          make install
+
+      - name: Cache cross-built json-c
+        id: cache-jsonc
+        uses: actions/cache@v4
+        with:
+          path: ~/ohos-deps/jsonc
+          key: ohos-jsonc-${{ env.JSONC_VERSION }}-${{ env.OHOS_NDK_VERSION }}
+
+      - name: Cross-build json-c for aarch64-linux-ohos
+        if: steps.cache-jsonc.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/ohos-deps && cd ~/ohos-deps
+          curl -L --retry 3 -o jsonc.tgz \
+            "https://github.com/json-c/json-c/archive/refs/tags/jsonc-${JSONC_VERSION}.tar.gz"
+          tar xf jsonc.tgz
+          cd "json-c-jsonc-${JSONC_VERSION}"
+          mkdir -p build && cd build
+          cmake -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+            -DOHOS_ARCH=arm64-v8a \
+            -DCMAKE_SYSROOT="${SYSROOT}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DCMAKE_INSTALL_PREFIX="$HOME/ohos-deps/jsonc" \
+            ..
+          ninja install
+
+      - name: Configure librnp for aarch64-linux-ohos
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+            -DOHOS_ARCH=arm64-v8a \
+            -DCMAKE_SYSROOT="${SYSROOT}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DENABLE_DOC=OFF \
+            -DDOWNLOAD_GTEST=OFF \
+            -DCRYPTO_BACKEND=botan \
+            -DBOTAN_INCLUDE_DIR="$HOME/ohos-deps/botan/include/botan-3" \
+            -DBOTAN_LIBRARY="$HOME/ohos-deps/botan/lib/libbotan-3.a" \
+            -DJSON-C_INCLUDE_DIR="$HOME/ohos-deps/jsonc/include/json-c" \
+            -DJSON-C_LIBRARY="$HOME/ohos-deps/jsonc/lib/libjson-c.a"
+
+      - name: Build librnp.a
+        run: cmake --build build --parallel "$(nproc)"
+
+      - name: Verify archive architecture
+        run: |
+          file build/src/lib/librnp.a
+          # The thin archive should contain aarch64-linux-ohos objects.
+          ar t build/src/lib/librnp.a | head -5
+          # Extract one object and verify its arch matches.
+          OBJ=$(ar t build/src/lib/librnp.a | head -1)
+          ar x build/src/lib/librnp.a "$OBJ"
+          file "$OBJ" | tee /dev/stderr | grep -q 'ELF 64-bit LSB.*aarch64'
+
+      - name: Upload librnp artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: librnp-aarch64-linux-ohos
+          path: |
+            build/src/lib/librnp.a
+            build/src/lib/rnp/rnp_export.h
+            build/src/lib/version.h
+            include/rnp/rnp.h
+            include/rnp/rnp_err.h
+          retention-days: 14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,40 @@ project(RNP
   DESCRIPTION "${PACKAGE_DESCRIPTION_SHORT}"
 )
 
+# Cross-compilation setup. When CMAKE_SYSTEM_NAME differs from CMAKE_HOST_SYSTEM_NAME,
+# CMake sets CMAKE_CROSSCOMPILING=TRUE. We additionally expose RNP_CROSSCOMPILING so
+# child modules (libsexpp) and find modules can branch without re-deriving it, and
+# constrain find_package/find_path/find_library to CMAKE_FIND_ROOT_PATH (the target
+# sysroot). Build-time helper executables (run during configure) bypass the root path
+# via explicit NO_CMAKE_FIND_ROOT_PATH on the relevant find_program/find_package calls.
+if(CMAKE_CROSSCOMPILING)
+  set(RNP_CROSSCOMPILING TRUE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+endif()
+
+# OHOS (OpenHarmony) is musl-based; the OHOS NDK's ohos.toolchain.cmake sets
+# CMAKE_SYSTEM_NAME=OHOS. We set RNP_TARGET_OHOS so downstream code can branch on
+# OHOS-specific quirks (musl rootfs layout, etc.).
+if(CMAKE_SYSTEM_NAME STREQUAL "OHOS")
+  set(RNP_TARGET_OHOS TRUE)
+  add_compile_definitions(RNP_PLATFORM_OHOS=1)
+endif()
+
+# Some cross-compile toolchain files (e.g. ohos.toolchain.cmake) default
+# CMAKE_INSTALL_PREFIX to /usr for sysroot staging. That causes install to
+# write to /usr/lib on the host filesystem. Surface a NOTICE so packagers
+# know to set DESTDIR or pass --prefix to cmake --install.
+if((CMAKE_INSTALL_PREFIX STREQUAL "/usr" OR CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
+    AND CMAKE_CROSSCOMPILING AND NOT DEFINED ENV{DESTDIR})
+  message(NOTICE
+    "CMAKE_INSTALL_PREFIX is '${CMAKE_INSTALL_PREFIX}' under cross-compile. "
+    "Install will write to '${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}' on the host. "
+    "For sysroot staging, set DESTDIR or pass --prefix to cmake --install.")
+endif()
+
 # tri-state options
 set(TRISTATE_VALUES On Off Auto)
 

--- a/cmake/Modules/FindBotan.cmake
+++ b/cmake/Modules/FindBotan.cmake
@@ -57,21 +57,28 @@
 #   Set to the root directory of the Botan installation.
 #
 
-# use pkg-config to get the directories and then use these values
-# in the find_path() and find_library() calls
-
-find_package(PkgConfig QUIET)
+# Use pkg-config to discover Botan on the host. When cross-compiling, pkg-config's
+# compiled-in paths point at the host root and would discover host-installed botan
+# even when CMAKE_FIND_ROOT_PATH is set; we therefore default to skipping it.
+# Callers who want pkg-config-driven discovery under cross-compile can force it on
+# with -DBOTAN_USE_PKGCONFIG=ON and set PKG_CONFIG_LIBDIR / PKG_CONFIG_SYSROOT_DIR.
+option(BOTAN_USE_PKGCONFIG "Use pkg-config to discover Botan" OFF)
+if(NOT BOTAN_USE_PKGCONFIG AND NOT CMAKE_CROSSCOMPILING)
+  find_package(PkgConfig QUIET)
+endif()
 
 # Search for the version 2 first unless version 3 requested
 if(NOT "${Botan_FIND_VERSION_MAJOR}" EQUAL "3")
-  pkg_check_modules(PC_BOTAN QUIET botan-2)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_BOTAN QUIET botan-2)
+  endif()
   set(_suffixes "botan-2" "botan-3")
   set(_names "botan-2" "libbotan-2" "botan-3" "libbotan-3")
 else()
   set(_suffixes "botan-3")
   set(_names "botan-3" "libbotan-3")
 endif()
-if(NOT PC_BOTAN_FOUND)
+if(PKG_CONFIG_FOUND AND NOT PC_BOTAN_FOUND)
   pkg_check_modules(PC_BOTAN QUIET botan-3)
 endif()
 
@@ -83,12 +90,23 @@ if(DEFINED ENV{BOTAN_ROOT_DIR})
   list(APPEND _hints_include "$ENV{BOTAN_ROOT_DIR}/include")
   list(APPEND _hints_lib "$ENV{BOTAN_ROOT_DIR}/lib")
 endif()
+# When cross-compiling, prepend CMAKE_FIND_ROOT_PATH entries so find_path /
+# find_library look inside the target sysroot.
+if(CMAKE_CROSSCOMPILING)
+  foreach(_root ${CMAKE_FIND_ROOT_PATH})
+    list(APPEND _hints_include "${_root}/include")
+    list(APPEND _hints_lib "${_root}/lib")
+  endforeach()
+  # Avoid host system paths (/usr, /usr/local, /lib) when cross-compiling.
+  set(_no_system_path "NO_CMAKE_SYSTEM_PATH")
+endif()
 
-# Append PC_* stuff only if BOTAN_ROOT_DIR is not specified
-if(NOT _hints_include)
+# Append PC_* stuff only if BOTAN_ROOT_DIR is not specified and pkg-config ran
+if(NOT _hints_include AND PC_BOTAN_INCLUDEDIR)
   list(APPEND _hints_include ${PC_BOTAN_INCLUDEDIR} ${PC_BOTAN_INCLUDE_DIRS})
   list(APPEND _hints_lib ${PC_BOTAN_LIBDIR} ${PC_BOTAN_LIBRARY_DIRS})
-else()
+endif()
+if(DEFINED BOTAN_ROOT_DIR)
   set(_no_def_path "NO_DEFAULT_PATH")
 endif()
 
@@ -99,6 +117,7 @@ find_path(BOTAN_INCLUDE_DIR
     ${_hints_include}
   PATH_SUFFIXES ${_suffixes}
   ${_no_def_path}
+  ${_no_system_path}
 )
 
 # find the library
@@ -108,6 +127,7 @@ if(MSVC)
     HINTS
       ${_hints_lib}
     ${_no_def_path}
+    ${_no_system_path}
   )
 else()
   find_library(BOTAN_LIBRARY
@@ -116,6 +136,7 @@ else()
     HINTS
       ${_hints_lib}
     ${_no_def_path}
+    ${_no_system_path}
   )
 endif()
 

--- a/cmake/Modules/FindJSON-C.cmake
+++ b/cmake/Modules/FindJSON-C.cmake
@@ -48,36 +48,67 @@
 #   JSON-C_LIBRARIES      - list of libraries to link
 #   JSON-C_VERSION        - library version that was found, if any
 
-# use pkg-config to get the directories and then use these values
-# in the find_path() and find_library() calls
-find_package(PkgConfig QUIET)
-pkg_check_modules(PC_JSON-C QUIET json-c)
+# Use pkg-config to discover json-c on the host. When cross-compiling,
+# pkg-config's compiled-in paths target the host root and would discover
+# host-installed json-c even when CMAKE_FIND_ROOT_PATH is set. Callers who
+# want pkg-config-driven discovery under cross-compile can force it on with
+# -DJSON-C_USE_PKGCONFIG=ON and set PKG_CONFIG_LIBDIR / PKG_CONFIG_SYSROOT_DIR.
+option(JSON-C_USE_PKGCONFIG "Use pkg-config to discover json-c" OFF)
+if(NOT JSON-C_USE_PKGCONFIG AND NOT CMAKE_CROSSCOMPILING)
+  find_package(PkgConfig QUIET)
+endif()
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_JSON-C QUIET json-c)
+endif()
 
 # RHEL-based systems may have json-c12
-if (NOT PC_JSON-C_FOUND)
+if(PKG_CONFIG_FOUND AND NOT PC_JSON-C_FOUND)
   pkg_check_modules(PC_JSON-C QUIET json-c12)
 endif()
 
 # ..or even json-c13, accompanied by non-develop json-c (RHEL 8 ubi)
-if (NOT PC_JSON-C_FOUND)
+if(PKG_CONFIG_FOUND AND NOT PC_JSON-C_FOUND)
   pkg_check_modules(PC_JSON-C QUIET json-c13)
+endif()
+
+if(DEFINED JSON-C_ROOT_DIR)
+  set(_hints_include "${JSON-C_ROOT_DIR}/include")
+  set(_hints_lib "${JSON-C_ROOT_DIR}/lib")
+endif()
+if(DEFINED ENV{JSON-C_ROOT_DIR})
+  list(APPEND _hints_include "$ENV{JSON-C_ROOT_DIR}/include")
+  list(APPEND _hints_lib "$ENV{JSON-C_ROOT_DIR}/lib")
+endif()
+# When cross-compiling, prepend CMAKE_FIND_ROOT_PATH entries so find_path /
+# find_library look inside the target sysroot.
+if(CMAKE_CROSSCOMPILING)
+  foreach(_root ${CMAKE_FIND_ROOT_PATH})
+    list(APPEND _hints_include "${_root}/include")
+    list(APPEND _hints_lib "${_root}/lib")
+  endforeach()
+  set(_no_system_path "NO_CMAKE_SYSTEM_PATH")
 endif()
 
 # find the headers
 find_path(JSON-C_INCLUDE_DIR
   NAMES json_c_version.h
   HINTS
+    ${_hints_include}
     ${PC_JSON-C_INCLUDEDIR}
     ${PC_JSON-C_INCLUDE_DIRS}
   PATH_SUFFIXES json-c json-c12 json-c13
+  ${_no_system_path}
 )
 
 # find the library
 find_library(JSON-C_LIBRARY
   NAMES json-c libjson-c json-c12 libjson-c12 json-c13 libjson-c13
   HINTS
+    ${_hints_lib}
     ${PC_JSON-C_LIBDIR}
     ${PC_JSON-C_LIBRARY_DIRS}
+  ${_no_system_path}
 )
 
 # determine the version

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -5,6 +5,9 @@ Binaries that will be installed:
 * `rnp`
 * `rnpkeys`
 
+For cross-compiling librnp to a target architecture (OpenHarmony, Android,
+MinGW, ARM Linux, etc.), see link:installation/cross-compile.html[Cross-compiling librnp].
+
 
 == On NixOS or Nix package manager
 

--- a/docs/installation/cross-compile.adoc
+++ b/docs/installation/cross-compile.adoc
@@ -1,0 +1,159 @@
+= Cross-compiling librnp
+
+This document describes how to cross-compile librnp to a target architecture
+that differs from the build host. The most common targets are
+`aarch64-linux-ohos` (OpenHarmony), `aarch64-linux-android`, `i686-w64-mingw32`
+(Windows via MinGW), and `arm-linux-gnueabihf` (ARM Linux).
+
+== Required CMake variables
+
+Regardless of target, three CMake variables control cross-compile behaviour:
+
+`CMAKE_TOOLCHAIN_FILE`::
+  Path to a toolchain file that sets `CMAKE_SYSTEM_NAME`, `CMAKE_SYSTEM_PROCESSOR`,
+  `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, and (optionally) `CMAKE_SYSROOT`.
+  Most NDKs ship one (e.g. `ohos.toolchain.cmake` for OHOS).
+
+`CMAKE_SYSROOT`::
+  Path to the target's sysroot directory. Some toolchain files set this
+  implicitly; passing it explicitly is safer.
+
+`CMAKE_FIND_ROOT_PATH`::
+  List of root paths to search for headers/libraries. Set this to your
+  dependency install prefix so `find_package(Botan)` and
+  `find_package(JSON-C)` look inside the target sysroot, not the host.
+
+rnp's top-level `CMakeLists.txt` sets `CMAKE_FIND_ROOT_PATH_MODE_*` to `ONLY`
+for library/include/package searches when `CMAKE_CROSSCOMPILING` is true, so
+`find_path` / `find_library` will not accidentally pick up host system
+libraries. Build-time helper tools (run during configure) bypass the root path
+via `NO_CMAKE_FIND_ROOT_PATH` on the relevant calls.
+
+== Specifying dependencies explicitly
+
+When cross-compiling, the most reliable approach is to skip pkg-config entirely
+and pass each dependency's include/lib path explicitly:
+
+[source,console]
+----
+cmake ../rnp \
+  -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN \
+  -DCMAKE_SYSROOT=$SYSROOT \
+  -DCMAKE_FIND_ROOT_PATH=$DEPS_PREFIX \
+  -DCRYPTO_BACKEND=botan \
+  -DBOTAN_INCLUDE_DIR=$DEPS_PREFIX/include/botan-3 \
+  -DBOTAN_LIBRARY=$DEPS_PREFIX/lib/libbotan-3.a \
+  -DJSON-C_INCLUDE_DIR=$DEPS_PREFIX/include/json-c \
+  -DJSON-C_LIBRARY=$DEPS_PREFIX/lib/libjson-c.a \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_TESTING=OFF
+----
+
+rnp's `FindBotan.cmake` and `FindJSON-C.cmake` modules skip pkg-config
+automatically when `CMAKE_CROSSCOMPILING` is true. To force pkg-config use
+under cross-compile (e.g. you have a target-aware `pkg-config` binary),
+pass `-DBOTAN_USE_PKGCONFIG=ON` or `-DJSON-C_USE_PKGCONFIG=ON` and set
+`PKG_CONFIG_LIBDIR` / `PKG_CONFIG_SYSROOT_DIR` to point at the target root.
+
+== OpenHarmony (aarch64-linux-ohos)
+
+The OHOS NDK ships `ohos.toolchain.cmake`, which sets
+`CMAKE_SYSTEM_NAME=OHOS`. A typical build looks like:
+
+[source,console]
+----
+TOOLCHAIN=$OHOS_NDK_HOME/native/build/cmake/ohos.toolchain.cmake
+SYSROOT=$OHOS_NDK_HOME/native/sysroot
+
+# 1. Cross-build Botan 3 against the OHOS sysroot.
+cd Botan-3.6.1
+python3 ./configure.py \
+  --cc=clang \
+  --cc-abi-flags="--target=aarch64-linux-ohos --sysroot=$SYSROOT" \
+  --cc-bin="$OHOS_NDK_HOME/native/llvm/bin/clang++ --target=aarch64-linux-ohos --sysroot=$SYSROOT" \
+  --build-targets=static \
+  --disable-shared-library \
+  --prefix=$DEPS/botan \
+  [..botan module list..]
+make -j && make install
+
+# 2. Cross-build json-c with the OHOS toolchain.
+cmake -S json-c -B json-c/build \
+  -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN -DOHOS_ARCH=arm64-v8a \
+  -DCMAKE_SYSROOT=$SYSROOT \
+  -DCMAKE_INSTALL_PREFIX=$DEPS/jsonc \
+  -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
+cmake --build json-c/build && cmake --install json-c/build
+
+# 3. Cross-build librnp.
+cmake -S rnp -B rnp/build \
+  -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN -DOHOS_ARCH=arm64-v8a \
+  -DCMAKE_SYSROOT=$SYSROOT \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DENABLE_DOC=OFF \
+  -DCRYPTO_BACKEND=botan \
+  -DBOTAN_INCLUDE_DIR=$DEPS/botan/include/botan-3 \
+  -DBOTAN_LIBRARY=$DEPS/botan/lib/libbotan-3.a \
+  -DJSON-C_INCLUDE_DIR=$DEPS/jsonc/include/json-c \
+  -DJSON-C_LIBRARY=$DEPS/jsonc/lib/libjson-c.a
+cmake --build rnp/build -j
+----
+
+OHOS is musl-based; some POSIX header paths differ from glibc. If you hit
+header-not-found errors in pthread or iconv, check that your OHOS NDK version
+matches the sysroot you are pointing at.
+
+The OHOS toolchain may default `CMAKE_INSTALL_PREFIX` to `/usr` for sysroot
+staging. If you run `cmake --install` without `DESTDIR` or `--prefix`, the
+install step will try to write to `/usr/lib` on the host filesystem. Set
+`DESTDIR=/path/to/staging` or pass `--prefix` to `cmake --install`.
+
+== Android (aarch64-linux-android)
+
+The Android NDK ships `android.toolchain.cmake`. The same pattern as OHOS
+applies: pass explicit include/lib paths for Botan and json-c, and set
+`CMAKE_FIND_ROOT_PATH` to your dependency prefix.
+
+== Windows via MinGW (x86_64-w64-mingw32)
+
+Use a MinGW toolchain file. rnp's existing MinGW support (see the
+`windows-msys2` CI workflow) handles this case natively; no additional
+`CMAKE_CROSSCOMPILING` adjustments are needed.
+
+== Verifying the result
+
+After building, verify the produced archive has the expected target
+architecture:
+
+[source,console]
+----
+file build/src/lib/librnp.a
+# Should print something like: "current ar archive" with member objects
+# "ELF 64-bit LSB ... aarch64" for OHOS, "... x86-64" for MinGW, etc.
+
+# Verify one member object:
+OBJ=$(ar t build/src/lib/librnp.a | head -1)
+ar x build/src/lib/librnp.a "$OBJ"
+file "$OBJ"
+----
+
+== Troubleshooting
+
+`find_package(Botan)` finds the host botan::
+  You're hitting the host's pkg-config. Confirm
+  `CMAKE_CROSSCOMPILING=TRUE` (run `cmake -L` and grep). If true,
+  `FindBotan.cmake` should skip pkg-config automatically. If it doesn't,
+  set `BOTAN_USE_PKGCONFIG=OFF` explicitly. If you must use pkg-config,
+  set `PKG_CONFIG_LIBDIR` to a directory containing the target's `.pc`
+  files.
+
+`check_cxx_symbol_exists` fails for `BOTAN_HAS_*`::
+  The try-compile is missing the sysroot. rnp now passes
+  `--sysroot=${CMAKE_SYSROOT}` via `CMAKE_REQUIRED_FLAGS` automatically.
+  If your toolchain file does not set `CMAKE_SYSROOT`, set it explicitly
+  on the command line.
+
+Install step writes to `/usr/lib`::
+  Your toolchain file defaulted `CMAKE_INSTALL_PREFIX` to `/usr`. Run
+  `cmake --install build --prefix /your/staging/dir`, or set
+  `DESTDIR=/your/staging/dir` in the environment.

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -79,6 +79,12 @@ endif()
 # generate a config.h
 include(CheckIncludeFileCXX)
 include(CheckCXXSymbolExists)
+# Some toolchain files (e.g. ohos.toolchain.cmake) set CMAKE_SYSROOT but the
+# try-compile doesn't always propagate it to the linker invocation. Pass
+# --sysroot explicitly to be safe; harmless when CMAKE_SYSROOT is empty.
+if(CMAKE_SYSROOT)
+  list(APPEND CMAKE_REQUIRED_FLAGS "--sysroot=${CMAKE_SYSROOT}")
+endif()
 check_include_file_cxx(fcntl.h HAVE_FCNTL_H)
 check_include_file_cxx(inttypes.h HAVE_INTTYPES_H)
 check_include_file_cxx(limits.h HAVE_LIMITS_H)


### PR DESCRIPTION
## Summary

Closes #2436.

Cross-compiling librnp to `aarch64-linux-ohos` (OpenHarmony) currently fails because `find_package(Botan)` and `find_package(JSON-C)` query the host's pkg-config, picking up host-installed libraries even when `CMAKE_FIND_ROOT_PATH` is set. Additionally, `check_cxx_symbol_exists` does not always honour `CMAKE_SYSROOT`, and there is no first-class OHOS platform branch or CI smoke test.

This PR fixes the bug class generally (any cross-compile target benefits) plus adds an explicit OHOS branch and a CI workflow.

## Changes

| File | Change |
|---|---|
| `CMakeLists.txt` | Detect `CMAKE_CROSSCOMPILING`; constrain `CMAKE_FIND_ROOT_PATH_MODE_*`. Detect `CMAKE_SYSTEM_NAME=OHOS`, set `RNP_TARGET_OHOS`. Surface a NOTICE when `CMAKE_INSTALL_PREFIX` defaults to `/usr` under cross-compile (the OHOS NDK does this for sysroot staging, causing install to write to `/usr/lib` on the host without DESTDIR). |
| `cmake/Modules/FindBotan.cmake` | Skip pkg-config when `CMAKE_CROSSCOMPILING` (force on with `BOTAN_USE_PKGCONFIG=ON` + `PKG_CONFIG_LIBDIR`). Add `CMAKE_FIND_ROOT_PATH`-derived hints and `NO_CMAKE_SYSTEM_PATH` so host system paths are not consulted. |
| `cmake/Modules/FindJSON-C.cmake` | Same pattern as Botan. |
| `src/lib/CMakeLists.txt` | Propagate `CMAKE_SYSROOT` to `CMAKE_REQUIRED_FLAGS` so `check_cxx_symbol_exists` (used for `BOTAN_HAS_*` feature detection) honours the sysroot. |
| `.github/workflows/ohos.yml` | New CI smoke test: download OHOS NDK, cross-build Botan 3 + json-c, build `librnp.a`, verify ELF arch. |
| `docs/installation/cross-compile.adoc` | New guide: required CMake variables, OHOS/Android/MinGW variants, troubleshooting. |
| `docs/installation.adoc` | Cross-link to the new guide. |

## How cross-compile users will use this

The recommended pattern (from the new docs):

```sh
cmake ../rnp \
  -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN \
  -DCMAKE_SYSROOT=$SYSROOT \
  -DCMAKE_FIND_ROOT_PATH=$DEPS_PREFIX \
  -DCRYPTO_BACKEND=botan \
  -DBOTAN_INCLUDE_DIR=$DEPS_PREFIX/include/botan-3 \
  -DBOTAN_LIBRARY=$DEPS_PREFIX/lib/libbotan-3.a \
  -DJSON-C_INCLUDE_DIR=$DEPS_PREFIX/include/json-c \
  -DJSON-C_LIBRARY=$DEPS_PREFIX/lib/libjson-c.a \
  -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
```

`BOTAN_USE_PKGCONFIG=OFF` is the default under cross-compile; callers who have a target-aware pkg-config can force it on with `BOTAN_USE_PKGCONFIG=ON` + `PKG_CONFIG_LIBDIR`.

## Out of scope

- **OpenSSL backend OHOS support** — covered separately by #2396 (OpenSSL feature-detection emulator support). This PR is Botan-only; the two are complementary.
- **libsexpp install-path notice in the submodule** — moved to rnp's top-level `CMakeLists.txt` to avoid a submodule bump for a 4-line notice. The libsexpp upstream change can be proposed separately.
- **armv7-ohos and x86-ohos in CI matrix** — only aarch64 needed today (the enprot target). Trivially extensible.
- **QEMU-based test execution of OHOS binaries** — significant complexity, marginal value for a smoke test. Skipped.

## Test plan

- [x] Native (non-cross) build still configures and builds cleanly on macOS (verified locally). The `NOT CMAKE_CROSSCOMPILING` guard preserves the existing pkg-config-driven path on the host.
- [x] `BOTAN_USE_PKGCONFIG` and `JSON-C_USE_PKGCONFIG` cache variables appear in `cmake -L` output as OFF (default).
- [x] No new warnings under Clang on macOS.
- [ ] OHOS CI workflow runs green on the PR (requires a few CI cycles to shake out NDK download / cache issues — please bear with the first run).
- [ ] enprot team confirms the cross-compile works end-to-end with this branch (tracked separately on enprot's side).
