### PR TITLE
fix: silence -Wnonnull-compare and Botan FFI deprecation warnings

### DIFF
--- a/src/lib/crypto/botan_utils.hpp
+++ b/src/lib/crypto/botan_utils.hpp
@@ -28,8 +28,34 @@
 #define RNP_BOTAN_UTILS_HPP_
 
 #include <botan/ffi.h>
+#include <botan/build.h>
+#include <botan/version.h>
+#include <cstring>
 #include "mpi.hpp"
 #include "utils.h"
+
+/* Destination descriptor for the Botan >= 3.6 view-style FFI helpers
+ * (botan_privkey_view_raw / botan_pubkey_view_raw), which replace the
+ * per-algorithm botan_{privkey,pubkey}_*_get_* helpers deprecated since
+ * Botan 3.x. The callback refuses to copy when the viewed length does not
+ * match the caller's expectation, so a fixed-size buffer cannot overrun. */
+struct rnp_botan_view_buf {
+    uint8_t *data;
+    size_t   size;
+};
+
+extern "C" {
+static inline int
+rnp_botan_view_bin(botan_view_ctx ctx, const uint8_t *data, size_t len)
+{
+    auto *vb = static_cast<rnp_botan_view_buf *>(ctx);
+    if (len != vb->size) {
+        return -1;
+    }
+    std::memcpy(vb->data, data, len);
+    return 0;
+}
+}
 
 /* Self-destructing wrappers around the Botan's FFI objects */
 namespace rnp {

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -66,7 +66,12 @@ Key::generate_x25519(rnp::RNG &rng)
 
     /* botan returns key in little-endian, while mpi is big-endian */
     rnp::secure_array<uint8_t, 32> keyle;
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf keyle_vb{keyle.data(), keyle.size()};
+    if (botan_privkey_view_raw(pr_key.get(), &keyle_vb, rnp_botan_view_bin)) {
+#else
     if (botan_privkey_x25519_get_privkey(pr_key.get(), keyle.data())) {
+#endif
         return RNP_ERROR_KEY_GENERATION;
     }
     x.resize(32);
@@ -79,7 +84,12 @@ Key::generate_x25519(rnp::RNG &rng)
     }
 
     p.resize(33);
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf pub_vb{&p[1], 32};
+    if (botan_pubkey_view_raw(pu_key.get(), &pub_vb, rnp_botan_view_bin)) {
+#else
     if (botan_pubkey_x25519_get_pubkey(pu_key.get(), &p[1])) {
+#endif
         return RNP_ERROR_KEY_GENERATION;
     }
     p[0] = 0x40;

--- a/src/lib/crypto/eddsa.cpp
+++ b/src/lib/crypto/eddsa.cpp
@@ -100,7 +100,12 @@ generate(rnp::RNG &rng, ec::Key &key)
     }
 
     uint8_t key_bits[64];
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf key_bits_vb{key_bits, 64};
+    if (botan_privkey_view_raw(eddsa.get(), &key_bits_vb, rnp_botan_view_bin)) {
+#else
     if (botan_privkey_ed25519_get_privkey(eddsa.get(), key_bits)) {
+#endif
         return RNP_ERROR_GENERIC;
     }
 

--- a/src/lib/logging.h
+++ b/src/lib/logging.h
@@ -87,6 +87,16 @@ class LogStop {
         RNP_LOG(msg, idhex.c_str());                                                    \
     } while (0)
 
+/* Like RNP_LOG_KEY, but for keys known to be non-null (e.g. the address of a
+ * reference). Avoids the null check, which would otherwise trip
+ * -Wnonnull-compare on a provably non-null pointer. */
+#define RNP_LOG_KEY_NN(msg, key)                                                        \
+    do {                                                                                \
+        auto keyid = (key)->keyid();                                                    \
+        auto idhex = bin_to_hex(keyid.data(), keyid.size(), rnp::HexFormat::Lowercase); \
+        RNP_LOG(msg, idhex.c_str());                                                    \
+    } while (0)
+
 #if defined(ENABLE_PQC_DBG_LOG)
 
 #define RNP_LOG_FD_NO_POS_INFO(fd, ...)    \

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -280,7 +280,7 @@ KeyStore::add_subkey(Key &srckey, Key *oldkey)
         /* check for the weird case when same subkey has different primary keys */
         if (srckey.has_primary_fp() && oldkey->has_primary_fp() &&
             (srckey.primary_fp() != oldkey->primary_fp())) {
-            RNP_LOG_KEY("Warning: different primary keys for subkey %s", &srckey);
+            RNP_LOG_KEY_NN("Warning: different primary keys for subkey %s", &srckey);
             auto *srcprim = get_key(srckey.primary_fp());
             if (srcprim && (srcprim != primary)) {
                 srcprim->remove_subkey_fp(srckey.fp());
@@ -288,7 +288,7 @@ KeyStore::add_subkey(Key &srckey, Key *oldkey)
         }
         /* in case we already have key let's merge it in */
         if (!oldkey->merge(srckey, primary)) {
-            RNP_LOG_KEY("failed to merge subkey %s", &srckey);
+            RNP_LOG_KEY_NN("failed to merge subkey %s", &srckey);
             RNP_LOG_KEY("primary key is %s", primary);
             return NULL;
         }
@@ -303,7 +303,7 @@ KeyStore::add_subkey(Key &srckey, Key *oldkey)
             }
         } catch (const std::exception &e) {
             /* LCOV_EXCL_START */
-            RNP_LOG_KEY("key %s copying failed", &srckey);
+            RNP_LOG_KEY_NN("key %s copying failed", &srckey);
             RNP_LOG_KEY("primary key is %s", primary);
             RNP_LOG("%s", e.what());
             if (oldkey) {
@@ -320,7 +320,7 @@ KeyStore::add_subkey(Key &srckey, Key *oldkey)
         oldkey->validate_subkey(primary, secctx);
     }
     if (!oldkey->refresh_data(primary, secctx)) {
-        RNP_LOG_KEY("Failed to refresh subkey %s data", &srckey);
+        RNP_LOG_KEY_NN("Failed to refresh subkey %s data", &srckey);
         RNP_LOG_KEY("primary key is %s", primary);
     }
     return oldkey;
@@ -343,7 +343,7 @@ KeyStore::add_key(Key &srckey)
 
     if (added_key) {
         if (!added_key->merge(srckey)) {
-            RNP_LOG_KEY("failed to merge key %s", &srckey);
+            RNP_LOG_KEY_NN("failed to merge key %s", &srckey);
             return NULL;
         }
     } else {
@@ -358,7 +358,7 @@ KeyStore::add_key(Key &srckey)
             }
         } catch (const std::exception &e) {
             /* LCOV_EXCL_START */
-            RNP_LOG_KEY("key %s copying failed", &srckey);
+            RNP_LOG_KEY_NN("key %s copying failed", &srckey);
             RNP_LOG("%s", e.what());
             if (added_key) {
                 keys.pop_back();
@@ -373,7 +373,7 @@ KeyStore::add_key(Key &srckey)
     if (!disable_validation && !added_key->validated()) {
         added_key->revalidate(*this);
     } else if (!added_key->refresh_data(secctx)) {
-        RNP_LOG_KEY("Failed to refresh key %s data", &srckey);
+        RNP_LOG_KEY_NN("Failed to refresh key %s data", &srckey);
     }
     /* Revalidate non-self revocations for all keys in keyring, as added_key key could be a
      * revoker. Should not be time-consuming as `validate_desig_revokes()` has early exit. */


### PR DESCRIPTION
## Summary

Fixes two build-warning classes reported in the v0.18.1 release build (GCC).

### 1. `-Wnonnull-compare` in `src/librekey/rnp_key_store.cpp`

`RNP_LOG_KEY(msg, &srckey)` expanded to `if (!(&srckey))`, but `&srckey` is the address of a `Key&` reference and is provably non-null, so GCC flagged every such call site. Added an `RNP_LOG_KEY_NN` variant (no null check) in `src/lib/logging.h` and switched **all** `&srckey` call sites to it. Nullable-pointer sites (`primary`, `added_key`) keep the null-checking `RNP_LOG_KEY`. Verified there are no remaining `RNP_LOG_KEY(..., &ref)` call sites in the tree.

### 2. `-Wdeprecated-declarations` in `src/lib/crypto/ec.cpp` and `src/lib/crypto/eddsa.cpp`

`botan_privkey_x25519_get_privkey`, `botan_pubkey_x25519_get_pubkey`, and `botan_privkey_ed25519_get_privkey` are deprecated in Botan 3.x. Switched to the generic `botan_privkey_view_raw` / `botan_pubkey_view_raw` API (available since Botan 3.6) under a `BOTAN_VERSION_CODE >= 3.6.0` guard, keeping the legacy calls for older Botan (2.x and 3.0–3.5, where the helpers are not deprecated and `view_raw` does not exist). A small length-checked view callback (`rnp_botan_view_bin`) and descriptor (`rnp_botan_view_buf`) live in `src/lib/crypto/botan_utils.hpp`; the per-site descriptors are declared inside the `#if` so they don't trigger `-Wunused-variable` on older Botan.

A codebase-wide sweep confirmed the remaining deprecated Botan FFI calls (`botan_key_wrap3394`/`botan_key_unwrap3394` in `ecdh.cpp`, the `_enc` SM2 loaders) are already behind `CRYPTO_BACKEND_BOTAN3` guards or use the non-deprecated overloads, and that ed448/x448 paths do not use the deprecated getters.

## Notes

- Builds against Botan 2.x and 3.0–3.5 are unaffected (legacy call paths retained).
- The pre-existing Botan 3.12 native C++ API breakage in `ec.cpp` (around `Botan::EC_Group::from_name`, under `ENABLE_CRYPTO_REFRESH`) is unrelated to these warning classes and intentionally left out of scope.

## Test plan

- [x] Configured with `-DCRYPTO_BACKEND=botan3` against Botan 3.12; `librnp-obj`, `rnpkeys`, and `rnp` build with **zero warnings/errors** (Apple Clang 15).
- [x] `ec.cpp`, `eddsa.cpp`, `rnp_key_store.cpp` compile clean.
- [x] Runtime: generated an Ed25519 primary + Curve25519 ECDH subkey (expert mode option 22) — exercises all three migrated `view_raw` call sites.
- [x] Sign/verify with the Ed25519 key passes; encrypt/decrypt round-trip through the Curve25519 subkey passes.
- [ ] CI (Linux/GCC) confirms `-Wnonnull-compare` and `-Wdeprecated-declarations` are gone for these files.
