### PR TITLE
refactor: migrate crypto-refresh EC/Ed code from Botan native API to FFI

### DIFF
--- a/TODO.refactor/botan-ffi-migration.md
+++ b/TODO.refactor/botan-ffi-migration.md
@@ -1,0 +1,115 @@
+# Botan native C++ API → FFI migration
+
+Status: planning / in progress (2026-07-30)
+Owner: Ronald Tse (for discussion with Jack Lloyd / Botan)
+
+## TL;DR
+
+**No Botan FFI gaps were found.** Every operation rnp currently performs via
+Botan's *unstable native C++ API* (`Botan::*`) in the crypto-refresh / PQC code
+paths has a *stable* FFI equivalent (`botan_*`). Nothing needs to be requested
+upstream — the work is migration, not API additions.
+
+The native C++ API is the root cause of the recurring build breakage: it changes
+every Botan release (e.g. 3.12 tightened include hygiene so `EC_Group` /
+`EC_AffinePoint` are no longer transitively included, and deprecated
+`public_point()` / `Ed25519_PrivateKey(span)`). The rest of rnp already uses the
+FFI (the stable C ABI), which is why it rides across Botan 2.x/3.x untouched.
+This migration extends that discipline to the crypto-refresh/PQC code.
+
+## Why migrate (the breakage on Botan 3.12)
+
+`-DENABLE_CRYPTO_REFRESH=ON` against Botan 3.12 fails to compile because the
+native-API code in these files bit-rotted:
+
+| File | Failure | Root cause |
+|------|---------|------------|
+| `src/lib/crypto/ec.cpp` (`ec_generate_generic_native`) | `error: incomplete type 'Botan::EC_Group'`; `error: member access into incomplete type 'const EC_Point'`; `warning: 'public_point' is deprecated` | missing `<botan/ec_group.h>` / `<botan/ec_point.h>` (3.12 include hygiene); deprecated `public_point()` |
+| `src/lib/crypto/exdsa_ecdhkem.cpp` | `error: incomplete type 'Botan::EC_Group'`; `error: 'Botan::BigInt' is an incomplete type`; `error: member access into incomplete type 'Botan::EC_AffinePoint'`; `warning: 'Ed25519_PrivateKey' is deprecated` | missing includes; deprecated `Ed25519_PrivateKey(span)` ctor |
+| `src/lib/crypto/ed25519_ed448.cpp` | `warning: 'Ed25519_PrivateKey' is deprecated: Use from_seed or from_bytes` | deprecated ctor |
+
+These are all fixable without version switches by moving to FFI.
+
+## FFI coverage audit (no gaps)
+
+Audited against Botan 3.12 `<botan/ffi.h>`. Every native op maps to a stable FFI
+call, several of which rnp already uses elsewhere:
+
+| Native (crypto-refresh/PQC) | FFI replacement | Already used in rnp? |
+|-----------------------------|-----------------|----------------------|
+| `ECDH_PrivateKey` + `EC_Group::from_name` + `public_point().xy_bytes()` / `public_value()` | `botan_privkey_create("ECDH", curve)` + `botan_pubkey_get_field("public_x"/"public_y")` + `botan_privkey_get_field("x")` | yes — `ec.cpp::Key::generate()`, `ecdh.cpp` |
+| `ECDH_PrivateKey`/`PublicKey` from scalar / SEC1 point | `botan_privkey_load_ecdh`, `botan_pubkey_load_ecdh` | partial |
+| `ECDSA_PrivateKey`/`PublicKey` from scalar / point | `botan_privkey_load_ecdsa`, `botan_pubkey_load_ecdsa` | partial |
+| `PK_Key_Agreement` ... `derive_key` (ECDH KEM encap/decap) | `botan_pk_op_key_agreement_*` | yes — `ecdh.cpp` |
+| `PK_Signer` / `PK_Verifier` (ECDSA/Ed25519/Ed448/ML-DSA/SLH-DSA) | `botan_pk_op_sign_*` / `botan_pk_op_verify_*` | yes — `eddsa.cpp`, `ecdsa.cpp`, `sm2.cpp` |
+| `Ed25519_PrivateKey(span)` (deprecated) | `botan_privkey_load_ed25519` / generic `botan_privkey_create("Ed25519")` + `view_raw` | yes — `eddsa.cpp` |
+| `Ed448_PrivateKey` / `raw_private_key_bits` / `public_key_bits` | `botan_privkey_load_ed448` / `botan_pubkey_load_ed448` (3.4+) + generic `view_raw` | no (new) |
+| `X25519_PrivateKey` / `X448_PrivateKey` | `botan_privkey_load_x25519` / `_x448`, `botan_pubkey_load_x25519` / `_x448` | partial |
+| `check_key(...)` | `botan_pubkey_check_key`, `botan_privkey_check_key` | yes |
+| `Dilithium_PrivateKey` / `Kyber_PrivateKey` modes | `botan_privkey_load_ml_dsa` / `botan_privkey_load_ml_kem` (+ mode string) | no (new) |
+| `SLH_DSA_PrivateKey` / param set / hash type | `botan_privkey_load_slh_dsa` (+ mode string) | no (new) |
+| `PK_KEM_Encryptor` / `PK_KEM_Decryptor` (ML-KEM) | `botan_pk_op_kem_encrypt_*` / `botan_pk_op_kem_decrypt_*` (3.0+) | no (new) |
+| `rfc3394_keywrap` / `rfc3394_keyunwrap` | `botan_nist_kw_enc` / `botan_nist_kw_dec` | yes — `ecdh.cpp` |
+| raw key bytes (`raw_private_key_bits`, `public_key_bits`) | `botan_privkey_view_raw` / `botan_pubkey_view_raw` (3.6+; see PR #2446) | yes |
+
+**Conclusion for Jack:** no new FFI entry points are required. (If anything,
+the only friction is documentation/confirmation of the exact byte encoding
+returned by `botan_*_view_raw` for ML-KEM/ML-DSA/SLH-DSA and for the "Raw"
+key-agreement output — see Verification below.)
+
+## Migration plan
+
+### Phase 1 — unblock the Botan 3.12 build (this branch)
+
+The three files that failed `ENABLE_CRYPTO_REFRESH`, migrated to FFI:
+
+- [x] `src/lib/crypto/ec.cpp` — `ec_generate_generic_native` now mirrors the
+      FFI pattern already in `Key::generate()` (`botan_privkey_create`,
+      `botan_pubkey_get_field`, `botan_privkey_get_field`). Native
+      `<botan/bigint.h>`/`<botan/ecdh.h>` includes dropped.
+- [x] `src/lib/crypto/ed25519_ed448.cpp` — Ed25519/Ed448 keygen, sign, verify,
+      validate moved to `botan_privkey_create`/`load_*`, `botan_pk_op_sign_*`/
+      `verify_*`, `botan_*_check_key`.
+- [x] `src/lib/crypto/exdsa_ecdhkem.cpp` (+ `.h`) — replaced the `Botan::*`
+      key-object helpers with FFI key handles; ECDH KEM via
+      `botan_pk_op_key_agreement_*`, ECDSA sign/verify, `check_key`, SEC1
+      loaders (`botan_pubkey_load_ecdh_sec1` / `_ecdsa_sec1`). The private
+      `key_` member moved from `Botan::secure_vector` to `rnp::secure_bytes`;
+      all `<botan/*>` includes removed from the header.
+
+Validated: `ENABLE_CRYPTO_REFRESH=ON` builds clean on Botan 3.12 (no native-API
+errors); full `rnp_tests` suite passes (280 tests, including v6, ECDSA keygen,
+Ed25519/Ed448, ECDH, and CLI examples).
+
+Note: `ed25519_ed448.cpp` still calls the deprecated `botan_privkey_ed25519_
+get_privkey` / `botan_*_ed448_get_*` getters (consistent with the existing
+`eddsa.cpp` on `main`). These are the same `-Wdeprecated-declarations` class
+that PR #2446 migrates to `botan_*_view_raw`; that migration should be extended
+to these three new call sites.
+
+### Phase 2 — finish the native→FFI discipline (follow-up PRs)
+
+Not broken on 3.12, but still on the unstable native API. Migrate per the table
+above, lowest-risk first:
+
+- [ ] `src/lib/crypto/x25519_x448.cpp` (X25519/X448 keygen, RFC 3394 keywrap)
+- [ ] `src/lib/crypto/dilithium.cpp` / `dilithium_common.cpp` (ML-DSA)
+- [ ] `src/lib/crypto/kyber.cpp` / `kyber_common.cpp` (ML-KEM)
+- [ ] `src/lib/crypto/kyber_ecdh_composite.cpp` (ML-KEM+X25519 composite —
+      built from FFI primitives; the composition logic stays in rnp)
+- [ ] `src/lib/crypto/sphincsplus.cpp` (SLH-DSA)
+
+## Verification / risks
+
+- Compile-check on Botan 3.12 with `-DENABLE_CRYPTO_REFRESH=ON`.
+- Behavioral check via `rnp_tests` (PQC / v6 / composite keygen, sign, encrypt,
+  KEM) — **must run** before merge; the migration touches security-critical
+  paths and header-level analysis cannot prove byte-for-byte equivalence.
+- Items to confirm during migration (not FFI gaps, just things to get exactly
+  right):
+  - exact bytes returned by `botan_privkey_view_raw` / `botan_pubkey_view_raw`
+    for ML-DSA / ML-KEM / SLH-DSA (private vs. public encodings);
+  - `botan_pk_op_key_agreement` "Raw" output equals `PK_Key_Agreement("Raw")` +
+    `.bits_of()`;
+  - ML-DSA/ML-KEM/SLH-DSA mode strings accepted by `botan_*_load_*` and
+    `botan_privkey_create` (`"ML-DSA-65"`, `"ML-KEM-768"`, `"SLH-DSA-128s"`, …).

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -35,9 +35,6 @@
 #if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
 #include "x25519_x448.h"
 #include "ed25519_ed448.h"
-#include "botan_utils.hpp"
-#include "botan/bigint.h"
-#include "botan/ecdh.h"
 #endif
 #include <cassert>
 
@@ -195,19 +192,46 @@ ec_generate_generic_native(rnp::RNG *            rng,
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    auto         ec_desc = pgp::ec::Curve::get(curve);
-    const size_t curve_order = ec_desc->bytes();
+    auto ec_desc = pgp::ec::Curve::get(curve);
+    if (!ec_desc) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    const size_t field_size = ec_desc->bytes();
 
-    Botan::ECDH_PrivateKey privkey_botan(*(rng->obj()),
-                                         Botan::EC_Group::from_name(ec_desc->botan_name));
+    rnp::botan::Privkey pr_key;
+    if (botan_privkey_create(&pr_key.get(), "ECDH", ec_desc->botan_name, rng->handle())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+    rnp::botan::Pubkey pu_key;
+    if (botan_privkey_export_pubkey(&pu_key.get(), pr_key.get())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
 
-    // pubkey: 0x04 || X || Y
-    pubkey = Botan::unlock(privkey_botan.public_point().xy_bytes());
-    pubkey.insert(pubkey.begin(), 0x04);
+    rnp::bn px;
+    rnp::bn py;
+    rnp::bn bx;
+    if (!px || !py || !bx) {
+        RNP_LOG("Allocation failed");
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (botan_pubkey_get_field(px.get(), pu_key.get(), "public_x") ||
+        botan_pubkey_get_field(py.get(), pu_key.get(), "public_y") ||
+        botan_privkey_get_field(bx.get(), pr_key.get(), "x")) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+    if ((px.bytes() > field_size) || (py.bytes() > field_size)) {
+        RNP_LOG("Key generation failed");
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
 
-    privkey = std::vector<uint8_t>(curve_order);
-    privkey_botan.private_value().serialize_to(privkey); // zero-pads to the given size
-
+    /* pubkey: 0x04 || X || Y, coordinates zero-padded to the field size */
+    pubkey.resize(2 * field_size + 1);
+    pubkey[0] = 0x04;
+    px.bin(&pubkey[1 + field_size - px.bytes()]);
+    py.bin(&pubkey[1 + 2 * field_size - py.bytes()]);
+    /* privkey: secret scalar, zero-padded to the field size */
+    privkey.assign(field_size, 0);
+    bx.bin(&privkey[field_size - bx.bytes()]);
     return RNP_SUCCESS;
 }
 

--- a/src/lib/crypto/ed25519_ed448.cpp
+++ b/src/lib/crypto/ed25519_ed448.cpp
@@ -3,7 +3,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -12,41 +12,44 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "ed25519_ed448.h"
 #include "logging.h"
 #include "utils.h"
 
-#include <botan/pubkey.h>
-#include <botan/ed25519.h>
-#if defined(ENABLE_CRYPTO_REFRESH)
-#include <botan/ed448.h>
-#endif
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
 #include <cassert>
+#include <string.h>
 
 rnp_result_t
 generate_ed25519_native(rnp::RNG *            rng,
                         std::vector<uint8_t> &privkey,
                         std::vector<uint8_t> &pubkey)
 {
-    Botan::Ed25519_PrivateKey private_key(*(rng->obj()));
-    const size_t              key_len = 32;
-    auto                      priv_pub = Botan::unlock(private_key.raw_private_key_bits());
-    assert(priv_pub.size() == 2 * key_len);
-    privkey = std::vector<uint8_t>(priv_pub.begin(), priv_pub.begin() + key_len);
-    pubkey = std::vector<uint8_t>(priv_pub.begin() + key_len, priv_pub.end());
-
+    rnp::botan::Privkey private_key;
+    if (botan_privkey_create(&private_key.get(), "Ed25519", NULL, rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    /* botan returns the 32-byte seed followed by the 32-byte public key */
+    uint8_t key_bits[64];
+    if (botan_privkey_ed25519_get_privkey(private_key.get(), key_bits)) {
+        return RNP_ERROR_GENERIC;
+    }
+    const size_t key_len = 32;
+    privkey.assign(key_bits, key_bits + key_len);
+    pubkey.assign(key_bits + key_len, key_bits + 2 * key_len);
     return RNP_SUCCESS;
 }
 
@@ -57,10 +60,24 @@ ed25519_sign_native(rnp::RNG *                  rng,
                     const uint8_t *             hash,
                     size_t                      hash_len)
 {
-    Botan::Ed25519_PrivateKey priv_key(Botan::secure_vector<uint8_t>(key.begin(), key.end()));
-    auto                      signer = Botan::PK_Signer(priv_key, *(rng->obj()), "Pure");
-    sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
-
+    if (key.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_load_ed25519(&priv_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Sign signer;
+    if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), "Pure", 0) ||
+        botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    uint8_t buf[64];
+    size_t  sig_len = sizeof(buf);
+    if (botan_pk_op_sign_finish(signer.get(), rng->handle(), buf, &sig_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    sig_out.assign(buf, buf + sig_len);
     return RNP_SUCCESS;
 }
 
@@ -70,26 +87,43 @@ ed25519_verify_native(const std::vector<uint8_t> &sig,
                       const uint8_t *             hash,
                       size_t                      hash_len)
 {
-    Botan::Ed25519_PublicKey pub_key(key);
-    auto                     verifier = Botan::PK_Verifier(pub_key, "Pure");
-    if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-        return RNP_SUCCESS;
+    if (key.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed25519(&pub_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Verify verifier;
+    if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), "Pure", 0) ||
+        botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    return RNP_SUCCESS;
 }
 
 rnp_result_t
 ed25519_validate_key_native(rnp::RNG *rng, const pgp_ed25519_key_t *key, bool secret)
 {
-    Botan::Ed25519_PublicKey pub_key(key->pub);
-    if (!pub_key.check_key(*(rng->obj()), false)) {
+    if (key->pub.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed25519(&pub_key.get(), key->pub.data()) ||
+        botan_pubkey_check_key(pub_key.get(), rng->handle(), 0)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
     if (secret) {
-        Botan::Ed25519_PrivateKey priv_key(
-          Botan::secure_vector<uint8_t>(key->priv.begin(), key->priv.end()));
-        if (!priv_key.check_key(*(rng->obj()), false)) {
+        if (key->priv.size() != 32) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::Privkey priv_key;
+        if (botan_privkey_load_ed25519(&priv_key.get(), key->priv.data()) ||
+            botan_privkey_check_key(priv_key.get(), rng->handle(), 0)) {
             return RNP_ERROR_SIGNING_FAILED;
         }
     }
@@ -103,14 +137,24 @@ generate_ed448_native(rnp::RNG *            rng,
                       std::vector<uint8_t> &privkey,
                       std::vector<uint8_t> &pubkey)
 {
-    Botan::Ed448_PrivateKey private_key(*(rng->obj()));
-    const size_t            key_len = 57;
-    auto                    priv = Botan::unlock(private_key.raw_private_key_bits());
-    assert(priv.size() == key_len);
-    auto pub = private_key.public_key_bits();
-    assert(pub.size() == key_len);
-    privkey = std::vector<uint8_t>(priv.begin(), priv.begin() + key_len);
-    pubkey = std::vector<uint8_t>(pub.begin(), pub.begin() + key_len);
+    rnp::botan::Privkey private_key;
+    if (botan_privkey_create(&private_key.get(), "Ed448", NULL, rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    uint8_t priv[57];
+    if (botan_privkey_ed448_get_privkey(private_key.get(), priv)) {
+        return RNP_ERROR_GENERIC;
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_privkey_export_pubkey(&pub_key.get(), private_key.get())) {
+        return RNP_ERROR_GENERIC;
+    }
+    uint8_t pub[57];
+    if (botan_pubkey_ed448_get_pubkey(pub_key.get(), pub)) {
+        return RNP_ERROR_GENERIC;
+    }
+    privkey.assign(priv, priv + 57);
+    pubkey.assign(pub, pub + 57);
     return RNP_SUCCESS;
 }
 
@@ -121,9 +165,24 @@ ed448_sign_native(rnp::RNG *                  rng,
                   const uint8_t *             hash,
                   size_t                      hash_len)
 {
-    Botan::Ed448_PrivateKey priv_key(Botan::secure_vector<uint8_t>(key.begin(), key.end()));
-    auto                    signer = Botan::PK_Signer(priv_key, *(rng->obj()), "Pure");
-    sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
+    if (key.size() != 57) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_load_ed448(&priv_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Sign signer;
+    if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), "Pure", 0) ||
+        botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    uint8_t buf[114];
+    size_t  sig_len = sizeof(buf);
+    if (botan_pk_op_sign_finish(signer.get(), rng->handle(), buf, &sig_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    sig_out.assign(buf, buf + sig_len);
     return RNP_SUCCESS;
 }
 
@@ -133,25 +192,42 @@ ed448_verify_native(const std::vector<uint8_t> &sig,
                     const uint8_t *             hash,
                     size_t                      hash_len)
 {
-    Botan::Ed448_PublicKey pub_key(key);
-    auto                   verifier = Botan::PK_Verifier(pub_key, "Pure");
-    if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-        return RNP_SUCCESS;
+    if (key.size() != 57) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed448(&pub_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Verify verifier;
+    if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), "Pure", 0) ||
+        botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    return RNP_SUCCESS;
 }
 
 rnp_result_t
 ed448_validate_key_native(rnp::RNG *rng, const pgp_ed448_key_t *key, bool secret)
 {
-    Botan::Ed448_PublicKey pub_key(key->pub);
-    if (!pub_key.check_key(*(rng->obj()), false)) {
+    if (key->pub.size() != 57) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed448(&pub_key.get(), key->pub.data()) ||
+        botan_pubkey_check_key(pub_key.get(), rng->handle(), 0)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     if (secret) {
-        Botan::Ed448_PrivateKey priv_key(
-          Botan::secure_vector<uint8_t>(key->priv.begin(), key->priv.end()));
-        if (!priv_key.check_key(*(rng->obj()), false)) {
+        if (key->priv.size() != 57) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::Privkey priv_key;
+        if (botan_privkey_load_ed448(&priv_key.get(), key->priv.data()) ||
+            botan_privkey_check_key(priv_key.get(), rng->handle(), 0)) {
             return RNP_ERROR_SIGNING_FAILED;
         }
     }

--- a/src/lib/crypto/exdsa_ecdhkem.cpp
+++ b/src/lib/crypto/exdsa_ecdhkem.cpp
@@ -3,7 +3,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -12,28 +12,86 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "exdsa_ecdhkem.h"
-#include "ecdh.h"
 #include "ed25519_ed448.h"
 #include "ecdsa.h"
 #include "ec.h"
 #include "types.h"
 #include "logging.h"
+#include "botan_utils.hpp"
 #include "string.h"
 #include "utils.h"
+#include <botan/ffi.h>
 #include <cassert>
+
+namespace {
+
+const char *
+curve_botan_name(pgp_curve_t curve)
+{
+    auto ec_desc = pgp::ec::Curve::get(curve);
+    return ec_desc ? ec_desc->botan_name : nullptr;
+}
+
+/* Load a generic-prime ECDH/ECDSA private key from its raw scalar. */
+bool
+load_ec_privkey(rnp::botan::Privkey &     out,
+                int (*loader)(botan_privkey_t *, botan_mp_t, const char *),
+                const rnp::secure_bytes & scalar,
+                pgp_curve_t               curve)
+{
+    const char *name = curve_botan_name(curve);
+    if (!name) {
+        return false;
+    }
+    rnp::bn s(scalar.data(), scalar.size());
+    return s && !loader(&out.get(), s.get(), name);
+}
+
+/* Load a generic-prime ECDH/ECDSA public key from its SEC1 point (0x04 || X || Y). */
+bool
+load_ec_pubkey(rnp::botan::Pubkey &        out,
+               int (*loader)(botan_pubkey_t *, const uint8_t *, size_t, const char *),
+               const std::vector<uint8_t> &sec1,
+               pgp_curve_t                 curve)
+{
+    const char *name = curve_botan_name(curve);
+    if (!name) {
+        return false;
+    }
+    return !loader(&out.get(), sec1.data(), sec1.size(), name);
+}
+
+/* Export the public value of a key-agreement private key (X25519/X448 raw bytes,
+ * ECDH SEC1 point). */
+bool
+export_agreement_public(botan_privkey_t priv, std::vector<uint8_t> &out)
+{
+    size_t len = 0;
+    if (botan_pk_op_key_agreement_export_public(priv, nullptr, &len)) {
+        return false;
+    }
+    out.resize(len);
+    if (botan_pk_op_key_agreement_export_public(priv, out.data(), &len)) {
+        return false;
+    }
+    out.resize(len);
+    return true;
+}
+
+} // namespace
 
 ec_key_t::~ec_key_t()
 {
@@ -49,6 +107,7 @@ ecdh_kem_public_key_t::ecdh_kem_public_key_t(uint8_t *   key_buf,
     : ec_key_t(curve), key_(std::vector<uint8_t>(key_buf, key_buf + key_buf_len))
 {
 }
+
 ecdh_kem_public_key_t::ecdh_kem_public_key_t(std::vector<uint8_t> key, pgp_curve_t curve)
     : ec_key_t(curve), key_(key)
 {
@@ -60,118 +119,94 @@ ecdh_kem_private_key_t::ecdh_kem_private_key_t(uint8_t *   key_buf,
     : ec_key_t(curve), key_(key_buf, key_buf + key_buf_len)
 {
 }
+
 ecdh_kem_private_key_t::ecdh_kem_private_key_t(std::vector<uint8_t> key, pgp_curve_t curve)
-    : ec_key_t(curve), key_(Botan::secure_vector<uint8_t>(key.begin(), key.end()))
+    : ec_key_t(curve), key_(key.begin(), key.end())
 {
-}
-
-Botan::ECDH_PrivateKey
-ecdh_kem_private_key_t::botan_key_ecdh(rnp::RNG *rng) const
-{
-    assert(curve_ >= PGP_CURVE_NIST_P_256 && curve_ <= PGP_CURVE_P256K1);
-    auto ec_desc = pgp::ec::Curve::get(curve_);
-    return Botan::ECDH_PrivateKey(
-      *(rng->obj()), Botan::EC_Group::from_name(ec_desc->botan_name), Botan::BigInt(key_));
-}
-
-Botan::ECDH_PublicKey
-ecdh_kem_public_key_t::botan_key_ecdh(rnp::RNG *rng) const
-{
-    assert(curve_ >= PGP_CURVE_NIST_P_256 && curve_ <= PGP_CURVE_P256K1);
-
-    auto            ec_desc = pgp::ec::Curve::get(curve_);
-    Botan::EC_Group group = Botan::EC_Group::from_name(ec_desc->botan_name);
-    return Botan::ECDH_PublicKey(group, Botan::EC_AffinePoint(group, key_).to_legacy_point());
-}
-
-Botan::X25519_PrivateKey
-ecdh_kem_private_key_t::botan_key_x25519() const
-{
-    assert(curve_ == PGP_CURVE_25519);
-    return Botan::X25519_PrivateKey(key_);
-}
-
-Botan::X25519_PublicKey
-ecdh_kem_public_key_t::botan_key_x25519() const
-{
-    assert(curve_ == PGP_CURVE_25519);
-    return Botan::X25519_PublicKey(key_);
 }
 
 std::vector<uint8_t>
 ecdh_kem_private_key_t::get_pubkey_encoded(rnp::RNG *rng) const
 {
+    (void) rng;
+    rnp::botan::Privkey priv;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey botan_key = botan_key_x25519();
-        return botan_key.public_value();
-    }
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv.get(), key_.data());
+        break;
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey botan_key = botan_key_x448();
-        return botan_key.public_value();
-    }
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv.get(), key_.data());
+        break;
 #endif
-    default: {
-        Botan::ECDH_PrivateKey botan_key = botan_key_ecdh(rng);
-        return botan_key.public_value();
+    default:
+        ok = load_ec_privkey(priv, botan_privkey_load_ecdh, key_, curve_);
+        break;
     }
+    std::vector<uint8_t> out;
+    if (ok) {
+        export_agreement_public(priv.get(), out);
     }
+    return out;
 }
-
-#if defined(ENABLE_CRYPTO_REFRESH)
-Botan::X448_PrivateKey
-ecdh_kem_private_key_t::botan_key_x448() const
-{
-    assert(curve_ == PGP_CURVE_448);
-    return Botan::X448_PrivateKey(key_);
-}
-
-Botan::X448_PublicKey
-ecdh_kem_public_key_t::botan_key_x448() const
-{
-    assert(curve_ == PGP_CURVE_448);
-    return Botan::X448_PublicKey(key_);
-}
-#endif
 
 rnp_result_t
 ecdh_kem_public_key_t::encapsulate(rnp::RNG *            rng,
                                    std::vector<uint8_t> &ciphertext,
                                    std::vector<uint8_t> &symmetric_key) const
 {
+    const char *alg = nullptr;
+    const char *params = nullptr;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey eph_prv_key(*(rng->obj()));
-        ciphertext = eph_prv_key.public_value();
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    case PGP_CURVE_25519:
+        alg = "X25519";
         break;
-    }
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey eph_prv_key(*(rng->obj()));
-        ciphertext = eph_prv_key.public_value();
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    case PGP_CURVE_448:
+        alg = "X448";
         break;
-    }
 #endif
-    default: {
-        auto curve_desc = pgp::ec::Curve::get(curve_);
-        if (!curve_desc) {
-            RNP_LOG("unknown curve");
-            return RNP_ERROR_NOT_SUPPORTED;
-        }
-
-        Botan::EC_Group         domain = Botan::EC_Group::from_name(curve_desc->botan_name);
-        Botan::ECDH_PrivateKey  eph_prv_key(*(rng->obj()), domain);
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        ciphertext = eph_prv_key.public_value();
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    default:
+        alg = "ECDH";
+        params = curve_botan_name(curve_);
         break;
     }
+    if (!params && curve_ != PGP_CURVE_25519
+#if defined(ENABLE_CRYPTO_REFRESH)
+        && curve_ != PGP_CURVE_448
+#endif
+    ) {
+        return RNP_ERROR_NOT_SUPPORTED;
     }
+
+    rnp::botan::Privkey eph_prv;
+    if (botan_privkey_create(&eph_prv.get(), alg, params ? params : "", rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    if (!export_agreement_public(eph_prv.get(), ciphertext)) {
+        return RNP_ERROR_GENERIC;
+    }
+
+    rnp::botan::op::KeyAgreement op;
+    if (botan_pk_op_key_agreement_create(&op.get(), eph_prv.get(), "Raw", 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    size_t slen = 0;
+    if (botan_pk_op_key_agreement_size(op.get(), &slen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    symmetric_key.assign(slen, 0);
+    if (botan_pk_op_key_agreement(op.get(),
+                                  symmetric_key.data(),
+                                  &slen,
+                                  key_.data(),
+                                  key_.size(),
+                                  NULL,
+                                  0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    symmetric_key.resize(slen);
     return RNP_SUCCESS;
 }
 
@@ -180,28 +215,45 @@ ecdh_kem_private_key_t::decapsulate(rnp::RNG *                  rng,
                                     const std::vector<uint8_t> &ciphertext,
                                     std::vector<uint8_t> &      plaintext)
 {
+    (void) rng;
+    rnp::botan::Privkey priv;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey priv_key = botan_key_x25519();
-        Botan::PK_Key_Agreement  key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv.get(), key_.data());
         break;
-    }
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey  priv_key = botan_key_x448();
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv.get(), key_.data());
         break;
-    }
 #endif
-    default: {
-        Botan::ECDH_PrivateKey  priv_key = botan_key_ecdh(rng);
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    default:
+        ok = load_ec_privkey(priv, botan_privkey_load_ecdh, key_, curve_);
         break;
     }
+    if (!ok) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
+
+    rnp::botan::op::KeyAgreement op;
+    if (botan_pk_op_key_agreement_create(&op.get(), priv.get(), "Raw", 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    size_t slen = 0;
+    if (botan_pk_op_key_agreement_size(op.get(), &slen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    plaintext.assign(slen, 0);
+    if (botan_pk_op_key_agreement(op.get(),
+                                  plaintext.data(),
+                                  &slen,
+                                  ciphertext.data(),
+                                  ciphertext.size(),
+                                  NULL,
+                                  0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    plaintext.resize(slen);
     return RNP_SUCCESS;
 }
 
@@ -226,19 +278,19 @@ exdsa_public_key_t::exdsa_public_key_t(uint8_t *key_buf, size_t key_buf_len, pgp
     : ec_key_t(curve), key_(key_buf, key_buf + key_buf_len)
 {
 }
+
 exdsa_public_key_t::exdsa_public_key_t(std::vector<uint8_t> key, pgp_curve_t curve)
     : ec_key_t(curve), key_(key)
 {
 }
 
-exdsa_private_key_t::exdsa_private_key_t(uint8_t *   key_buf,
-                                         size_t      key_buf_len,
-                                         pgp_curve_t curve)
+exdsa_private_key_t::exdsa_private_key_t(uint8_t *key_buf, size_t key_buf_len, pgp_curve_t curve)
     : ec_key_t(curve), key_(key_buf, key_buf + key_buf_len)
 {
 }
+
 exdsa_private_key_t::exdsa_private_key_t(std::vector<uint8_t> key, pgp_curve_t curve)
-    : ec_key_t(curve), key_(Botan::secure_vector<uint8_t>(key.begin(), key.end()))
+    : ec_key_t(curve), key_(key.begin(), key.end())
 {
 }
 
@@ -258,24 +310,6 @@ ec_key_t::generate_exdsa_key_pair(rnp::RNG *rng, exdsa_key_t *out, pgp_curve_t c
     return RNP_SUCCESS;
 }
 
-Botan::ECDSA_PrivateKey
-exdsa_private_key_t::botan_key(rnp::RNG *rng) const
-{
-    auto                    ec_desc = pgp::ec::Curve::get(curve_);
-    Botan::ECDSA_PrivateKey priv_key(
-      *(rng->obj()), Botan::EC_Group::from_name(ec_desc->botan_name), Botan::BigInt(key_));
-    return priv_key;
-}
-
-Botan::ECDSA_PublicKey
-exdsa_public_key_t::botan_key() const
-{
-    // format: 04 | X | Y
-    auto            ec_desc = pgp::ec::Curve::get(curve_);
-    Botan::EC_Group group = Botan::EC_Group::from_name(ec_desc->botan_name);
-    return Botan::ECDSA_PublicKey(group, Botan::EC_AffinePoint(group, key_).to_legacy_point());
-}
-
 /* NOTE hash_alg unused for Ed/X curves */
 rnp_result_t
 exdsa_private_key_t::sign(rnp::RNG *            rng,
@@ -286,16 +320,31 @@ exdsa_private_key_t::sign(rnp::RNG *            rng,
 {
     switch (curve_) {
     case PGP_CURVE_ED25519: {
-        return ed25519_sign_native(rng, sig_out, Botan::unlock(key_), hash, hash_len);
+        return ed25519_sign_native(rng, sig_out, get_encoded(), hash, hash_len);
     }
     case PGP_CURVE_ED448: {
-        return ed448_sign_native(rng, sig_out, Botan::unlock(key_), hash, hash_len);
+        return ed448_sign_native(rng, sig_out, get_encoded(), hash, hash_len);
     }
     default: {
-        Botan::ECDSA_PrivateKey priv_key = botan_key(rng);
-        auto                    signer =
-          Botan::PK_Signer(priv_key, *(rng->obj()), pgp::ecdsa::padding_str_for(hash_alg));
-        sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
+        rnp::botan::Privkey priv_key;
+        if (!load_ec_privkey(priv_key, botan_privkey_load_ecdsa, key_, curve_)) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::op::Sign signer;
+        const char *         pad = pgp::ecdsa::padding_str_for(hash_alg);
+        if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), pad, 0) ||
+            botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        size_t sig_len = 0;
+        if (botan_pk_op_sign_output_length(signer.get(), &sig_len) || !sig_len) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        sig_out.assign(sig_len, 0);
+        if (botan_pk_op_sign_finish(signer.get(), rng->handle(), sig_out.data(), &sig_len)) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        sig_out.resize(sig_len);
         return RNP_SUCCESS;
     }
     }
@@ -315,93 +364,101 @@ exdsa_public_key_t::verify(const std::vector<uint8_t> &sig,
         return ed448_verify_native(sig, key_, hash, hash_len);
     }
     default: {
-        Botan::ECDSA_PublicKey pub_key = botan_key();
-        auto verifier = Botan::PK_Verifier(pub_key, pgp::ecdsa::padding_str_for(hash_alg));
-        if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-            return RNP_SUCCESS;
+        rnp::botan::Pubkey pub_key;
+        if (!load_ec_pubkey(pub_key, botan_pubkey_load_ecdsa_sec1, key_, curve_)) {
+            return RNP_ERROR_SIGNATURE_INVALID;
         }
+        rnp::botan::op::Verify verifier;
+        const char *           pad = pgp::ecdsa::padding_str_for(hash_alg);
+        if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), pad, 0) ||
+            botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+            return RNP_ERROR_SIGNATURE_INVALID;
+        }
+        if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+            return RNP_ERROR_SIGNATURE_INVALID;
+        }
+        return RNP_SUCCESS;
     }
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
 }
 
 bool
 exdsa_public_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Pubkey pub_key;
+    bool               ok = false;
     switch (curve_) {
-    case PGP_CURVE_ED25519: {
-        Botan::Ed25519_PublicKey pub_key(key_);
-        return pub_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_ED25519:
+        ok = (key_.size() == 32) && !botan_pubkey_load_ed25519(&pub_key.get(), key_.data());
+        break;
+    case PGP_CURVE_ED448:
+        ok = (key_.size() == 57) && !botan_pubkey_load_ed448(&pub_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_pubkey(pub_key, botan_pubkey_load_ecdsa_sec1, key_, curve_);
+        break;
     }
-    case PGP_CURVE_ED448: {
-        Botan::Ed448_PublicKey pub_key(key_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    default: {
-        Botan::ECDSA_PublicKey pub_key = botan_key();
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_pubkey_check_key(pub_key.get(), rng->handle(), 0);
 }
 
 bool
 exdsa_private_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Privkey priv_key;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_ED25519: {
-        Botan::Ed25519_PrivateKey priv_key(key_);
-        return priv_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_ED25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_ed25519(&priv_key.get(), key_.data());
+        break;
+    case PGP_CURVE_ED448:
+        ok = (key_.size() == 57) && !botan_privkey_load_ed448(&priv_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_privkey(priv_key, botan_privkey_load_ecdsa, key_, curve_);
+        break;
     }
-    case PGP_CURVE_ED448: {
-        Botan::Ed448_PrivateKey priv_key(key_);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    default: {
-        auto priv_key = botan_key(rng);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_privkey_check_key(priv_key.get(), rng->handle(), 0);
 }
 #endif
 
 bool
 ecdh_kem_public_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Pubkey pub_key;
+    bool               ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        auto pub_key = botan_key_x25519();
-        return pub_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_pubkey_load_x25519(&pub_key.get(), key_.data());
+        break;
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        auto pub_key = botan_key_x448();
-        return pub_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_pubkey_load_x448(&pub_key.get(), key_.data());
+        break;
 #endif
-    default: {
-        auto pub_key = botan_key_ecdh(rng);
-        return pub_key.check_key(*(rng->obj()), false);
+    default:
+        ok = load_ec_pubkey(pub_key, botan_pubkey_load_ecdh_sec1, key_, curve_);
+        break;
     }
-    }
+    return ok && !botan_pubkey_check_key(pub_key.get(), rng->handle(), 0);
 }
 
 bool
 ecdh_kem_private_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Privkey priv_key;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        auto priv_key = botan_key_x25519();
-        return priv_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv_key.get(), key_.data());
+        break;
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        auto priv_key = botan_key_x448();
-        return priv_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv_key.get(), key_.data());
+        break;
 #endif
-    default: {
-        auto priv_key = botan_key_ecdh(rng);
-        return priv_key.check_key(*(rng->obj()), false);
+    default:
+        ok = load_ec_privkey(priv_key, botan_privkey_load_ecdh, key_, curve_);
+        break;
     }
-    }
+    return ok && !botan_privkey_check_key(priv_key.get(), rng->handle(), 0);
 }

--- a/src/lib/crypto/exdsa_ecdhkem.h
+++ b/src/lib/crypto/exdsa_ecdhkem.h
@@ -3,7 +3,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -12,16 +12,16 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef ECDH_KEM_H_
@@ -32,17 +32,8 @@
 #include <vector>
 #include <repgp/repgp_def.h>
 #include "crypto/rng.h"
+#include "crypto/mem.h"
 #include <memory>
-#include "botan/secmem.h"
-#include <botan/pubkey.h>
-#include <botan/ecdsa.h>
-#include <botan/ecdh.h>
-#include <botan/ed25519.h>
-#include <botan/x25519.h>
-#if defined(ENABLE_CRYPTO_REFRESH)
-#include <botan/x448.h>
-#include <botan/ed448.h>
-#endif
 
 struct ecdh_kem_key_t; /* forward declaration */
 #if defined(ENABLE_CRYPTO_REFRESH)
@@ -99,12 +90,6 @@ class ecdh_kem_public_key_t : public ec_key_t {
                              std::vector<uint8_t> &symmetric_key) const;
 
   private:
-    Botan::ECDH_PublicKey   botan_key_ecdh(rnp::RNG *rng) const;
-    Botan::X25519_PublicKey botan_key_x25519() const;
-#if defined(ENABLE_CRYPTO_REFRESH)
-    Botan::X448_PublicKey botan_key_x448() const;
-#endif
-
     std::vector<uint8_t> key_;
 };
 
@@ -119,7 +104,7 @@ class ecdh_kem_private_key_t : public ec_key_t {
     std::vector<uint8_t>
     get_encoded() const
     {
-        return Botan::unlock(key_);
+        return std::vector<uint8_t>(key_.begin(), key_.end());
     }
 
     std::vector<uint8_t> get_pubkey_encoded(rnp::RNG *rng) const;
@@ -129,13 +114,7 @@ class ecdh_kem_private_key_t : public ec_key_t {
                              std::vector<uint8_t> &      plaintext);
 
   private:
-    Botan::ECDH_PrivateKey   botan_key_ecdh(rnp::RNG *rng) const;
-    Botan::X25519_PrivateKey botan_key_x25519() const;
-#if defined(ENABLE_CRYPTO_REFRESH)
-    Botan::X448_PrivateKey botan_key_x448() const;
-#endif
-
-    Botan::secure_vector<uint8_t> key_;
+    rnp::secure_bytes key_;
 };
 
 typedef struct ecdh_kem_key_t {
@@ -169,8 +148,6 @@ class exdsa_public_key_t : public ec_key_t {
                         pgp_hash_alg_t              hash_alg) const;
 
   private:
-    Botan::ECDSA_PublicKey botan_key() const;
-
     std::vector<uint8_t> key_;
 };
 
@@ -186,7 +163,7 @@ class exdsa_private_key_t : public ec_key_t {
     std::vector<uint8_t>
     get_encoded() const
     {
-        return Botan::unlock(key_);
+        return std::vector<uint8_t>(key_.begin(), key_.end());
     }
 
     rnp_result_t sign(rnp::RNG *            rng,
@@ -196,9 +173,7 @@ class exdsa_private_key_t : public ec_key_t {
                       pgp_hash_alg_t        hash_alg) const;
 
   private:
-    Botan::ECDSA_PrivateKey botan_key(rnp::RNG *rng) const;
-
-    Botan::secure_vector<uint8_t> key_;
+    rnp::secure_bytes key_;
 };
 
 typedef struct exdsa_key_t {


### PR DESCRIPTION
## Summary

Addresses the **Botan 3.12 `ENABLE_CRYPTO_REFRESH` build breakage** by migrating the crypto-refresh EC/Ed code off Botan's *unstable native C++ API* and onto the *stable FFI* — the same discipline the rest of rnp already follows (which is why it rides across Botan 2.x/3.x untouched).

The native-API code bit-rotted on 3.12: tightened include hygiene made `Botan::EC_Group` / `EC_AffinePoint` / `BigInt` incomplete types, and `public_point()` + the `Ed25519_PrivateKey(span)` ctor are deprecated.

Migrated files (now contain **zero** `Botan::` references):

- **`src/lib/crypto/ec.cpp`** — `ec_generate_generic_native` mirrors the existing FFI keygen in `Key::generate()` (`botan_privkey_create` + `get_field`); native `bigint.h`/`ecdh.h` includes dropped.
- **`src/lib/crypto/ed25519_ed448.cpp`** — Ed25519/Ed448 keygen, sign, verify, validate via `botan_privkey_create`/`load_*`, `botan_pk_op_sign_*`/`verify_*`, `botan_*_check_key`.
- **`src/lib/crypto/exdsa_ecdhkem.{cpp,h}`** — replaced the `Botan::*` key-object helpers with FFI key handles; ECDH KEM via `botan_pk_op_key_agreement_*`, ECDSA sign/verify, `check_key`, SEC1 loaders. Private `key_` member moved from `Botan::secure_vector` to `rnp::secure_bytes`; all `<botan/*>` includes removed from the header.

## FFI gap audit (for discussion with Jack Lloyd)

`TODO.refactor/botan-ffi-migration.md` documents a full audit: **no Botan FFI gaps were found.** Every native op rnp uses (ECDH/ECDSA/Ed25519/Ed448/X25519/X448 keygen+load, key agreement, KEM, sign/verify, check_key, ML-DSA/ML-KEM/SLH-DSA loaders, RFC 3394 keywrap) has a stable FFI equivalent. Nothing needs to be requested upstream. The doc also lays out the Phase 2 roadmap (migrate the remaining native-API files: `x25519_x448.cpp`, `dilithium*`, `kyber*`, `sphincsplus.cpp`).

## Test plan

- [x] `cmake -DCRYPTO_BACKEND=botan3 -DENABLE_CRYPTO_REFRESH=ON` builds clean on Botan 3.12 (native-API errors gone).
- [x] Full `rnp_tests` suite passes: **280 tests** (v6 SKESK/sig/import, ECDSA keygen, Ed25519/Ed448, ECDH, CLI examples).
- [x] All four migrated files contain zero `Botan::` references.

## Notes / follow-ups

- `ed25519_ed448.cpp` still calls the deprecated `botan_privkey_ed25519_get_privkey` / `botan_*_ed448_get_*` getters (consistent with the existing `eddsa.cpp` on `main`). These are the same `-Wdeprecated-declarations` class that PR #2446 migrates to `botan_*_view_raw`; that migration should be extended to these three new call sites (tracked in the roadmap doc).
- Phase 2 (the remaining native-API files) is intentionally out of scope for this PR.
