### PR TITLE
ci: upgrade GHA actions to Node.js 24

### DIFF
--- a/.github/workflows/centos-and-fedora.yml
+++ b/.github/workflows/centos-and-fedora.yml
@@ -100,7 +100,7 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true  
 
@@ -199,7 +199,7 @@ jobs:
 
       - name: Checkout shell test framework
         if: env.BUILD_MODE != 'coverage' && env.SHARED_LIBS == 'on'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kward/shunit2
           path: ci/tests/shunit2
@@ -228,7 +228,7 @@ jobs:
         run:  yum -y install rpm-build
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true  
 
@@ -239,14 +239,14 @@ jobs:
         run:  cpack -B build/SRPM -G RPM --config build/CPackSourceConfig.cmake
 
       - name: Upload SRPM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'SRPM ${{ matrix.image.name }}'
           path: 'build/SRPM/*.src.rpm'
           retention-days: 5
 
       - name: Stash packaging tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'tests-${{ matrix.image.name }}'
           path: 'ci/tests/**'
@@ -271,7 +271,7 @@ jobs:
         run:  yum -y install rpm-build
 
       - name: Download SRPM
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: 'SRPM ${{ matrix.image.name }}'
           path: ~/rpmbuild/SRPMS
@@ -291,7 +291,7 @@ jobs:
         run: cpack -G RPM -B ~/rpmbuild/SOURCES/RPMS --config ~/rpmbuild/SOURCES/BUILD/CPackConfig.cmake
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'RPM ${{ matrix.image.name}}'
           path: '~/rpmbuild/SOURCES/RPMS/*.rpm'
@@ -336,19 +336,19 @@ jobs:
         run:  sudo yum -y install findutils
 
       - name: Download rnp rpms
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: 'RPM ${{ matrix.image.name}}'
 
       - name: Checkout shell test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kward/shunit2
           path: ci/tests/shunit2
 
       - name: Unstash tests
         if: matrix.image.container != 'centos:7'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tests-${{ matrix.image.name }}
           path: ci/tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -20,7 +20,7 @@ jobs:
                      zlib1g-dev libbz2-dev libjson-c-dev libbotan-3-dev asciidoctor curl
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -72,7 +72,7 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch dependent repositories
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.RNP_CI_PAT_TOKEN }}
           repository: rnpgp/${{ matrix.repo }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -35,7 +35,7 @@ jobs:
         fuzz-seconds: 300
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
-      - uses: DoozyX/clang-format-lint-action@v0.18.2
+      - uses: DoozyX/clang-format-lint-action@v0.20
         with:
           clangFormatVersion: 11.0.0
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
         submodules: true
@@ -55,12 +55,12 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           path: rnp
       - name: Download latest version.cmake
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: rnpgp/cmake-versioning
           fetch-depth: 1
@@ -74,7 +74,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           path: rnp

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 250
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -110,7 +110,7 @@ jobs:
 
       - name: Botan2 cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         if: matrix.backend == 'botan'
         with:
           path: Botan-${{ env.BOTAN_VERSION }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Checkout shell test framework
         if: matrix.shared_libs == 'on'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kward/shunit2
           path: ci/tests/shunit2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -35,7 +35,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -64,7 +64,7 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     container: ghcr.io/rnpgp/ci-rnp-fedora-40-amd64
     steps:
       - name: Checkout release scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build source tarball
         run: |
@@ -40,7 +40,7 @@ jobs:
           ls -la "${GITHUB_WORKSPACE}/artifacts/"
 
       - name: Upload tarball artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-tarball
           path: artifacts/
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download tarball artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-tarball
           path: artifacts/

--- a/.github/workflows/time-machine.yml
+++ b/.github/workflows/time-machine.yml
@@ -86,7 +86,7 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -119,7 +119,7 @@ jobs:
         run: tar -czvf build.tar.gz build
 
       - name: Upload build files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'build-${{ matrix.env.CC }}-${{ matrix.image.backend }}'
           path: 'build.tar.gz'
@@ -154,7 +154,7 @@ jobs:
         run: dnf -y install libfaketime
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -173,7 +173,7 @@ jobs:
           printf "\nrnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf
 
       - name: Download build files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: 'build-${{ matrix.env.CC }}-${{ matrix.image.backend }}'
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -90,7 +90,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -125,7 +125,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -224,7 +224,7 @@ jobs:
           sudo apt-get -y install cmake libbz2-dev libjson-c-dev libbotan-2-dev asciidoctor
 
       - name: Checkout sexpp
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: rnpgp/sexpp
           path: sexpp
@@ -248,7 +248,7 @@ jobs:
         run: rm -rf sexpp
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false
@@ -278,7 +278,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -301,14 +301,14 @@ jobs:
         run: cpack -B build/source-deb -G DEB --config build/CPackSourceConfig.cmake
 
       - name: Upload source package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'source-debian'
           path: 'build/source-deb/*.deb'
           retention-days: 5
 
       - name: Stash packaging tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tests
           path: 'ci/tests/**'
@@ -326,7 +326,7 @@ jobs:
           sudo apt-get -y install cmake libbz2-dev libjson-c-dev libbotan-2-dev asciidoctor
 
       - name: Download source package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: 'source-debian'
           path: source-debian
@@ -351,7 +351,7 @@ jobs:
         run: cpack -G DEB -B debian --config rnp/build/CPackConfig.cmake
 
       - name: Upload binary package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'debian'
           path: 'debian/*.deb'
@@ -363,18 +363,18 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Download enp deb file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: 'debian'
 
       - name: Checkout shell test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kward/shunit2
           path: ci/tests/shunit2
 
       - name: Unstash tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tests
           path: ci/tests

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -145,7 +145,7 @@ jobs:
         run: cmake --install build
 
       - name: Checkout shell test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kward/shunit2
           path: ci/tests/shunit2

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
           lfs: true
@@ -111,7 +111,7 @@ jobs:
           mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
 
       - name: vcpkg cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: vcpkg-${{ hashFiles('vcpkg.version') }}-${{ matrix.arch.triplet }}-${{ matrix.toolset }}-${{ matrix.backend }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload vcpkg logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vcpkg-error-logs
           path: |


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating the Node.js 20 runtime. This PR upgrades every workflow that used a Node.js 20-bundled action to the latest stable major that ships Node.js 24.

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v7 |
| actions/cache | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| peter-evans/repository-dispatch | v2 | v4 |
| DoozyX/clang-format-lint-action | v0.18.2 | v0.20 |

Actions already on their latest major tag (codeql-action v3, msys2/setup-msys2 v2, cachix/install-nix-action v31, vapier/coverity-scan-action v1) and actions tracking @master (crate-ci/typos, ludeeus/action-shellcheck, google/oss-fuzz) are unchanged.

## Test plan

- [ ] CI on this PR runs without Node.js 20 deprecation warnings
- [ ] checkout, cache, upload-artifact, download-artifact behave the same on Linux/macOS/Windows runners
- [ ] repository-dispatch still fires correctly
- [ ] clang-format-lint still enforces formatting
