### PR TITLE
refactor: migrate Botan backend crypto-refresh/PQC code to FFI

### DIFF
--- a/src/lib/crypto/backend_version.cpp
+++ b/src/lib/crypto/backend_version.cpp
@@ -27,7 +27,8 @@
 #include "backend_version.h"
 #include "logging.h"
 #if defined(CRYPTO_BACKEND_BOTAN)
-#include <botan/version.h>
+#include <botan/ffi.h>
+#include <cstdio>
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
@@ -63,7 +64,16 @@ const char *
 backend_version()
 {
 #if defined(CRYPTO_BACKEND_BOTAN)
-    return Botan::short_version_cstr();
+    static char version[32] = {};
+    if (!version[0]) {
+        snprintf(version,
+                 sizeof(version),
+                 "%u.%u.%u",
+                 botan_version_major(),
+                 botan_version_minor(),
+                 botan_version_patch());
+    }
+    return version;
 #elif defined(CRYPTO_BACKEND_OPENSSL)
     /* Use regexp to retrieve version (second word) from version string
      * like "OpenSSL 1.1.1l  24 Aug 2021"

--- a/src/lib/crypto/backend_version.cpp
+++ b/src/lib/crypto/backend_version.cpp
@@ -27,7 +27,8 @@
 #include "backend_version.h"
 #include "logging.h"
 #if defined(CRYPTO_BACKEND_BOTAN)
-#include <botan/version.h>
+#include <botan/ffi.h>
+#include <cstdio>
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
@@ -63,7 +64,16 @@ const char *
 backend_version()
 {
 #if defined(CRYPTO_BACKEND_BOTAN)
-    return Botan::short_version_cstr();
+    static char version[32] = {};
+    if (!version[0]) {
+        snprintf(version,
+                 sizeof(version),
+                 "%u.%u.%u",
+                 botan_version_major(),
+                 botan_version_minor(),
+                 botan_version_patch());
+    }
+    return version;
 #elif defined(CRYPTO_BACKEND_OPENSSL)
     /* Use regexp to retrieve version (second word) from version string
      * like "OpenSSL 1.1.1l  24 Aug 2021"
@@ -72,7 +82,7 @@ backend_version()
     if (version[0]) {
         return version;
     }
-    const char *reg = "OpenSSL (([0-9]+\\.[0-9]+\\.[0-9]+)[a-z]*(-[a-z0-9]+)*) ";
+    const char *   reg = "OpenSSL (([0-9]+\\.[0-9]+\\.[0-9]+)[a-z]*(-[a-z0-9]+)*) ";
 #ifndef RNP_USE_STD_REGEX
     static regex_t r;
     regmatch_t     matches[5];

--- a/src/lib/crypto/botan_utils.hpp
+++ b/src/lib/crypto/botan_utils.hpp
@@ -28,8 +28,45 @@
 #define RNP_BOTAN_UTILS_HPP_
 
 #include <botan/ffi.h>
+#include <botan/build.h>
+#include <botan/version.h>
+#include <cstring>
+#include <vector>
 #include "mpi.hpp"
 #include "utils.h"
+
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+/* Destination descriptor for the Botan view-style FFI helpers
+ * (botan_privkey_view_raw / botan_pubkey_view_raw). The callback refuses to
+ * copy when the viewed length does not match the caller's expectation, so a
+ * fixed-size buffer cannot overrun. */
+struct rnp_botan_view_buf {
+    uint8_t *data;
+    size_t   size;
+};
+
+extern "C" {
+static inline int
+rnp_botan_view_bin(botan_view_ctx ctx, const uint8_t *data, size_t len)
+{
+    auto *vb = static_cast<rnp_botan_view_buf *>(ctx);
+    if (len != vb->size) {
+        return -1;
+    }
+    std::memcpy(vb->data, data, len);
+    return 0;
+}
+
+/* Variant for variable-length output (e.g. PQC raw key encodings): the viewed
+ * bytes are assigned into the caller's vector, sizing it to fit. */
+static inline int
+rnp_botan_view_bin_vec(botan_view_ctx ctx, const uint8_t *data, size_t len)
+{
+    static_cast<std::vector<uint8_t> *>(ctx)->assign(data, data + len);
+    return 0;
+}
+}
+#endif
 
 /* Self-destructing wrappers around the Botan's FFI objects */
 namespace rnp {
@@ -251,6 +288,48 @@ class KeyAgreement {
         return op_;
     };
 };
+
+#if defined(ENABLE_PQC)
+class KemEncrypt {
+    botan_pk_op_kem_encrypt_t op_;
+
+  public:
+    KemEncrypt() : op_(NULL){};
+
+    KemEncrypt(const KemEncrypt &) = delete;
+
+    ~KemEncrypt()
+    {
+        botan_pk_op_kem_encrypt_destroy(op_);
+    }
+
+    botan_pk_op_kem_encrypt_t &
+    get() noexcept
+    {
+        return op_;
+    };
+};
+
+class KemDecrypt {
+    botan_pk_op_kem_decrypt_t op_;
+
+  public:
+    KemDecrypt() : op_(NULL){};
+
+    KemDecrypt(const KemDecrypt &) = delete;
+
+    ~KemDecrypt()
+    {
+        botan_pk_op_kem_decrypt_destroy(op_);
+    }
+
+    botan_pk_op_kem_decrypt_t &
+    get() noexcept
+    {
+        return op_;
+    };
+};
+#endif
 
 } // namespace op
 } // namespace botan

--- a/src/lib/crypto/dilithium.cpp
+++ b/src/lib/crypto/dilithium.cpp
@@ -4,7 +4,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -13,52 +13,31 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "dilithium.h"
-#include <botan/dilithium.h>
-#include <botan/pubkey.h>
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
 #include "logging.h"
 #include "types.h"
 #include <cassert>
 
 namespace {
 
-Botan::DilithiumMode
-rnp_dilithium_param_to_botan_dimension(dilithium_parameter_e mode)
+const char *
+dilithium_mode_str(dilithium_parameter_e mode)
 {
-    Botan::DilithiumMode result = Botan::DilithiumMode::ML_DSA_8x7;
-    if (mode == dilithium_parameter_e::dilithium_L3) {
-        result = Botan::DilithiumMode::ML_DSA_6x5;
-    }
-    return result;
-}
-
-Botan::Dilithium_PublicKey
-dilithium_pubkey_from_bytes(const std::vector<uint8_t> &key_encoded,
-                            dilithium_parameter_e       param)
-{
-    return Botan::Dilithium_PublicKey(key_encoded,
-                                      rnp_dilithium_param_to_botan_dimension(param));
-}
-
-Botan::Dilithium_PrivateKey
-dilithium_privkey_from_bytes(const uint8_t *       key_data,
-                             size_t                key_size,
-                             dilithium_parameter_e param)
-{
-    Botan::secure_vector<uint8_t> priv_sv(key_data, key_data + key_size);
-    return Botan::Dilithium_PrivateKey(priv_sv, rnp_dilithium_param_to_botan_dimension(param));
+    return mode == dilithium_parameter_e::dilithium_L3 ? "ML-DSA-6x5" : "ML-DSA-8x7";
 }
 
 } // namespace
@@ -67,12 +46,32 @@ std::vector<uint8_t>
 pgp_dilithium_private_key_t::sign(rnp::RNG *rng, const uint8_t *msg, size_t msg_len) const
 {
     assert(is_initialized_);
-    auto priv_key =
-      dilithium_privkey_from_bytes(key_encoded_.data(), key_encoded_.size(), dilithium_param_);
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_load_ml_dsa(&priv_key.get(),
+                                  key_encoded_.data(),
+                                  key_encoded_.size(),
+                                  dilithium_mode_str(dilithium_param_))) {
+        RNP_LOG("Failed to load ML-DSA private key");
+        return std::vector<uint8_t>();
+    }
 
-    auto                 signer = Botan::PK_Signer(priv_key, *rng->obj(), "");
-    std::vector<uint8_t> signature = signer.sign_message(msg, msg_len, *rng->obj());
+    rnp::botan::op::Sign signer;
+    if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), "", 0) ||
+        botan_pk_op_sign_update(signer.get(), msg, msg_len)) {
+        RNP_LOG("ML-DSA signing init failed");
+        return std::vector<uint8_t>();
+    }
 
+    size_t sig_len = 0;
+    if (botan_pk_op_sign_output_length(signer.get(), &sig_len) || !sig_len) {
+        return std::vector<uint8_t>();
+    }
+    std::vector<uint8_t> signature(sig_len);
+    if (botan_pk_op_sign_finish(signer.get(), rng->handle(), signature.data(), &sig_len)) {
+        RNP_LOG("ML-DSA signing failed");
+        return std::vector<uint8_t>();
+    }
+    signature.resize(sig_len);
     return signature;
 }
 
@@ -83,22 +82,49 @@ pgp_dilithium_public_key_t::verify_signature(const uint8_t *msg,
                                              size_t         signature_len) const
 {
     assert(is_initialized_);
-    auto pub_key = dilithium_pubkey_from_bytes(key_encoded_, dilithium_param_);
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ml_dsa(&pub_key.get(),
+                                 key_encoded_.data(),
+                                 key_encoded_.size(),
+                                 dilithium_mode_str(dilithium_param_))) {
+        RNP_LOG("Failed to load ML-DSA public key");
+        return false;
+    }
 
-    auto verificator = Botan::PK_Verifier(pub_key, "");
-    return verificator.verify_message(msg, msg_len, signature, signature_len);
+    rnp::botan::op::Verify verifier;
+    if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), "", 0) ||
+        botan_pk_op_verify_update(verifier.get(), msg, msg_len)) {
+        return false;
+    }
+    return !botan_pk_op_verify_finish(verifier.get(), signature, signature_len);
 }
 
 std::pair<pgp_dilithium_public_key_t, pgp_dilithium_private_key_t>
 dilithium_generate_keypair(rnp::RNG *rng, dilithium_parameter_e dilithium_param)
 {
-    Botan::Dilithium_PrivateKey priv_key(
-      *rng->obj(), rnp_dilithium_param_to_botan_dimension(dilithium_param));
+    const char *mode = dilithium_mode_str(dilithium_param);
 
-    std::unique_ptr<Botan::Public_Key> pub_key = priv_key.public_key();
-    Botan::secure_vector<uint8_t>      priv_bits = priv_key.private_key_bits();
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_create(&priv_key.get(), "ML-DSA", mode, rng->handle())) {
+        RNP_LOG("ML-DSA key generation failed");
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
+    std::vector<uint8_t> priv_bits;
+    if (botan_privkey_view_raw(priv_key.get(), &priv_bits, rnp_botan_view_bin_vec)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_privkey_export_pubkey(&pub_key.get(), priv_key.get())) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    std::vector<uint8_t> pub_bits;
+    if (botan_pubkey_view_raw(pub_key.get(), &pub_bits, rnp_botan_view_bin_vec)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
     return std::make_pair(
-      pgp_dilithium_public_key_t(pub_key->public_key_bits(), dilithium_param),
+      pgp_dilithium_public_key_t(pub_bits, dilithium_param),
       pgp_dilithium_private_key_t(priv_bits.data(), priv_bits.size(), dilithium_param));
 }
 
@@ -108,9 +134,14 @@ pgp_dilithium_public_key_t::is_valid(rnp::RNG *rng) const
     if (!is_initialized_) {
         return false;
     }
-
-    auto key = dilithium_pubkey_from_bytes(key_encoded_, dilithium_param_);
-    return key.check_key(*(rng->obj()), false);
+    rnp::botan::Pubkey key;
+    if (botan_pubkey_load_ml_dsa(&key.get(),
+                                 key_encoded_.data(),
+                                 key_encoded_.size(),
+                                 dilithium_mode_str(dilithium_param_))) {
+        return false;
+    }
+    return !botan_pubkey_check_key(key.get(), rng->handle(), 0);
 }
 
 bool
@@ -119,8 +150,12 @@ pgp_dilithium_private_key_t::is_valid(rnp::RNG *rng) const
     if (!is_initialized_) {
         return false;
     }
-
-    auto key =
-      dilithium_privkey_from_bytes(key_encoded_.data(), key_encoded_.size(), dilithium_param_);
-    return key.check_key(*(rng->obj()), false);
+    rnp::botan::Privkey key;
+    if (botan_privkey_load_ml_dsa(&key.get(),
+                                  key_encoded_.data(),
+                                  key_encoded_.size(),
+                                  dilithium_mode_str(dilithium_param_))) {
+        return false;
+    }
+    return !botan_privkey_check_key(key.get(), rng->handle(), 0);
 }

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -31,6 +31,7 @@
 #include "types.h"
 #include "utils.h"
 #include "mem.h"
+#include "botan_utils.hpp"
 #include "botan/ec_group.h"
 #include "botan/ecdh.h"
 #if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -31,14 +31,11 @@
 #include "types.h"
 #include "utils.h"
 #include "mem.h"
-#include "botan_utils.hpp"
 #include "botan/ec_group.h"
 #include "botan/ecdh.h"
 #if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
 #include "x25519_x448.h"
 #include "ed25519_ed448.h"
-#include "botan_utils.hpp"
-#include "botan/bigint.h"
 #endif
 #include <cassert>
 
@@ -67,9 +64,16 @@ Key::generate_x25519(rnp::RNG &rng)
 
     /* botan returns key in little-endian, while mpi is big-endian */
     rnp::secure_array<uint8_t, 32> keyle;
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf keyle_vb{keyle.data(), keyle.size()};
+    if (botan_privkey_view_raw(pr_key.get(), &keyle_vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+#else
     if (botan_privkey_x25519_get_privkey(pr_key.get(), keyle.data())) {
         return RNP_ERROR_KEY_GENERATION;
     }
+#endif
     x.resize(32);
     for (int i = 0; i < 32; i++) {
         x[31 - i] = keyle[i];
@@ -80,9 +84,16 @@ Key::generate_x25519(rnp::RNG &rng)
     }
 
     p.resize(33);
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf pub_vb{&p[1], 32};
+    if (botan_pubkey_view_raw(pu_key.get(), &pub_vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+#else
     if (botan_pubkey_x25519_get_pubkey(pu_key.get(), &p[1])) {
         return RNP_ERROR_KEY_GENERATION;
     }
+#endif
     p[0] = 0x40;
     return RNP_SUCCESS;
 }
@@ -196,19 +207,46 @@ ec_generate_generic_native(rnp::RNG *            rng,
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    auto         ec_desc = pgp::ec::Curve::get(curve);
-    const size_t curve_order = ec_desc->bytes();
+    auto ec_desc = pgp::ec::Curve::get(curve);
+    if (!ec_desc) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    const size_t field_size = ec_desc->bytes();
 
-    Botan::ECDH_PrivateKey privkey_botan(*(rng->obj()),
-                                         Botan::EC_Group::from_name(ec_desc->botan_name));
+    rnp::botan::Privkey pr_key;
+    if (botan_privkey_create(&pr_key.get(), "ECDH", ec_desc->botan_name, rng->handle())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+    rnp::botan::Pubkey pu_key;
+    if (botan_privkey_export_pubkey(&pu_key.get(), pr_key.get())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
 
-    // pubkey: 0x04 || X || Y
-    pubkey = Botan::unlock(privkey_botan.public_point().xy_bytes());
-    pubkey.insert(pubkey.begin(), 0x04);
+    rnp::bn px;
+    rnp::bn py;
+    rnp::bn bx;
+    if (!px || !py || !bx) {
+        RNP_LOG("Allocation failed");
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (botan_pubkey_get_field(px.get(), pu_key.get(), "public_x") ||
+        botan_pubkey_get_field(py.get(), pu_key.get(), "public_y") ||
+        botan_privkey_get_field(bx.get(), pr_key.get(), "x")) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+    if ((px.bytes() > field_size) || (py.bytes() > field_size)) {
+        RNP_LOG("Key generation failed");
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
 
-    privkey = std::vector<uint8_t>(curve_order);
-    privkey_botan.private_value().serialize_to(privkey); // zero-pads to the given size
-
+    /* pubkey: 0x04 || X || Y, coordinates zero-padded to the field size */
+    pubkey.resize(2 * field_size + 1);
+    pubkey[0] = 0x04;
+    px.bin(&pubkey[1 + field_size - px.bytes()]);
+    py.bin(&pubkey[1 + 2 * field_size - py.bytes()]);
+    /* privkey: secret scalar, zero-padded to the field size */
+    privkey.assign(field_size, 0);
+    bx.bin(&privkey[field_size - bx.bytes()]);
     return RNP_SUCCESS;
 }
 

--- a/src/lib/crypto/ec.cpp
+++ b/src/lib/crypto/ec.cpp
@@ -35,9 +35,6 @@
 #if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
 #include "x25519_x448.h"
 #include "ed25519_ed448.h"
-#include "botan_utils.hpp"
-#include "botan/bigint.h"
-#include "botan/ecdh.h"
 #endif
 #include <cassert>
 
@@ -66,9 +63,16 @@ Key::generate_x25519(rnp::RNG &rng)
 
     /* botan returns key in little-endian, while mpi is big-endian */
     rnp::secure_array<uint8_t, 32> keyle;
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf keyle_vb{keyle.data(), keyle.size()};
+    if (botan_privkey_view_raw(pr_key.get(), &keyle_vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+#else
     if (botan_privkey_x25519_get_privkey(pr_key.get(), keyle.data())) {
         return RNP_ERROR_KEY_GENERATION;
     }
+#endif
     x.resize(32);
     for (int i = 0; i < 32; i++) {
         x[31 - i] = keyle[i];
@@ -79,9 +83,16 @@ Key::generate_x25519(rnp::RNG &rng)
     }
 
     p.resize(33);
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf pub_vb{&p[1], 32};
+    if (botan_pubkey_view_raw(pu_key.get(), &pub_vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+#else
     if (botan_pubkey_x25519_get_pubkey(pu_key.get(), &p[1])) {
         return RNP_ERROR_KEY_GENERATION;
     }
+#endif
     p[0] = 0x40;
     return RNP_SUCCESS;
 }
@@ -195,19 +206,46 @@ ec_generate_generic_native(rnp::RNG *            rng,
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    auto         ec_desc = pgp::ec::Curve::get(curve);
-    const size_t curve_order = ec_desc->bytes();
+    auto ec_desc = pgp::ec::Curve::get(curve);
+    if (!ec_desc) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    const size_t field_size = ec_desc->bytes();
 
-    Botan::ECDH_PrivateKey privkey_botan(*(rng->obj()),
-                                         Botan::EC_Group::from_name(ec_desc->botan_name));
+    rnp::botan::Privkey pr_key;
+    if (botan_privkey_create(&pr_key.get(), "ECDH", ec_desc->botan_name, rng->handle())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+    rnp::botan::Pubkey pu_key;
+    if (botan_privkey_export_pubkey(&pu_key.get(), pr_key.get())) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
 
-    // pubkey: 0x04 || X || Y
-    pubkey = Botan::unlock(privkey_botan.public_point().xy_bytes());
-    pubkey.insert(pubkey.begin(), 0x04);
+    rnp::bn px;
+    rnp::bn py;
+    rnp::bn bx;
+    if (!px || !py || !bx) {
+        RNP_LOG("Allocation failed");
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (botan_pubkey_get_field(px.get(), pu_key.get(), "public_x") ||
+        botan_pubkey_get_field(py.get(), pu_key.get(), "public_y") ||
+        botan_privkey_get_field(bx.get(), pr_key.get(), "x")) {
+        return RNP_ERROR_KEY_GENERATION;
+    }
+    if ((px.bytes() > field_size) || (py.bytes() > field_size)) {
+        RNP_LOG("Key generation failed");
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
 
-    privkey = std::vector<uint8_t>(curve_order);
-    privkey_botan.private_value().serialize_to(privkey); // zero-pads to the given size
-
+    /* pubkey: 0x04 || X || Y, coordinates zero-padded to the field size */
+    pubkey.resize(2 * field_size + 1);
+    pubkey[0] = 0x04;
+    px.bin(&pubkey[1 + field_size - px.bytes()]);
+    py.bin(&pubkey[1 + 2 * field_size - py.bytes()]);
+    /* privkey: secret scalar, zero-padded to the field size */
+    privkey.assign(field_size, 0);
+    bx.bin(&privkey[field_size - bx.bytes()]);
     return RNP_SUCCESS;
 }
 

--- a/src/lib/crypto/ed25519_ed448.cpp
+++ b/src/lib/crypto/ed25519_ed448.cpp
@@ -3,7 +3,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -12,41 +12,45 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "ed25519_ed448.h"
 #include "logging.h"
 #include "utils.h"
 
-#include <botan/pubkey.h>
-#include <botan/ed25519.h>
-#if defined(ENABLE_CRYPTO_REFRESH)
-#include <botan/ed448.h>
-#endif
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
 #include <cassert>
+#include <string.h>
 
 rnp_result_t
 generate_ed25519_native(rnp::RNG *            rng,
                         std::vector<uint8_t> &privkey,
                         std::vector<uint8_t> &pubkey)
 {
-    Botan::Ed25519_PrivateKey private_key(*(rng->obj()));
-    const size_t              key_len = 32;
-    auto                      priv_pub = Botan::unlock(private_key.raw_private_key_bits());
-    assert(priv_pub.size() == 2 * key_len);
-    privkey = std::vector<uint8_t>(priv_pub.begin(), priv_pub.begin() + key_len);
-    pubkey = std::vector<uint8_t>(priv_pub.begin() + key_len, priv_pub.end());
-
+    rnp::botan::Privkey private_key;
+    if (botan_privkey_create(&private_key.get(), "Ed25519", NULL, rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    /* botan returns the 32-byte seed followed by the 32-byte public key */
+    uint8_t            key_bits[64];
+    rnp_botan_view_buf vb{key_bits, sizeof(key_bits)};
+    if (botan_privkey_view_raw(private_key.get(), &vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_GENERIC;
+    }
+    const size_t key_len = 32;
+    privkey.assign(key_bits, key_bits + key_len);
+    pubkey.assign(key_bits + key_len, key_bits + 2 * key_len);
     return RNP_SUCCESS;
 }
 
@@ -57,10 +61,24 @@ ed25519_sign_native(rnp::RNG *                  rng,
                     const uint8_t *             hash,
                     size_t                      hash_len)
 {
-    Botan::Ed25519_PrivateKey priv_key(Botan::secure_vector<uint8_t>(key.begin(), key.end()));
-    auto                      signer = Botan::PK_Signer(priv_key, *(rng->obj()), "Pure");
-    sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
-
+    if (key.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_load_ed25519(&priv_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Sign signer;
+    if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), "Pure", 0) ||
+        botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    uint8_t buf[64];
+    size_t  sig_len = sizeof(buf);
+    if (botan_pk_op_sign_finish(signer.get(), rng->handle(), buf, &sig_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    sig_out.assign(buf, buf + sig_len);
     return RNP_SUCCESS;
 }
 
@@ -70,26 +88,43 @@ ed25519_verify_native(const std::vector<uint8_t> &sig,
                       const uint8_t *             hash,
                       size_t                      hash_len)
 {
-    Botan::Ed25519_PublicKey pub_key(key);
-    auto                     verifier = Botan::PK_Verifier(pub_key, "Pure");
-    if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-        return RNP_SUCCESS;
+    if (key.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed25519(&pub_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Verify verifier;
+    if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), "Pure", 0) ||
+        botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    return RNP_SUCCESS;
 }
 
 rnp_result_t
 ed25519_validate_key_native(rnp::RNG *rng, const pgp_ed25519_key_t *key, bool secret)
 {
-    Botan::Ed25519_PublicKey pub_key(key->pub);
-    if (!pub_key.check_key(*(rng->obj()), false)) {
+    if (key->pub.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed25519(&pub_key.get(), key->pub.data()) ||
+        botan_pubkey_check_key(pub_key.get(), rng->handle(), 0)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
     if (secret) {
-        Botan::Ed25519_PrivateKey priv_key(
-          Botan::secure_vector<uint8_t>(key->priv.begin(), key->priv.end()));
-        if (!priv_key.check_key(*(rng->obj()), false)) {
+        if (key->priv.size() != 32) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::Privkey priv_key;
+        if (botan_privkey_load_ed25519(&priv_key.get(), key->priv.data()) ||
+            botan_privkey_check_key(priv_key.get(), rng->handle(), 0)) {
             return RNP_ERROR_SIGNING_FAILED;
         }
     }
@@ -103,14 +138,26 @@ generate_ed448_native(rnp::RNG *            rng,
                       std::vector<uint8_t> &privkey,
                       std::vector<uint8_t> &pubkey)
 {
-    Botan::Ed448_PrivateKey private_key(*(rng->obj()));
-    const size_t            key_len = 57;
-    auto                    priv = Botan::unlock(private_key.raw_private_key_bits());
-    assert(priv.size() == key_len);
-    auto pub = private_key.public_key_bits();
-    assert(pub.size() == key_len);
-    privkey = std::vector<uint8_t>(priv.begin(), priv.begin() + key_len);
-    pubkey = std::vector<uint8_t>(pub.begin(), pub.begin() + key_len);
+    rnp::botan::Privkey private_key;
+    if (botan_privkey_create(&private_key.get(), "Ed448", NULL, rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    uint8_t            priv[57];
+    rnp_botan_view_buf priv_vb{priv, sizeof(priv)};
+    if (botan_privkey_view_raw(private_key.get(), &priv_vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_GENERIC;
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_privkey_export_pubkey(&pub_key.get(), private_key.get())) {
+        return RNP_ERROR_GENERIC;
+    }
+    uint8_t            pub[57];
+    rnp_botan_view_buf pub_vb{pub, sizeof(pub)};
+    if (botan_pubkey_view_raw(pub_key.get(), &pub_vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_GENERIC;
+    }
+    privkey.assign(priv, priv + 57);
+    pubkey.assign(pub, pub + 57);
     return RNP_SUCCESS;
 }
 
@@ -121,9 +168,24 @@ ed448_sign_native(rnp::RNG *                  rng,
                   const uint8_t *             hash,
                   size_t                      hash_len)
 {
-    Botan::Ed448_PrivateKey priv_key(Botan::secure_vector<uint8_t>(key.begin(), key.end()));
-    auto                    signer = Botan::PK_Signer(priv_key, *(rng->obj()), "Pure");
-    sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
+    if (key.size() != 57) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_load_ed448(&priv_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Sign signer;
+    if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), "Pure", 0) ||
+        botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    uint8_t buf[114];
+    size_t  sig_len = sizeof(buf);
+    if (botan_pk_op_sign_finish(signer.get(), rng->handle(), buf, &sig_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    sig_out.assign(buf, buf + sig_len);
     return RNP_SUCCESS;
 }
 
@@ -133,25 +195,42 @@ ed448_verify_native(const std::vector<uint8_t> &sig,
                     const uint8_t *             hash,
                     size_t                      hash_len)
 {
-    Botan::Ed448_PublicKey pub_key(key);
-    auto                   verifier = Botan::PK_Verifier(pub_key, "Pure");
-    if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-        return RNP_SUCCESS;
+    if (key.size() != 57) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed448(&pub_key.get(), key.data())) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::op::Verify verifier;
+    if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), "Pure", 0) ||
+        botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    return RNP_SUCCESS;
 }
 
 rnp_result_t
 ed448_validate_key_native(rnp::RNG *rng, const pgp_ed448_key_t *key, bool secret)
 {
-    Botan::Ed448_PublicKey pub_key(key->pub);
-    if (!pub_key.check_key(*(rng->obj()), false)) {
+    if (key->pub.size() != 57) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_ed448(&pub_key.get(), key->pub.data()) ||
+        botan_pubkey_check_key(pub_key.get(), rng->handle(), 0)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
     if (secret) {
-        Botan::Ed448_PrivateKey priv_key(
-          Botan::secure_vector<uint8_t>(key->priv.begin(), key->priv.end()));
-        if (!priv_key.check_key(*(rng->obj()), false)) {
+        if (key->priv.size() != 57) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::Privkey priv_key;
+        if (botan_privkey_load_ed448(&priv_key.get(), key->priv.data()) ||
+            botan_privkey_check_key(priv_key.get(), rng->handle(), 0)) {
             return RNP_ERROR_SIGNING_FAILED;
         }
     }

--- a/src/lib/crypto/eddsa.cpp
+++ b/src/lib/crypto/eddsa.cpp
@@ -100,9 +100,16 @@ generate(rnp::RNG &rng, ec::Key &key)
     }
 
     uint8_t key_bits[64];
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 6, 0)
+    rnp_botan_view_buf vb{key_bits, sizeof(key_bits)};
+    if (botan_privkey_view_raw(eddsa.get(), &vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_GENERIC;
+    }
+#else
     if (botan_privkey_ed25519_get_privkey(eddsa.get(), key_bits)) {
         return RNP_ERROR_GENERIC;
     }
+#endif
 
     // First 32 bytes of key_bits are the EdDSA seed (private key)
     // Second 32 bytes are the EdDSA public key

--- a/src/lib/crypto/elgamal.cpp
+++ b/src/lib/crypto/elgamal.cpp
@@ -28,8 +28,6 @@
 #include <string.h>
 #include <vector>
 #include <botan/ffi.h>
-#include <botan/bigint.h>
-#include <botan/numthry.h>
 #include "botan_utils.hpp"
 #include <rnp/rnp_def.h>
 #include "elgamal.h"
@@ -88,26 +86,36 @@ Key::validate(bool secret) const noexcept
     /* Use custom validation since we added some custom validation, and Botan has slow test for
      * prime for p */
     try {
-        Botan::BigInt bp(p.data(), p.size());
-        Botan::BigInt bg(g.data(), g.size());
+        rnp::bn bp(p.data(), p.size());
+        rnp::bn bg(g.data(), g.size());
+        uint8_t oneb = 1;
+        rnp::bn one(&oneb, 1);
+        int     c = 0;
 
         /* 1 < g < p */
-        if ((bg.cmp_word(1) != 1) || (bg.cmp(bp) != -1)) {
+        botan_mp_cmp(&c, bg.get(), one.get());
+        if (c <= 0) {
+            return false;
+        }
+        botan_mp_cmp(&c, bg.get(), bp.get());
+        if (c >= 0) {
             return false;
         }
         /* g ^ (p - 1) = 1 mod p */
-        if (Botan::power_mod(bg, bp - 1, bp).cmp_word(1)) {
+        rnp::bn pm1;
+        rnp::bn gm;
+        botan_mp_sub(pm1.get(), bp.get(), one.get());
+        botan_mp_powmod(gm.get(), bg.get(), pm1.get(), bp.get());
+        botan_mp_cmp(&c, gm.get(), one.get());
+        if (c != 0) {
             return false;
         }
         /* check for small order subgroups */
-        /* Note: we use (v * bg) % bp instead of Modular_Reducer::multiply() because
-         * Botan >= 3.8.0 changed Modular_Reducer::reduce() to use constant-time
-         * ct_modulo(), causing a ~190x slowdown.
-         * BigInt::operator% uses variable-time division. */
-        Botan::BigInt v = bg;
+        rnp::bn v(g.data(), g.size());
         for (size_t i = 2; i < (1 << 17); i++) {
-            v = (v * bg) % bp;
-            if (!v.cmp_word(1)) {
+            botan_mp_mod_mul(v.get(), v.get(), bg.get(), bp.get());
+            botan_mp_cmp(&c, v.get(), one.get());
+            if (c == 0) {
                 RNP_LOG("Small subgroup detected. Order %zu", i);
                 return false;
             }
@@ -116,9 +124,12 @@ Key::validate(bool secret) const noexcept
             return true;
         }
         /* check that g ^ x = y (mod p) */
-        Botan::BigInt by(y.data(), y.size());
-        Botan::BigInt bx(x.data(), x.size());
-        return Botan::power_mod(bg, bx, bp) == by;
+        rnp::bn by(y.data(), y.size());
+        rnp::bn bx(x.data(), x.size());
+        rnp::bn gx;
+        botan_mp_powmod(gx.get(), bg.get(), bx.get(), bp.get());
+        botan_mp_cmp(&c, gx.get(), by.get());
+        return c == 0;
     } catch (const std::exception &e) {
         RNP_LOG("%s", e.what());
         return false;

--- a/src/lib/crypto/exdsa_ecdhkem.cpp
+++ b/src/lib/crypto/exdsa_ecdhkem.cpp
@@ -168,9 +168,7 @@ ecdh_kem_public_key_t::encapsulate(rnp::RNG *            rng,
         params = curve_botan_name(curve_);
         break;
     }
-    if (!params && curve_ != PGP_CURVE_25519
-        && curve_ != PGP_CURVE_448
-    ) {
+    if (!params && curve_ != PGP_CURVE_25519 && curve_ != PGP_CURVE_448) {
         return RNP_ERROR_NOT_SUPPORTED;
     }
 

--- a/src/lib/crypto/exdsa_ecdhkem.cpp
+++ b/src/lib/crypto/exdsa_ecdhkem.cpp
@@ -4,7 +4,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -13,32 +13,21 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "exdsa_ecdhkem.h"
-#include <botan/secmem.h>
-#include <botan/pubkey.h>
-#include <botan/bigint.h>
-#include <botan/ec_group.h>
-#include <botan/ecdh.h>
-#include <botan/ecdsa.h>
-#include <botan/ed25519.h>
-#include <botan/x25519.h>
-#if defined(ENABLE_CRYPTO_REFRESH)
-#include <botan/x448.h>
-#include <botan/ed448.h>
-#endif
-#include "ecdh.h"
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
 #include "ed25519_ed448.h"
 #include "ecdsa.h"
 #include "ec.h"
@@ -47,7 +36,64 @@
 #include "string.h"
 #include "utils.h"
 #include <cassert>
-#include <botan/ec_group.h>
+
+namespace {
+
+const char *
+curve_botan_name(pgp_curve_t curve)
+{
+    auto ec_desc = pgp::ec::Curve::get(curve);
+    return ec_desc ? ec_desc->botan_name : nullptr;
+}
+
+bool
+load_ec_privkey(rnp::botan::Privkey &out,
+                int (*loader)(botan_privkey_t *, botan_mp_t, const char *),
+                const uint8_t *scalar,
+                size_t         scalar_len,
+                pgp_curve_t    curve)
+{
+    const char *name = curve_botan_name(curve);
+    if (!name) {
+        return false;
+    }
+    rnp::bn s(scalar, scalar_len);
+    return s && !loader(&out.get(), s.get(), name);
+}
+
+bool
+load_ec_pubkey(rnp::botan::Pubkey &out,
+               int (*loader)(botan_pubkey_t *, const uint8_t *, size_t, const char *),
+               const uint8_t *sec1,
+               size_t         sec1_len,
+               pgp_curve_t    curve)
+{
+    const char *name = curve_botan_name(curve);
+    if (!name) {
+        return false;
+    }
+    return !loader(&out.get(), sec1, sec1_len, name);
+}
+
+bool
+export_agreement_public(botan_privkey_t priv, std::vector<uint8_t> &out)
+{
+    /* The length query returns the size via out_len but signals it via
+     * BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE rather than success. */
+    size_t len = 0;
+    botan_pk_op_key_agreement_export_public(priv, nullptr, &len);
+    if (!len) {
+        return false;
+    }
+    out.resize(len);
+    if (botan_pk_op_key_agreement_export_public(priv, out.data(), &len)) {
+        return false;
+    }
+    out.resize(len);
+    return true;
+}
+
+} // namespace
 
 ec_key_t::~ec_key_t()
 {
@@ -79,77 +125,28 @@ ecdh_kem_private_key_t::ecdh_kem_private_key_t(std::vector<uint8_t> key, pgp_cur
 {
 }
 
-static Botan::ECDH_PrivateKey
-ecdh_kem_privkey_from_bytes(rnp::RNG *     rng,
-                            const uint8_t *key_data,
-                            size_t         key_size,
-                            pgp_curve_t    curve)
-{
-    assert(curve >= PGP_CURVE_NIST_P_256 && curve <= PGP_CURVE_P256K1);
-    auto ec_desc = pgp::ec::Curve::get(curve);
-    return Botan::ECDH_PrivateKey(*(rng->obj()),
-                                  Botan::EC_Group::from_name(ec_desc->botan_name),
-                                  Botan::BigInt(key_data, key_size));
-}
-
-static Botan::ECDH_PublicKey
-ecdh_kem_pubkey_from_bytes(rnp::RNG *rng, const std::vector<uint8_t> &key, pgp_curve_t curve)
-{
-    assert(curve >= PGP_CURVE_NIST_P_256 && curve <= PGP_CURVE_P256K1);
-    auto            ec_desc = pgp::ec::Curve::get(curve);
-    Botan::EC_Group group = Botan::EC_Group::from_name(ec_desc->botan_name);
-    return Botan::ECDH_PublicKey(group, Botan::EC_AffinePoint(group, key).to_legacy_point());
-}
-
-static Botan::X25519_PrivateKey
-x25519_privkey_from_bytes(const uint8_t *key_data, size_t key_size)
-{
-    Botan::secure_vector<uint8_t> sv(key_data, key_data + key_size);
-    return Botan::X25519_PrivateKey(sv);
-}
-
-static Botan::X25519_PublicKey
-x25519_pubkey_from_bytes(const std::vector<uint8_t> &key)
-{
-    return Botan::X25519_PublicKey(key);
-}
-
-#if defined(ENABLE_CRYPTO_REFRESH)
-static Botan::X448_PrivateKey
-x448_privkey_from_bytes(const uint8_t *key_data, size_t key_size)
-{
-    Botan::secure_vector<uint8_t> sv(key_data, key_data + key_size);
-    return Botan::X448_PrivateKey(sv);
-}
-
-static Botan::X448_PublicKey
-x448_pubkey_from_bytes(const std::vector<uint8_t> &key)
-{
-    return Botan::X448_PublicKey(key);
-}
-#endif
-
 std::vector<uint8_t>
 ecdh_kem_private_key_t::get_pubkey_encoded(rnp::RNG *rng) const
 {
+    (void) rng;
+    rnp::botan::Privkey priv;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey botan_key =
-          x25519_privkey_from_bytes(key_.data(), key_.size());
-        return botan_key.public_value();
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv.get(), key_.data());
+        break;
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_privkey(priv, botan_privkey_load_ecdh, key_.data(), key_.size(), curve_);
+        break;
     }
-#if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey botan_key = x448_privkey_from_bytes(key_.data(), key_.size());
-        return botan_key.public_value();
+    std::vector<uint8_t> out;
+    if (ok) {
+        export_agreement_public(priv.get(), out);
     }
-#endif
-    default: {
-        Botan::ECDH_PrivateKey botan_key =
-          ecdh_kem_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        return botan_key.public_value();
-    }
-    }
+    return out;
 }
 
 rnp_result_t
@@ -157,38 +154,48 @@ ecdh_kem_public_key_t::encapsulate(rnp::RNG *            rng,
                                    std::vector<uint8_t> &ciphertext,
                                    std::vector<uint8_t> &symmetric_key) const
 {
+    const char *alg = nullptr;
+    const char *params = nullptr;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey eph_prv_key(*(rng->obj()));
-        ciphertext = eph_prv_key.public_value();
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    case PGP_CURVE_25519:
+        alg = "X25519";
+        break;
+    case PGP_CURVE_448:
+        alg = "X448";
+        break;
+    default:
+        alg = "ECDH";
+        params = curve_botan_name(curve_);
         break;
     }
-#if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey eph_prv_key(*(rng->obj()));
-        ciphertext = eph_prv_key.public_value();
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
-        break;
+    if (!params && curve_ != PGP_CURVE_25519
+        && curve_ != PGP_CURVE_448
+    ) {
+        return RNP_ERROR_NOT_SUPPORTED;
     }
-#endif
-    default: {
-        auto curve_desc = pgp::ec::Curve::get(curve_);
-        if (!curve_desc) {
-            RNP_LOG("unknown curve");
-            return RNP_ERROR_NOT_SUPPORTED;
-        }
 
-        Botan::EC_Group         domain = Botan::EC_Group::from_name(curve_desc->botan_name);
-        Botan::ECDH_PrivateKey  eph_prv_key(*(rng->obj()), domain);
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        ciphertext = eph_prv_key.public_value();
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
-        break;
+    rnp::botan::Privkey eph_prv;
+    if (botan_privkey_create(&eph_prv.get(), alg, params ? params : "", rng->handle())) {
+        return RNP_ERROR_GENERIC;
     }
+    if (!export_agreement_public(eph_prv.get(), ciphertext)) {
+        return RNP_ERROR_GENERIC;
     }
+
+    rnp::botan::op::KeyAgreement op;
+    if (botan_pk_op_key_agreement_create(&op.get(), eph_prv.get(), "Raw", 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    size_t slen = 0;
+    if (botan_pk_op_key_agreement_size(op.get(), &slen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    symmetric_key.assign(slen, 0);
+    if (botan_pk_op_key_agreement(
+          op.get(), symmetric_key.data(), &slen, key_.data(), key_.size(), NULL, 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    symmetric_key.resize(slen);
     return RNP_SUCCESS;
 }
 
@@ -197,30 +204,38 @@ ecdh_kem_private_key_t::decapsulate(rnp::RNG *                  rng,
                                     const std::vector<uint8_t> &ciphertext,
                                     std::vector<uint8_t> &      plaintext)
 {
+    (void) rng;
+    rnp::botan::Privkey priv;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey priv_key =
-          x25519_privkey_from_bytes(key_.data(), key_.size());
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv.get(), key_.data());
+        break;
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_privkey(priv, botan_privkey_load_ecdh, key_.data(), key_.size(), curve_);
         break;
     }
-#if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey  priv_key = x448_privkey_from_bytes(key_.data(), key_.size());
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
-        break;
+    if (!ok) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-#endif
-    default: {
-        Botan::ECDH_PrivateKey priv_key =
-          ecdh_kem_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
-        break;
+
+    rnp::botan::op::KeyAgreement op;
+    if (botan_pk_op_key_agreement_create(&op.get(), priv.get(), "Raw", 0)) {
+        return RNP_ERROR_GENERIC;
     }
+    size_t slen = 0;
+    if (botan_pk_op_key_agreement_size(op.get(), &slen)) {
+        return RNP_ERROR_GENERIC;
     }
+    plaintext.assign(slen, 0);
+    if (botan_pk_op_key_agreement(
+          op.get(), plaintext.data(), &slen, ciphertext.data(), ciphertext.size(), NULL, 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    plaintext.resize(slen);
     return RNP_SUCCESS;
 }
 
@@ -240,7 +255,6 @@ ec_key_t::generate_ecdh_kem_key_pair(rnp::RNG *rng, ecdh_kem_key_t *out, pgp_cur
     return RNP_SUCCESS;
 }
 
-#if defined(ENABLE_CRYPTO_REFRESH)
 exdsa_public_key_t::exdsa_public_key_t(uint8_t *key_buf, size_t key_buf_len, pgp_curve_t curve)
     : ec_key_t(curve), key_(key_buf, key_buf + key_buf_len)
 {
@@ -277,27 +291,6 @@ ec_key_t::generate_exdsa_key_pair(rnp::RNG *rng, exdsa_key_t *out, pgp_curve_t c
     return RNP_SUCCESS;
 }
 
-static Botan::ECDSA_PrivateKey
-exdsa_privkey_from_bytes(rnp::RNG *     rng,
-                         const uint8_t *key_data,
-                         size_t         key_size,
-                         pgp_curve_t    curve)
-{
-    auto ec_desc = pgp::ec::Curve::get(curve);
-    return Botan::ECDSA_PrivateKey(*(rng->obj()),
-                                   Botan::EC_Group::from_name(ec_desc->botan_name),
-                                   Botan::BigInt(key_data, key_size));
-}
-
-static Botan::ECDSA_PublicKey
-exdsa_pubkey_from_bytes(const std::vector<uint8_t> &key, pgp_curve_t curve)
-{
-    /* format: 04 | X | Y */
-    auto            ec_desc = pgp::ec::Curve::get(curve);
-    Botan::EC_Group group = Botan::EC_Group::from_name(ec_desc->botan_name);
-    return Botan::ECDSA_PublicKey(group, Botan::EC_AffinePoint(group, key).to_legacy_point());
-}
-
 /* NOTE hash_alg unused for Ed/X curves */
 rnp_result_t
 exdsa_private_key_t::sign(rnp::RNG *            rng,
@@ -314,11 +307,26 @@ exdsa_private_key_t::sign(rnp::RNG *            rng,
         return ed448_sign_native(rng, sig_out, key_.unlock(), hash, hash_len);
     }
     default: {
-        Botan::ECDSA_PrivateKey priv_key =
-          exdsa_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        auto signer =
-          Botan::PK_Signer(priv_key, *(rng->obj()), pgp::ecdsa::padding_str_for(hash_alg));
-        sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
+        rnp::botan::Privkey priv_key;
+        if (!load_ec_privkey(
+              priv_key, botan_privkey_load_ecdsa, key_.data(), key_.size(), curve_)) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::op::Sign signer;
+        const char *         pad = pgp::ecdsa::padding_str_for(hash_alg);
+        if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), pad, 0) ||
+            botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        size_t sig_len = 0;
+        if (botan_pk_op_sign_output_length(signer.get(), &sig_len) || !sig_len) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        sig_out.assign(sig_len, 0);
+        if (botan_pk_op_sign_finish(signer.get(), rng->handle(), sig_out.data(), &sig_len)) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        sig_out.resize(sig_len);
         return RNP_SUCCESS;
     }
     }
@@ -338,94 +346,101 @@ exdsa_public_key_t::verify(const std::vector<uint8_t> &sig,
         return ed448_verify_native(sig, key_, hash, hash_len);
     }
     default: {
-        Botan::ECDSA_PublicKey pub_key = exdsa_pubkey_from_bytes(key_, curve_);
-        auto verifier = Botan::PK_Verifier(pub_key, pgp::ecdsa::padding_str_for(hash_alg));
-        if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-            return RNP_SUCCESS;
+        rnp::botan::Pubkey pub_key;
+        if (!load_ec_pubkey(
+              pub_key, botan_pubkey_load_ecdsa_sec1, key_.data(), key_.size(), curve_)) {
+            return RNP_ERROR_SIGNATURE_INVALID;
         }
+        rnp::botan::op::Verify verifier;
+        const char *           pad = pgp::ecdsa::padding_str_for(hash_alg);
+        if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), pad, 0) ||
+            botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+            return RNP_ERROR_SIGNATURE_INVALID;
+        }
+        if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+            return RNP_ERROR_SIGNATURE_INVALID;
+        }
+        return RNP_SUCCESS;
     }
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
 }
 
 bool
 exdsa_public_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Pubkey pub_key;
+    bool               ok = false;
     switch (curve_) {
-    case PGP_CURVE_ED25519: {
-        Botan::Ed25519_PublicKey pub_key(key_);
-        return pub_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_ED25519:
+        ok = (key_.size() == 32) && !botan_pubkey_load_ed25519(&pub_key.get(), key_.data());
+        break;
+    case PGP_CURVE_ED448:
+        ok = (key_.size() == 57) && !botan_pubkey_load_ed448(&pub_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_pubkey(
+          pub_key, botan_pubkey_load_ecdsa_sec1, key_.data(), key_.size(), curve_);
+        break;
     }
-    case PGP_CURVE_ED448: {
-        Botan::Ed448_PublicKey pub_key(key_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    default: {
-        Botan::ECDSA_PublicKey pub_key = exdsa_pubkey_from_bytes(key_, curve_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_pubkey_check_key(pub_key.get(), rng->handle(), 0);
 }
 
 bool
 exdsa_private_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Privkey priv_key;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_ED25519: {
-        Botan::secure_vector<uint8_t> sv(key_.begin(), key_.end());
-        Botan::Ed25519_PrivateKey     priv_key(sv);
-        return priv_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_ED25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_ed25519(&priv_key.get(), key_.data());
+        break;
+    case PGP_CURVE_ED448:
+        ok = (key_.size() == 57) && !botan_privkey_load_ed448(&priv_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_privkey(
+          priv_key, botan_privkey_load_ecdsa, key_.data(), key_.size(), curve_);
+        break;
     }
-    case PGP_CURVE_ED448: {
-        Botan::Ed448_PrivateKey priv_key(key_);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    default: {
-        auto priv_key = exdsa_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_privkey_check_key(priv_key.get(), rng->handle(), 0);
 }
-#endif
 
 bool
 ecdh_kem_public_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Pubkey pub_key;
+    bool               ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        auto pub_key = x25519_pubkey_from_bytes(key_);
-        return pub_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_pubkey_load_x25519(&pub_key.get(), key_.data());
+        break;
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_pubkey_load_x448(&pub_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_pubkey(
+          pub_key, botan_pubkey_load_ecdh_sec1, key_.data(), key_.size(), curve_);
+        break;
     }
-#if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        auto pub_key = x448_pubkey_from_bytes(key_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-#endif
-    default: {
-        auto pub_key = ecdh_kem_pubkey_from_bytes(rng, key_, curve_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_pubkey_check_key(pub_key.get(), rng->handle(), 0);
 }
 
 bool
 ecdh_kem_private_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Privkey priv_key;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        auto priv_key = x25519_privkey_from_bytes(key_.data(), key_.size());
-        return priv_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv_key.get(), key_.data());
+        break;
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv_key.get(), key_.data());
+        break;
+    default:
+        ok =
+          load_ec_privkey(priv_key, botan_privkey_load_ecdh, key_.data(), key_.size(), curve_);
+        break;
     }
-#if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        auto priv_key = x448_privkey_from_bytes(key_.data(), key_.size());
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-#endif
-    default: {
-        auto priv_key = ecdh_kem_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_privkey_check_key(priv_key.get(), rng->handle(), 0);
 }

--- a/src/lib/crypto/exdsa_ecdhkem.cpp
+++ b/src/lib/crypto/exdsa_ecdhkem.cpp
@@ -4,7 +4,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -13,30 +13,21 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "exdsa_ecdhkem.h"
-#include <botan/secmem.h>
-#include <botan/pubkey.h>
-#include <botan/ecdh.h>
-#include <botan/ecdsa.h>
-#include <botan/ed25519.h>
-#include <botan/x25519.h>
-#if defined(ENABLE_CRYPTO_REFRESH)
-#include <botan/x448.h>
-#include <botan/ed448.h>
-#endif
-#include "ecdh.h"
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
 #include "ed25519_ed448.h"
 #include "ecdsa.h"
 #include "ec.h"
@@ -45,6 +36,64 @@
 #include "string.h"
 #include "utils.h"
 #include <cassert>
+
+namespace {
+
+const char *
+curve_botan_name(pgp_curve_t curve)
+{
+    auto ec_desc = pgp::ec::Curve::get(curve);
+    return ec_desc ? ec_desc->botan_name : nullptr;
+}
+
+bool
+load_ec_privkey(rnp::botan::Privkey &out,
+                int (*loader)(botan_privkey_t *, botan_mp_t, const char *),
+                const uint8_t *scalar,
+                size_t         scalar_len,
+                pgp_curve_t    curve)
+{
+    const char *name = curve_botan_name(curve);
+    if (!name) {
+        return false;
+    }
+    rnp::bn s(scalar, scalar_len);
+    return s && !loader(&out.get(), s.get(), name);
+}
+
+bool
+load_ec_pubkey(rnp::botan::Pubkey &out,
+               int (*loader)(botan_pubkey_t *, const uint8_t *, size_t, const char *),
+               const uint8_t *sec1,
+               size_t         sec1_len,
+               pgp_curve_t    curve)
+{
+    const char *name = curve_botan_name(curve);
+    if (!name) {
+        return false;
+    }
+    return !loader(&out.get(), sec1, sec1_len, name);
+}
+
+bool
+export_agreement_public(botan_privkey_t priv, std::vector<uint8_t> &out)
+{
+    /* The length query returns the size via out_len but signals it via
+     * BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE rather than success. */
+    size_t len = 0;
+    botan_pk_op_key_agreement_export_public(priv, nullptr, &len);
+    if (!len) {
+        return false;
+    }
+    out.resize(len);
+    if (botan_pk_op_key_agreement_export_public(priv, out.data(), &len)) {
+        return false;
+    }
+    out.resize(len);
+    return true;
+}
+
+} // namespace
 
 ec_key_t::~ec_key_t()
 {
@@ -76,77 +125,30 @@ ecdh_kem_private_key_t::ecdh_kem_private_key_t(std::vector<uint8_t> key, pgp_cur
 {
 }
 
-static Botan::ECDH_PrivateKey
-ecdh_kem_privkey_from_bytes(rnp::RNG *     rng,
-                            const uint8_t *key_data,
-                            size_t         key_size,
-                            pgp_curve_t    curve)
-{
-    assert(curve >= PGP_CURVE_NIST_P_256 && curve <= PGP_CURVE_P256K1);
-    auto ec_desc = pgp::ec::Curve::get(curve);
-    return Botan::ECDH_PrivateKey(*(rng->obj()),
-                                  Botan::EC_Group::from_name(ec_desc->botan_name),
-                                  Botan::BigInt(key_data, key_size));
-}
-
-static Botan::ECDH_PublicKey
-ecdh_kem_pubkey_from_bytes(rnp::RNG *rng, const std::vector<uint8_t> &key, pgp_curve_t curve)
-{
-    assert(curve >= PGP_CURVE_NIST_P_256 && curve <= PGP_CURVE_P256K1);
-    auto            ec_desc = pgp::ec::Curve::get(curve);
-    Botan::EC_Group group = Botan::EC_Group::from_name(ec_desc->botan_name);
-    return Botan::ECDH_PublicKey(group, Botan::EC_AffinePoint(group, key).to_legacy_point());
-}
-
-static Botan::X25519_PrivateKey
-x25519_privkey_from_bytes(const uint8_t *key_data, size_t key_size)
-{
-    Botan::secure_vector<uint8_t> sv(key_data, key_data + key_size);
-    return Botan::X25519_PrivateKey(sv);
-}
-
-static Botan::X25519_PublicKey
-x25519_pubkey_from_bytes(const std::vector<uint8_t> &key)
-{
-    return Botan::X25519_PublicKey(key);
-}
-
-#if defined(ENABLE_CRYPTO_REFRESH)
-static Botan::X448_PrivateKey
-x448_privkey_from_bytes(const uint8_t *key_data, size_t key_size)
-{
-    Botan::secure_vector<uint8_t> sv(key_data, key_data + key_size);
-    return Botan::X448_PrivateKey(sv);
-}
-
-static Botan::X448_PublicKey
-x448_pubkey_from_bytes(const std::vector<uint8_t> &key)
-{
-    return Botan::X448_PublicKey(key);
-}
-#endif
-
 std::vector<uint8_t>
 ecdh_kem_private_key_t::get_pubkey_encoded(rnp::RNG *rng) const
 {
+    (void) rng;
+    rnp::botan::Privkey priv;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey botan_key =
-          x25519_privkey_from_bytes(key_.data(), key_.size());
-        return botan_key.public_value();
-    }
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv.get(), key_.data());
+        break;
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey botan_key = x448_privkey_from_bytes(key_.data(), key_.size());
-        return botan_key.public_value();
-    }
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv.get(), key_.data());
+        break;
 #endif
-    default: {
-        Botan::ECDH_PrivateKey botan_key =
-          ecdh_kem_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        return botan_key.public_value();
+    default:
+        ok = load_ec_privkey(priv, botan_privkey_load_ecdh, key_.data(), key_.size(), curve_);
+        break;
     }
+    std::vector<uint8_t> out;
+    if (ok) {
+        export_agreement_public(priv.get(), out);
     }
+    return out;
 }
 
 rnp_result_t
@@ -154,38 +156,52 @@ ecdh_kem_public_key_t::encapsulate(rnp::RNG *            rng,
                                    std::vector<uint8_t> &ciphertext,
                                    std::vector<uint8_t> &symmetric_key) const
 {
+    const char *alg = nullptr;
+    const char *params = nullptr;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey eph_prv_key(*(rng->obj()));
-        ciphertext = eph_prv_key.public_value();
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    case PGP_CURVE_25519:
+        alg = "X25519";
         break;
-    }
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey eph_prv_key(*(rng->obj()));
-        ciphertext = eph_prv_key.public_value();
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    case PGP_CURVE_448:
+        alg = "X448";
         break;
-    }
 #endif
-    default: {
-        auto curve_desc = pgp::ec::Curve::get(curve_);
-        if (!curve_desc) {
-            RNP_LOG("unknown curve");
-            return RNP_ERROR_NOT_SUPPORTED;
-        }
-
-        Botan::EC_Group         domain = Botan::EC_Group::from_name(curve_desc->botan_name);
-        Botan::ECDH_PrivateKey  eph_prv_key(*(rng->obj()), domain);
-        Botan::PK_Key_Agreement key_agreement(eph_prv_key, *(rng->obj()), "Raw");
-        ciphertext = eph_prv_key.public_value();
-        symmetric_key = Botan::unlock(key_agreement.derive_key(0, key_).bits_of());
+    default:
+        alg = "ECDH";
+        params = curve_botan_name(curve_);
         break;
     }
+    if (!params && curve_ != PGP_CURVE_25519
+#if defined(ENABLE_CRYPTO_REFRESH)
+        && curve_ != PGP_CURVE_448
+#endif
+    ) {
+        return RNP_ERROR_NOT_SUPPORTED;
     }
+
+    rnp::botan::Privkey eph_prv;
+    if (botan_privkey_create(&eph_prv.get(), alg, params ? params : "", rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    if (!export_agreement_public(eph_prv.get(), ciphertext)) {
+        return RNP_ERROR_GENERIC;
+    }
+
+    rnp::botan::op::KeyAgreement op;
+    if (botan_pk_op_key_agreement_create(&op.get(), eph_prv.get(), "Raw", 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    size_t slen = 0;
+    if (botan_pk_op_key_agreement_size(op.get(), &slen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    symmetric_key.assign(slen, 0);
+    if (botan_pk_op_key_agreement(
+          op.get(), symmetric_key.data(), &slen, key_.data(), key_.size(), NULL, 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    symmetric_key.resize(slen);
     return RNP_SUCCESS;
 }
 
@@ -194,30 +210,40 @@ ecdh_kem_private_key_t::decapsulate(rnp::RNG *                  rng,
                                     const std::vector<uint8_t> &ciphertext,
                                     std::vector<uint8_t> &      plaintext)
 {
+    (void) rng;
+    rnp::botan::Privkey priv;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        Botan::X25519_PrivateKey priv_key =
-          x25519_privkey_from_bytes(key_.data(), key_.size());
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv.get(), key_.data());
         break;
-    }
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        Botan::X448_PrivateKey  priv_key = x448_privkey_from_bytes(key_.data(), key_.size());
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv.get(), key_.data());
         break;
-    }
 #endif
-    default: {
-        Botan::ECDH_PrivateKey priv_key =
-          ecdh_kem_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        Botan::PK_Key_Agreement key_agreement(priv_key, *(rng->obj()), "Raw");
-        plaintext = Botan::unlock(key_agreement.derive_key(0, ciphertext).bits_of());
+    default:
+        ok = load_ec_privkey(priv, botan_privkey_load_ecdh, key_.data(), key_.size(), curve_);
         break;
     }
+    if (!ok) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
+
+    rnp::botan::op::KeyAgreement op;
+    if (botan_pk_op_key_agreement_create(&op.get(), priv.get(), "Raw", 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    size_t slen = 0;
+    if (botan_pk_op_key_agreement_size(op.get(), &slen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    plaintext.assign(slen, 0);
+    if (botan_pk_op_key_agreement(
+          op.get(), plaintext.data(), &slen, ciphertext.data(), ciphertext.size(), NULL, 0)) {
+        return RNP_ERROR_GENERIC;
+    }
+    plaintext.resize(slen);
     return RNP_SUCCESS;
 }
 
@@ -274,27 +300,6 @@ ec_key_t::generate_exdsa_key_pair(rnp::RNG *rng, exdsa_key_t *out, pgp_curve_t c
     return RNP_SUCCESS;
 }
 
-static Botan::ECDSA_PrivateKey
-exdsa_privkey_from_bytes(rnp::RNG *     rng,
-                         const uint8_t *key_data,
-                         size_t         key_size,
-                         pgp_curve_t    curve)
-{
-    auto ec_desc = pgp::ec::Curve::get(curve);
-    return Botan::ECDSA_PrivateKey(*(rng->obj()),
-                                   Botan::EC_Group::from_name(ec_desc->botan_name),
-                                   Botan::BigInt(key_data, key_size));
-}
-
-static Botan::ECDSA_PublicKey
-exdsa_pubkey_from_bytes(const std::vector<uint8_t> &key, pgp_curve_t curve)
-{
-    /* format: 04 | X | Y */
-    auto            ec_desc = pgp::ec::Curve::get(curve);
-    Botan::EC_Group group = Botan::EC_Group::from_name(ec_desc->botan_name);
-    return Botan::ECDSA_PublicKey(group, Botan::EC_AffinePoint(group, key).to_legacy_point());
-}
-
 /* NOTE hash_alg unused for Ed/X curves */
 rnp_result_t
 exdsa_private_key_t::sign(rnp::RNG *            rng,
@@ -311,11 +316,26 @@ exdsa_private_key_t::sign(rnp::RNG *            rng,
         return ed448_sign_native(rng, sig_out, key_.unlock(), hash, hash_len);
     }
     default: {
-        Botan::ECDSA_PrivateKey priv_key =
-          exdsa_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        auto signer =
-          Botan::PK_Signer(priv_key, *(rng->obj()), pgp::ecdsa::padding_str_for(hash_alg));
-        sig_out = signer.sign_message(hash, hash_len, *(rng->obj()));
+        rnp::botan::Privkey priv_key;
+        if (!load_ec_privkey(
+              priv_key, botan_privkey_load_ecdsa, key_.data(), key_.size(), curve_)) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+        rnp::botan::op::Sign signer;
+        const char *         pad = pgp::ecdsa::padding_str_for(hash_alg);
+        if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), pad, 0) ||
+            botan_pk_op_sign_update(signer.get(), hash, hash_len)) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        size_t sig_len = 0;
+        if (botan_pk_op_sign_output_length(signer.get(), &sig_len) || !sig_len) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        sig_out.assign(sig_len, 0);
+        if (botan_pk_op_sign_finish(signer.get(), rng->handle(), sig_out.data(), &sig_len)) {
+            return RNP_ERROR_SIGNING_FAILED;
+        }
+        sig_out.resize(sig_len);
         return RNP_SUCCESS;
     }
     }
@@ -335,94 +355,106 @@ exdsa_public_key_t::verify(const std::vector<uint8_t> &sig,
         return ed448_verify_native(sig, key_, hash, hash_len);
     }
     default: {
-        Botan::ECDSA_PublicKey pub_key = exdsa_pubkey_from_bytes(key_, curve_);
-        auto verifier = Botan::PK_Verifier(pub_key, pgp::ecdsa::padding_str_for(hash_alg));
-        if (verifier.verify_message(hash, hash_len, sig.data(), sig.size())) {
-            return RNP_SUCCESS;
+        rnp::botan::Pubkey pub_key;
+        if (!load_ec_pubkey(
+              pub_key, botan_pubkey_load_ecdsa_sec1, key_.data(), key_.size(), curve_)) {
+            return RNP_ERROR_SIGNATURE_INVALID;
         }
+        rnp::botan::op::Verify verifier;
+        const char *           pad = pgp::ecdsa::padding_str_for(hash_alg);
+        if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), pad, 0) ||
+            botan_pk_op_verify_update(verifier.get(), hash, hash_len)) {
+            return RNP_ERROR_SIGNATURE_INVALID;
+        }
+        if (botan_pk_op_verify_finish(verifier.get(), sig.data(), sig.size())) {
+            return RNP_ERROR_SIGNATURE_INVALID;
+        }
+        return RNP_SUCCESS;
     }
     }
-    return RNP_ERROR_VERIFICATION_FAILED;
 }
 
 bool
 exdsa_public_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Pubkey pub_key;
+    bool               ok = false;
     switch (curve_) {
-    case PGP_CURVE_ED25519: {
-        Botan::Ed25519_PublicKey pub_key(key_);
-        return pub_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_ED25519:
+        ok = (key_.size() == 32) && !botan_pubkey_load_ed25519(&pub_key.get(), key_.data());
+        break;
+    case PGP_CURVE_ED448:
+        ok = (key_.size() == 57) && !botan_pubkey_load_ed448(&pub_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_pubkey(
+          pub_key, botan_pubkey_load_ecdsa_sec1, key_.data(), key_.size(), curve_);
+        break;
     }
-    case PGP_CURVE_ED448: {
-        Botan::Ed448_PublicKey pub_key(key_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    default: {
-        Botan::ECDSA_PublicKey pub_key = exdsa_pubkey_from_bytes(key_, curve_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_pubkey_check_key(pub_key.get(), rng->handle(), 0);
 }
 
 bool
 exdsa_private_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Privkey priv_key;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_ED25519: {
-        Botan::secure_vector<uint8_t> sv(key_.begin(), key_.end());
-        Botan::Ed25519_PrivateKey     priv_key(sv);
-        return priv_key.check_key(*(rng->obj()), false);
+    case PGP_CURVE_ED25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_ed25519(&priv_key.get(), key_.data());
+        break;
+    case PGP_CURVE_ED448:
+        ok = (key_.size() == 57) && !botan_privkey_load_ed448(&priv_key.get(), key_.data());
+        break;
+    default:
+        ok = load_ec_privkey(
+          priv_key, botan_privkey_load_ecdsa, key_.data(), key_.size(), curve_);
+        break;
     }
-    case PGP_CURVE_ED448: {
-        Botan::Ed448_PrivateKey priv_key(key_);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    default: {
-        auto priv_key = exdsa_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        return priv_key.check_key(*(rng->obj()), false);
-    }
-    }
+    return ok && !botan_privkey_check_key(priv_key.get(), rng->handle(), 0);
 }
 #endif
 
 bool
 ecdh_kem_public_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Pubkey pub_key;
+    bool               ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        auto pub_key = x25519_pubkey_from_bytes(key_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_pubkey_load_x25519(&pub_key.get(), key_.data());
+        break;
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        auto pub_key = x448_pubkey_from_bytes(key_);
-        return pub_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_pubkey_load_x448(&pub_key.get(), key_.data());
+        break;
 #endif
-    default: {
-        auto pub_key = ecdh_kem_pubkey_from_bytes(rng, key_, curve_);
-        return pub_key.check_key(*(rng->obj()), false);
+    default:
+        ok = load_ec_pubkey(
+          pub_key, botan_pubkey_load_ecdh_sec1, key_.data(), key_.size(), curve_);
+        break;
     }
-    }
+    return ok && !botan_pubkey_check_key(pub_key.get(), rng->handle(), 0);
 }
 
 bool
 ecdh_kem_private_key_t::is_valid(rnp::RNG *rng) const
 {
+    rnp::botan::Privkey priv_key;
+    bool                ok = false;
     switch (curve_) {
-    case PGP_CURVE_25519: {
-        auto priv_key = x25519_privkey_from_bytes(key_.data(), key_.size());
-        return priv_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_25519:
+        ok = (key_.size() == 32) && !botan_privkey_load_x25519(&priv_key.get(), key_.data());
+        break;
 #if defined(ENABLE_CRYPTO_REFRESH)
-    case PGP_CURVE_448: {
-        auto priv_key = x448_privkey_from_bytes(key_.data(), key_.size());
-        return priv_key.check_key(*(rng->obj()), false);
-    }
+    case PGP_CURVE_448:
+        ok = (key_.size() == 56) && !botan_privkey_load_x448(&priv_key.get(), key_.data());
+        break;
 #endif
-    default: {
-        auto priv_key = ecdh_kem_privkey_from_bytes(rng, key_.data(), key_.size(), curve_);
-        return priv_key.check_key(*(rng->obj()), false);
+    default:
+        ok =
+          load_ec_privkey(priv_key, botan_privkey_load_ecdh, key_.data(), key_.size(), curve_);
+        break;
     }
-    }
+    return ok && !botan_privkey_check_key(priv_key.get(), rng->handle(), 0);
 }

--- a/src/lib/crypto/hash.cpp
+++ b/src/lib/crypto/hash.cpp
@@ -3,25 +3,24 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
+ * modification, are permitted that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *    notice, this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "hash_botan.hpp"
@@ -53,13 +52,15 @@ Hash_Botan::Hash_Botan(pgp_hash_alg_t alg) : Hash(alg)
         throw rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
 
-    fn_ = Botan::HashFunction::create(name);
-    if (!fn_) {
+    if (botan_hash_init(&fn_, name, 0)) {
         RNP_LOG("Error creating hash object for '%s'", name);
+        fn_ = nullptr;
         throw rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
 
-    assert(size_ == fn_->output_length());
+    size_t outlen = 0;
+    botan_hash_output_length(fn_, &outlen);
+    assert(size_ == outlen);
 }
 
 Hash_Botan::Hash_Botan(const Hash_Botan &src) : Hash(src.alg_)
@@ -67,11 +68,16 @@ Hash_Botan::Hash_Botan(const Hash_Botan &src) : Hash(src.alg_)
     if (!src.fn_) {
         throw rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
-    fn_ = src.fn_->copy_state();
+    if (botan_hash_copy_state(&fn_, src.fn_)) {
+        throw rnp_exception(RNP_ERROR_GENERIC);
+    }
 }
 
 Hash_Botan::~Hash_Botan()
 {
+    if (fn_) {
+        botan_hash_destroy(fn_);
+    }
 }
 
 std::unique_ptr<Hash_Botan>
@@ -92,7 +98,9 @@ Hash_Botan::add(const void *buf, size_t len)
     if (!fn_) {
         throw rnp_exception(RNP_ERROR_NULL_POINTER);
     }
-    fn_->update(static_cast<const uint8_t *>(buf), len);
+    if (botan_hash_update(fn_, static_cast<const uint8_t *>(buf), len)) {
+        throw rnp_exception(RNP_ERROR_GENERIC);
+    }
 }
 
 void
@@ -103,8 +111,9 @@ Hash_Botan::finish(uint8_t *digest)
         return;
     }
     if (digest) {
-        fn_->final(digest);
+        botan_hash_final(fn_, digest);
     }
+    botan_hash_destroy(fn_);
     fn_ = nullptr;
     size_ = 0;
 }
@@ -117,16 +126,21 @@ Hash_Botan::name_backend(pgp_hash_alg_t alg)
 
 CRC24_Botan::CRC24_Botan()
 {
-    fn_ = Botan::HashFunction::create("CRC24");
-    if (!fn_) {
+    if (botan_hash_init(&fn_, "CRC24", 0)) {
         RNP_LOG("Error creating CRC24 object");
+        fn_ = nullptr;
         throw rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
-    assert(3 == fn_->output_length());
+    size_t outlen = 0;
+    botan_hash_output_length(fn_, &outlen);
+    assert(3 == outlen);
 }
 
 CRC24_Botan::~CRC24_Botan()
 {
+    if (fn_) {
+        botan_hash_destroy(fn_);
+    }
 }
 
 std::unique_ptr<CRC24_Botan>
@@ -141,7 +155,9 @@ CRC24_Botan::add(const void *buf, size_t len)
     if (!fn_) {
         throw rnp_exception(RNP_ERROR_NULL_POINTER);
     }
-    fn_->update(static_cast<const uint8_t *>(buf), len);
+    if (botan_hash_update(fn_, static_cast<const uint8_t *>(buf), len)) {
+        throw rnp_exception(RNP_ERROR_GENERIC);
+    }
 }
 
 std::array<uint8_t, 3>
@@ -151,7 +167,8 @@ CRC24_Botan::finish()
         throw rnp_exception(RNP_ERROR_NULL_POINTER);
     }
     std::array<uint8_t, 3> crc{};
-    fn_->final(crc.data());
+    botan_hash_final(fn_, crc.data());
+    botan_hash_destroy(fn_);
     fn_ = nullptr;
     return crc;
 }

--- a/src/lib/crypto/hash_botan.hpp
+++ b/src/lib/crypto/hash_botan.hpp
@@ -3,37 +3,36 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
+ * modification, are permitted that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *    notice, this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef CRYPTO_HASH_BOTAN_HPP_
 #define CRYPTO_HASH_BOTAN_HPP_
 
 #include "hash.hpp"
-#include <botan/hash.h>
+#include <botan/ffi.h>
 
 namespace rnp {
 class Hash_Botan : public Hash {
   private:
-    std::unique_ptr<Botan::HashFunction> fn_;
+    botan_hash_t fn_{nullptr};
 
     Hash_Botan(pgp_hash_alg_t alg);
     Hash_Botan(const Hash_Botan &src);
@@ -51,7 +50,7 @@ class Hash_Botan : public Hash {
 };
 
 class CRC24_Botan : public CRC24 {
-    std::unique_ptr<Botan::HashFunction> fn_;
+    botan_hash_t fn_{nullptr};
     CRC24_Botan();
 
   public:

--- a/src/lib/crypto/hkdf_botan.cpp
+++ b/src/lib/crypto/hkdf_botan.cpp
@@ -30,6 +30,9 @@
 
 #include "hkdf_botan.hpp"
 #include "hash_botan.hpp"
+#include "logging.h"
+#include "types.h"
+#include <botan/ffi.h>
 
 namespace rnp {
 
@@ -59,12 +62,18 @@ Hkdf_Botan::extract_expand(const uint8_t *salt,
                            uint8_t *      output_buf,
                            size_t         output_length)
 {
-    std::unique_ptr<Botan::KDF> kdf = Botan::KDF::create_or_throw(Hkdf_Botan::alg(), "");
-
-    Botan::secure_vector<uint8_t> OKM;
-    OKM = kdf->derive_key(output_length, ikm, ikm_len, salt, salt_len, info, info_len);
-
-    memcpy(output_buf, Botan::unlock(OKM).data(), output_length);
+    if (botan_kdf(Hkdf_Botan::alg().c_str(),
+                  output_buf,
+                  output_length,
+                  ikm,
+                  ikm_len,
+                  salt,
+                  salt_len,
+                  info,
+                  info_len)) {
+        RNP_LOG("HKDF derivation failed");
+        throw rnp_exception(RNP_ERROR_GENERIC);
+    }
 }
 
 Hkdf_Botan::~Hkdf_Botan()

--- a/src/lib/crypto/kyber.cpp
+++ b/src/lib/crypto/kyber.cpp
@@ -4,7 +4,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -13,34 +13,33 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "kyber.h"
-#include <botan/kyber.h>
-#include <botan/pubkey.h>
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
+#include "types.h"
+#include "logging.h"
 #include <utility>
 #include <vector>
 #include <cassert>
 
 namespace {
-Botan::KyberMode
-rnp_kyber_param_to_botan_kyber_mode(kyber_parameter_e mode)
+
+const char *
+kyber_mode_str(kyber_parameter_e mode)
 {
-    Botan::KyberMode result = Botan::KyberMode::ML_KEM_1024;
-    if (mode == kyber_768) {
-        result = Botan::KyberMode::ML_KEM_768;
-    }
-    return result;
+    return mode == kyber_768 ? "ML-KEM-768" : "ML-KEM-1024";
 }
 
 uint32_t
@@ -49,34 +48,33 @@ kyber_key_share_size()
     return 32;
 }
 
-Botan::Kyber_PublicKey
-kyber_pubkey_from_bytes(const std::vector<uint8_t> &key_encoded, kyber_parameter_e kyber_mode)
-{
-    return Botan::Kyber_PublicKey(key_encoded,
-                                  rnp_kyber_param_to_botan_kyber_mode(kyber_mode));
-}
-
-Botan::Kyber_PrivateKey
-kyber_privkey_from_bytes(const uint8_t *   key_data,
-                         size_t            key_size,
-                         kyber_parameter_e kyber_mode)
-{
-    Botan::secure_vector<uint8_t> key_sv(key_data, key_data + key_size);
-    return Botan::Kyber_PrivateKey(key_sv, rnp_kyber_param_to_botan_kyber_mode(kyber_mode));
-}
 } // namespace
 
 std::pair<pgp_kyber_public_key_t, pgp_kyber_private_key_t>
 kyber_generate_keypair(rnp::RNG *rng, kyber_parameter_e kyber_param)
 {
-    Botan::Kyber_PrivateKey kyber_priv(*rng->obj(),
-                                       rnp_kyber_param_to_botan_kyber_mode(kyber_param));
+    const char *mode = kyber_mode_str(kyber_param);
 
-    /* returns the two 32-byte values d and z of ML-KEM.KeyGen() */
-    Botan::secure_vector<uint8_t>      encoded_private_key = kyber_priv.private_key_bits();
-    std::unique_ptr<Botan::Public_Key> kyber_pub = kyber_priv.public_key();
+    rnp::botan::Privkey kyber_priv;
+    if (botan_privkey_create(&kyber_priv.get(), "ML-KEM", mode, rng->handle())) {
+        RNP_LOG("ML-KEM key generation failed");
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
 
-    std::vector<uint8_t> encoded_public_key = kyber_priv.public_key_bits();
+    std::vector<uint8_t> encoded_private_key;
+    if (botan_privkey_view_raw(
+          kyber_priv.get(), &encoded_private_key, rnp_botan_view_bin_vec)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    rnp::botan::Pubkey kyber_pub;
+    if (botan_privkey_export_pubkey(&kyber_pub.get(), kyber_priv.get())) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    std::vector<uint8_t> encoded_public_key;
+    if (botan_pubkey_view_raw(kyber_pub.get(), &encoded_public_key, rnp_botan_view_bin_vec)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
     return std::make_pair(pgp_kyber_public_key_t(encoded_public_key, kyber_param),
                           pgp_kyber_private_key_t(encoded_private_key.data(),
                                                   encoded_private_key.size(),
@@ -87,19 +85,41 @@ kyber_encap_result_t
 pgp_kyber_public_key_t::encapsulate(rnp::RNG *rng) const
 {
     assert(is_initialized_);
-    auto decoded_kyber_pub = kyber_pubkey_from_bytes(key_encoded_, kyber_mode_);
+    rnp::botan::Pubkey pub;
+    if (botan_pubkey_load_ml_kem(
+          &pub.get(), key_encoded_.data(), key_encoded_.size(), kyber_mode_str(kyber_mode_))) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
 
-    Botan::PK_KEM_Encryptor       kem_enc(decoded_kyber_pub, "Raw", "base");
-    Botan::secure_vector<uint8_t> encap_key;           // this has to go over the wire
-    Botan::secure_vector<uint8_t> data_encryption_key; // this is the key used for
-    // encryption of the payload data
-    kem_enc.encrypt(encap_key, data_encryption_key, *rng->obj(), kyber_key_share_size());
+    rnp::botan::op::KemEncrypt kem_enc;
+    if (botan_pk_op_kem_encrypt_create(&kem_enc.get(), pub.get(), "Raw")) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
+    size_t encap_len = 0;
+    size_t shared_len = 0;
+    if (botan_pk_op_kem_encrypt_encapsulated_key_length(kem_enc.get(), &encap_len) ||
+        botan_pk_op_kem_encrypt_shared_key_length(
+          kem_enc.get(), kyber_key_share_size(), &shared_len)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
     kyber_encap_result_t result;
-    result.ciphertext.insert(
-      result.ciphertext.end(), encap_key.data(), encap_key.data() + encap_key.size());
-    result.symmetric_key.insert(result.symmetric_key.end(),
-                                data_encryption_key.data(),
-                                data_encryption_key.data() + data_encryption_key.size());
+    result.ciphertext.assign(encap_len, 0);
+    result.symmetric_key.assign(shared_len, 0);
+    if (botan_pk_op_kem_encrypt_create_shared_key(kem_enc.get(),
+                                                  rng->handle(),
+                                                  NULL,
+                                                  0,
+                                                  kyber_key_share_size(),
+                                                  result.symmetric_key.data(),
+                                                  &shared_len,
+                                                  result.ciphertext.data(),
+                                                  &encap_len)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    result.ciphertext.resize(encap_len);
+    result.symmetric_key.resize(shared_len);
     return result;
 }
 
@@ -108,14 +128,39 @@ pgp_kyber_private_key_t::decapsulate(rnp::RNG *     rng,
                                      const uint8_t *ciphertext,
                                      size_t         ciphertext_len)
 {
+    (void) rng;
     assert(is_initialized_);
-    auto decoded_kyber_priv =
-      kyber_privkey_from_bytes(key_encoded_.data(), key_encoded_.size(), kyber_mode_);
-    Botan::PK_KEM_Decryptor       kem_dec(decoded_kyber_priv, *rng->obj(), "Raw", "base");
-    Botan::secure_vector<uint8_t> dec_shared_key =
-      kem_dec.decrypt(ciphertext, ciphertext_len, kyber_key_share_size());
-    return std::vector<uint8_t>(dec_shared_key.data(),
-                                dec_shared_key.data() + dec_shared_key.size());
+    rnp::botan::Privkey priv;
+    if (botan_privkey_load_ml_kem(&priv.get(),
+                                  key_encoded_.data(),
+                                  key_encoded_.size(),
+                                  kyber_mode_str(kyber_mode_))) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
+    rnp::botan::op::KemDecrypt kem_dec;
+    if (botan_pk_op_kem_decrypt_create(&kem_dec.get(), priv.get(), "Raw")) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
+    size_t shared_len = 0;
+    if (botan_pk_op_kem_decrypt_shared_key_length(
+          kem_dec.get(), kyber_key_share_size(), &shared_len)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    std::vector<uint8_t> shared(shared_len, 0);
+    if (botan_pk_op_kem_decrypt_shared_key(kem_dec.get(),
+                                           NULL,
+                                           0,
+                                           ciphertext,
+                                           ciphertext_len,
+                                           kyber_key_share_size(),
+                                           shared.data(),
+                                           &shared_len)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    shared.resize(shared_len);
+    return shared;
 }
 
 bool
@@ -124,9 +169,12 @@ pgp_kyber_public_key_t::is_valid(rnp::RNG *rng) const
     if (!is_initialized_) {
         return false;
     }
-
-    auto key = kyber_pubkey_from_bytes(key_encoded_, kyber_mode_);
-    return key.check_key(*(rng->obj()), false);
+    rnp::botan::Pubkey key;
+    if (botan_pubkey_load_ml_kem(
+          &key.get(), key_encoded_.data(), key_encoded_.size(), kyber_mode_str(kyber_mode_))) {
+        return false;
+    }
+    return !botan_pubkey_check_key(key.get(), rng->handle(), 0);
 }
 
 bool
@@ -135,7 +183,10 @@ pgp_kyber_private_key_t::is_valid(rnp::RNG *rng) const
     if (!is_initialized_) {
         return false;
     }
-
-    auto key = kyber_privkey_from_bytes(key_encoded_.data(), key_encoded_.size(), kyber_mode_);
-    return key.check_key(*(rng->obj()), false);
+    rnp::botan::Privkey key;
+    if (botan_privkey_load_ml_kem(
+          &key.get(), key_encoded_.data(), key_encoded_.size(), kyber_mode_str(kyber_mode_))) {
+        return false;
+    }
+    return !botan_privkey_check_key(key.get(), rng->handle(), 0);
 }

--- a/src/lib/crypto/kyber_ecdh_composite.cpp
+++ b/src/lib/crypto/kyber_ecdh_composite.cpp
@@ -31,8 +31,8 @@
 #include "ecdh_utils.h"
 #include "kem_combiner.hpp"
 #if defined(CRYPTO_BACKEND_BOTAN)
-#include <botan/rfc3394.h>
-#include <botan/symkey.h>
+#include <botan/ffi.h>
+#include <cstdio>
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 #include <openssl/evp.h>
 #include "ossl_utils.hpp"
@@ -361,19 +361,24 @@ pgp_kyber_ecdh_composite_private_key_t::decrypt(
                                    ecdh_kyber_pub_key.get_ecdh_encoded(),
                                    pk_alg());
 #if defined(CRYPTO_BACKEND_BOTAN)
-    Botan::SymmetricKey kek(kek_vec);
-    // Compute sessionKey := AESKeyUnwrap(KEK, C) with AES-256 as per [RFC3394], aborting if
-    // the 64 bit integrity check fails
-    Botan::secure_vector<uint8_t> tmp_out;
-    try {
-        tmp_out =
-          Botan::rfc3394_keyunwrap(Botan::secure_vector<uint8_t>(enc->wrapped_sesskey.begin(),
-                                                                 enc->wrapped_sesskey.end()),
-                                   kek);
-    } catch (const std::exception &e) {
-        RNP_LOG("Keyunwrap failed: %s", e.what());
+    /* Compute sessionKey := AESKeyUnwrap(KEK, C) with AES-256 as per [RFC3394],
+     * aborting if the 64 bit integrity check fails */
+    char name[16];
+    snprintf(name, sizeof(name), "AES-%zu", 8 * kek_vec.size());
+    std::vector<uint8_t> tmp_out(enc->wrapped_sesskey.size());
+    size_t               tmp_out_len = tmp_out.size();
+    if (botan_nist_kw_dec(name,
+                          0,
+                          enc->wrapped_sesskey.data(),
+                          enc->wrapped_sesskey.size(),
+                          kek_vec.data(),
+                          kek_vec.size(),
+                          tmp_out.data(),
+                          &tmp_out_len)) {
+        RNP_LOG("Keyunwrap failed");
         return RNP_ERROR_DECRYPT_FAILED;
     }
+    tmp_out.resize(tmp_out_len);
 
     if (*out_len < tmp_out.size()) {
         RNP_LOG("buffer for decryption result too small");
@@ -532,15 +537,25 @@ pgp_kyber_ecdh_composite_public_key_t::encrypt(rnp::RNG *                  rng,
                                                                 ecdh_key_.get_encoded(),
                                                                 pk_alg());
 #if defined(CRYPTO_BACKEND_BOTAN)
-    Botan::SymmetricKey kek(kek_vec);
-    // Compute C := AESKeyWrap(KEK, sessionKey) with AES-256 as per [RFC3394] that includes a
-    // 64 bit integrity check
-    try {
-        out->wrapped_sesskey = Botan::unlock(Botan::rfc3394_keywrap(
-          Botan::secure_vector<uint8_t>(session_key, session_key + session_key_len), kek));
-    } catch (const std::exception &e) {
-        RNP_LOG("Keywrap failed: %s", e.what());
-        return RNP_ERROR_ENCRYPT_FAILED;
+    /* Compute C := AESKeyWrap(KEK, sessionKey) with AES-256 as per [RFC3394],
+     * including the 64 bit integrity check */
+    {
+        char name[16];
+        snprintf(name, sizeof(name), "AES-%zu", 8 * kek_vec.size());
+        out->wrapped_sesskey.assign(session_key_len + 8, 0);
+        size_t wrapped_len = out->wrapped_sesskey.size();
+        if (botan_nist_kw_enc(name,
+                              0,
+                              session_key,
+                              session_key_len,
+                              kek_vec.data(),
+                              kek_vec.size(),
+                              out->wrapped_sesskey.data(),
+                              &wrapped_len)) {
+            RNP_LOG("Keywrap failed");
+            return RNP_ERROR_ENCRYPT_FAILED;
+        }
+        out->wrapped_sesskey.resize(wrapped_len);
     }
 #elif defined(CRYPTO_BACKEND_OPENSSL)
     // Compute C := AESKeyWrap(KEK, sessionKey) with AES-256 as per [RFC3394]

--- a/src/lib/crypto/mem.h
+++ b/src/lib/crypto/mem.h
@@ -31,8 +31,9 @@
 #include <array>
 #include <vector>
 #if defined(CRYPTO_BACKEND_BOTAN)
-#include <botan/secmem.h>
 #include <botan/ffi.h>
+#include <cstdlib>
+#include <type_traits>
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 #include <cstdlib>
 #include <openssl/crypto.h>
@@ -42,7 +43,49 @@
 namespace rnp {
 
 #if defined(CRYPTO_BACKEND_BOTAN)
-template <typename T> using secure_vector = Botan::secure_vector<T>;
+template <typename T> class secure_allocator {
+  public:
+#if !defined(_MSC_VER) || !defined(_DEBUG)
+    /* MSVC in debug mode uses non-integral proxy types in container types */
+    static_assert(std::is_integral<T>::value, "secure_vector can hold integral types only");
+#endif
+
+    typedef T           value_type;
+    typedef std::size_t size_type;
+
+    secure_allocator() noexcept = default;
+    secure_allocator(const secure_allocator &) noexcept = default;
+    secure_allocator &operator=(const secure_allocator &) noexcept = default;
+    ~secure_allocator() noexcept = default;
+
+    template <typename U> secure_allocator(const secure_allocator<U> &) noexcept
+    {
+    }
+
+    T *
+    allocate(std::size_t n)
+    {
+        if (!n) {
+            return nullptr;
+        }
+        T *ptr = static_cast<T *>(std::calloc(n, sizeof(T)));
+        if (!ptr)
+            throw std::bad_alloc();
+        return ptr;
+    }
+
+    void
+    deallocate(T *p, std::size_t n)
+    {
+        if (!p) {
+            return;
+        }
+        botan_scrub_mem(p, n * sizeof(T));
+        std::free(p);
+    }
+};
+
+template <typename T> using secure_vector = std::vector<T, secure_allocator<T> >;
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 template <typename T> class ossl_allocator {
   public:

--- a/src/lib/crypto/mem.h
+++ b/src/lib/crypto/mem.h
@@ -31,8 +31,9 @@
 #include <array>
 #include <vector>
 #if defined(CRYPTO_BACKEND_BOTAN)
-#include <botan/secmem.h>
 #include <botan/ffi.h>
+#include <cstdlib>
+#include <type_traits>
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 #include <openssl/crypto.h>
 #endif
@@ -41,7 +42,49 @@
 namespace rnp {
 
 #if defined(CRYPTO_BACKEND_BOTAN)
-template <typename T> using secure_vector = Botan::secure_vector<T>;
+template <typename T> class secure_allocator {
+  public:
+#if !defined(_MSC_VER) || !defined(_DEBUG)
+    /* MSVC in debug mode uses non-integral proxy types in container types */
+    static_assert(std::is_integral<T>::value, "secure_vector can hold integral types only");
+#endif
+
+    typedef T           value_type;
+    typedef std::size_t size_type;
+
+    secure_allocator() noexcept = default;
+    secure_allocator(const secure_allocator &) noexcept = default;
+    secure_allocator &operator=(const secure_allocator &) noexcept = default;
+    ~secure_allocator() noexcept = default;
+
+    template <typename U> secure_allocator(const secure_allocator<U> &) noexcept
+    {
+    }
+
+    T *
+    allocate(std::size_t n)
+    {
+        if (!n) {
+            return nullptr;
+        }
+        T *ptr = static_cast<T *>(std::calloc(n, sizeof(T)));
+        if (!ptr)
+            throw std::bad_alloc();
+        return ptr;
+    }
+
+    void
+    deallocate(T *p, std::size_t n)
+    {
+        if (!p) {
+            return;
+        }
+        botan_scrub_mem(p, n * sizeof(T));
+        std::free(p);
+    }
+};
+
+template <typename T> using secure_vector = std::vector<T, secure_allocator<T> >;
 #elif defined(CRYPTO_BACKEND_OPENSSL)
 template <typename T> class ossl_allocator {
   public:

--- a/src/lib/crypto/rng.cpp
+++ b/src/lib/crypto/rng.cpp
@@ -35,13 +35,6 @@ RNG::RNG(Type type)
     if (botan_rng_init(&botan_rng, type == Type::DRBG ? "user" : NULL)) {
         throw rnp::rnp_exception(RNP_ERROR_RNG);
     }
-#if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
-    if (type == Type::DRBG) {
-        botan_rng_obj.reset(new Botan::AutoSeeded_RNG);
-    } else {
-        botan_rng_obj.reset(new Botan::System_RNG);
-    }
-#endif
 }
 
 RNG::~RNG()
@@ -63,12 +56,4 @@ RNG::handle()
 {
     return botan_rng;
 }
-
-#if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
-Botan::RandomNumberGenerator *
-RNG::obj() const
-{
-    return botan_rng_obj.get();
-}
-#endif
 } // namespace rnp

--- a/src/lib/crypto/rng.h
+++ b/src/lib/crypto/rng.h
@@ -34,11 +34,6 @@
 
 #ifdef CRYPTO_BACKEND_BOTAN
 typedef struct botan_rng_struct *botan_rng_t;
-
-#if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
-#include <botan/system_rng.h>
-#include <botan/auto_rng.h>
-#endif
 #endif
 
 namespace rnp {
@@ -46,9 +41,6 @@ class RNG {
   private:
 #ifdef CRYPTO_BACKEND_BOTAN
     struct botan_rng_struct *botan_rng;
-#if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
-    std::unique_ptr<Botan::RandomNumberGenerator> botan_rng_obj;
-#endif
 #endif
   public:
     enum Type { DRBG, System };
@@ -79,15 +71,6 @@ class RNG {
      *          internal error NULL is returned
      */
     struct botan_rng_struct *handle();
-
-#if defined(ENABLE_CRYPTO_REFRESH) || defined(ENABLE_PQC)
-    /**
-     * @brief Returns the Botan RNG C++ object
-     *        Note: It is planned to move away from the FFI handle.
-     *        For the transition phase, both approaches are implemented.
-     */
-    Botan::RandomNumberGenerator *obj() const;
-#endif
 #endif
 };
 } // namespace rnp

--- a/src/lib/crypto/s2k.cpp
+++ b/src/lib/crypto/s2k.cpp
@@ -44,7 +44,6 @@
 #ifdef CRYPTO_BACKEND_BOTAN
 #if defined(ENABLE_CRYPTO_REFRESH)
 #include "botan/bigint.h"
-#include <botan/pwdhash.h>
 #include <cmath>
 #endif
 #include <botan/ffi.h>
@@ -127,15 +126,17 @@ pgp_s2k_argon2(uint8_t *      out,
         return -1;
     }
 
-    try {
-        auto pwdhash_fam = Botan::PasswordHashFamily::create_or_throw("Argon2id");
-
-        std::unique_ptr<Botan::PasswordHash> pwhash =
-          pwdhash_fam->from_params(((size_t) 1) << encoded_m, t, p);
-        pwhash->derive_key(
-          out, output_len, password, std::strlen(password), salt, argon2_salt_size);
-    } catch (const std::exception &e) {
-        RNP_LOG("%s", e.what());
+    if (botan_pwdhash("Argon2id",
+                      ((size_t) 1) << encoded_m,
+                      t,
+                      p,
+                      out,
+                      output_len,
+                      password,
+                      std::strlen(password),
+                      salt,
+                      argon2_salt_size)) {
+        RNP_LOG("Argon2 key derivation failed");
         return -1;
     }
     return 0;

--- a/src/lib/crypto/sphincsplus.cpp
+++ b/src/lib/crypto/sphincsplus.cpp
@@ -4,7 +4,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -13,57 +13,44 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "sphincsplus.h"
-#include <botan/slh_dsa.h>
-#include <botan/pubkey.h>
+#include <botan/ffi.h>
+#include "botan_utils.hpp"
 #include <cassert>
 #include "logging.h"
 #include "types.h"
 
 namespace {
-Botan::SLH_DSA_Parameter_Set
-rnp_sphincsplus_alg_to_botan_param(pgp_pubkey_alg_t alg)
+
+/* SLH-DSA mode string for Botan's FFI (SHAKE variants used by rnp). */
+const char *
+sphincsplus_mode_str(pgp_pubkey_alg_t alg)
 {
     switch (alg) {
     case PGP_PKA_SPHINCSPLUS_SHAKE_128f:
-        return Botan::SLH_DSA_Parameter_Set::SLHDSA128Fast;
+        return "SLH-DSA-SHAKE-128f";
     case PGP_PKA_SPHINCSPLUS_SHAKE_128s:
-        return Botan::SLH_DSA_Parameter_Set::SLHDSA128Small;
+        return "SLH-DSA-SHAKE-128s";
     case PGP_PKA_SPHINCSPLUS_SHAKE_256s:
-        return Botan::SLH_DSA_Parameter_Set::SLHDSA256Small;
+        return "SLH-DSA-SHAKE-256s";
     default:
         RNP_LOG("invalid algorithm ID given");
         throw rnp::rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
 }
 
-Botan::SLH_DSA_PublicKey
-sphincsplus_pubkey_from_bytes(const std::vector<uint8_t> &key_encoded, pgp_pubkey_alg_t alg)
-{
-    return Botan::SLH_DSA_PublicKey(key_encoded,
-                                    rnp_sphincsplus_alg_to_botan_param(alg),
-                                    Botan::SLH_DSA_Hash_Type::Shake256);
-}
-
-Botan::SLH_DSA_PrivateKey
-sphincsplus_privkey_from_bytes(const uint8_t *key_data, size_t key_size, pgp_pubkey_alg_t alg)
-{
-    Botan::secure_vector<uint8_t> priv_sv(key_data, key_data + key_size);
-    return Botan::SLH_DSA_PrivateKey(
-      priv_sv, rnp_sphincsplus_alg_to_botan_param(alg), Botan::SLH_DSA_Hash_Type::Shake256);
-}
 } // namespace
 
 pgp_sphincsplus_public_key_t::pgp_sphincsplus_public_key_t(const uint8_t *  key_encoded,
@@ -101,12 +88,30 @@ pgp_sphincsplus_private_key_t::sign(rnp::RNG *                   rng,
                                     size_t                       msg_len) const
 {
     assert(is_initialized_);
-    auto priv_key =
-      sphincsplus_privkey_from_bytes(key_encoded_.data(), key_encoded_.size(), pk_alg_);
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_load_slh_dsa(&priv_key.get(),
+                                   key_encoded_.data(),
+                                   key_encoded_.size(),
+                                   sphincsplus_mode_str(pk_alg_))) {
+        RNP_LOG("Failed to load SLH-DSA private key");
+        return RNP_ERROR_GENERIC;
+    }
 
-    auto signer = Botan::PK_Signer(priv_key, *rng->obj(), "");
-    sig->sig = signer.sign_message(msg, msg_len, *rng->obj());
-
+    rnp::botan::op::Sign signer;
+    if (botan_pk_op_sign_create(&signer.get(), priv_key.get(), "", 0) ||
+        botan_pk_op_sign_update(signer.get(), msg, msg_len)) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    size_t sig_len = 0;
+    if (botan_pk_op_sign_output_length(signer.get(), &sig_len) || !sig_len) {
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    sig->sig.assign(sig_len, 0);
+    if (botan_pk_op_sign_finish(signer.get(), rng->handle(), sig->sig.data(), &sig_len)) {
+        RNP_LOG("SLH-DSA signing failed");
+        return RNP_ERROR_SIGNING_FAILED;
+    }
+    sig->sig.resize(sig_len);
     return RNP_SUCCESS;
 }
 
@@ -116,26 +121,52 @@ pgp_sphincsplus_public_key_t::verify(const pgp_sphincsplus_signature_t *sig,
                                      size_t                             msg_len) const
 {
     assert(is_initialized_);
-    auto pub_key = sphincsplus_pubkey_from_bytes(key_encoded_, pk_alg_);
-
-    auto verificator = Botan::PK_Verifier(pub_key, "");
-    if (verificator.verify_message(msg, msg_len, sig->sig.data(), sig->sig.size())) {
-        return RNP_SUCCESS;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_slh_dsa(&pub_key.get(),
+                                  key_encoded_.data(),
+                                  key_encoded_.size(),
+                                  sphincsplus_mode_str(pk_alg_))) {
+        RNP_LOG("Failed to load SLH-DSA public key");
+        return RNP_ERROR_SIGNATURE_INVALID;
     }
-    return RNP_ERROR_SIGNATURE_INVALID;
+
+    rnp::botan::op::Verify verifier;
+    if (botan_pk_op_verify_create(&verifier.get(), pub_key.get(), "", 0) ||
+        botan_pk_op_verify_update(verifier.get(), msg, msg_len)) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    if (botan_pk_op_verify_finish(verifier.get(), sig->sig.data(), sig->sig.size())) {
+        return RNP_ERROR_SIGNATURE_INVALID;
+    }
+    return RNP_SUCCESS;
 }
 
 std::pair<pgp_sphincsplus_public_key_t, pgp_sphincsplus_private_key_t>
 sphincsplus_generate_keypair(rnp::RNG *rng, pgp_pubkey_alg_t alg)
 {
-    Botan::SLH_DSA_PrivateKey priv_key(*rng->obj(),
-                                       rnp_sphincsplus_alg_to_botan_param(alg),
-                                       Botan::SLH_DSA_Hash_Type::Shake256);
+    const char *mode = sphincsplus_mode_str(alg);
 
-    std::unique_ptr<Botan::Public_Key> pub_key = priv_key.public_key();
-    Botan::secure_vector<uint8_t>      priv_bits = priv_key.private_key_bits();
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_create(&priv_key.get(), "SLH-DSA", mode, rng->handle())) {
+        RNP_LOG("SLH-DSA key generation failed");
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
+    std::vector<uint8_t> priv_bits;
+    if (botan_privkey_view_raw(priv_key.get(), &priv_bits, rnp_botan_view_bin_vec)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    rnp::botan::Pubkey pub_key;
+    if (botan_privkey_export_pubkey(&pub_key.get(), priv_key.get())) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+    std::vector<uint8_t> pub_bits;
+    if (botan_pubkey_view_raw(pub_key.get(), &pub_bits, rnp_botan_view_bin_vec)) {
+        throw rnp::rnp_exception(RNP_ERROR_GENERIC);
+    }
+
     return std::make_pair(
-      pgp_sphincsplus_public_key_t(pub_key->public_key_bits(), alg),
+      pgp_sphincsplus_public_key_t(pub_bits, alg),
       pgp_sphincsplus_private_key_t(priv_bits.data(), priv_bits.size(), alg));
 }
 
@@ -155,9 +186,14 @@ pgp_sphincsplus_public_key_t::is_valid(rnp::RNG *rng) const
     if (!is_initialized_) {
         return false;
     }
-
-    auto key = sphincsplus_pubkey_from_bytes(key_encoded_, pk_alg_);
-    return key.check_key(*(rng->obj()), false);
+    rnp::botan::Pubkey key;
+    if (botan_pubkey_load_slh_dsa(&key.get(),
+                                  key_encoded_.data(),
+                                  key_encoded_.size(),
+                                  sphincsplus_mode_str(pk_alg_))) {
+        return false;
+    }
+    return !botan_pubkey_check_key(key.get(), rng->handle(), 0);
 }
 
 bool
@@ -166,10 +202,14 @@ pgp_sphincsplus_private_key_t::is_valid(rnp::RNG *rng) const
     if (!is_initialized_) {
         return false;
     }
-
-    auto key =
-      sphincsplus_privkey_from_bytes(key_encoded_.data(), key_encoded_.size(), pk_alg_);
-    return key.check_key(*(rng->obj()), false);
+    rnp::botan::Privkey key;
+    if (botan_privkey_load_slh_dsa(&key.get(),
+                                   key_encoded_.data(),
+                                   key_encoded_.size(),
+                                   sphincsplus_mode_str(pk_alg_))) {
+        return false;
+    }
+    return !botan_privkey_check_key(key.get(), rng->handle(), 0);
 }
 
 rnp_result_t

--- a/src/lib/crypto/x25519_x448.cpp
+++ b/src/lib/crypto/x25519_x448.cpp
@@ -3,7 +3,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * are permitted that the following conditions are met:
  *
  * 1.  Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -12,27 +12,26 @@
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "x25519_x448.h"
-#include <botan/x25519.h>
-#if defined(ENABLE_CRYPTO_REFRESH)
-#include <botan/x448.h>
-#endif
 #include "exdsa_ecdhkem.h"
 #include "hkdf.hpp"
 #include "utils.h"
-#include "botan/rfc3394.h"
+#include "botan_utils.hpp"
+#include <botan/ffi.h>
+#include <cstdio>
+#include <string.h>
 
 static const std::vector<uint8_t> hkdf_x25519_info_str = {
   'O', 'p', 'e', 'n', 'P', 'G', 'P', ' ', 'X', '2', '5', '5', '1', '9'};
@@ -70,6 +69,41 @@ x_hkdf(std::vector<uint8_t> &      derived_key,
                         derived_key.size());
 }
 
+/* AES key wrap (RFC 3394) with the KEK length selecting the AES variant. */
+static rnp_result_t
+aes_kw_enc(const std::vector<uint8_t> &kek,
+           const uint8_t *             in,
+           size_t                      in_len,
+           std::vector<uint8_t> &      out)
+{
+    char name[16];
+    snprintf(name, sizeof(name), "AES-%zu", 8 * kek.size());
+    out.resize(in_len + 8);
+    size_t out_len = out.size();
+    if (botan_nist_kw_enc(name, 0, in, in_len, kek.data(), kek.size(), out.data(), &out_len)) {
+        return RNP_ERROR_ENCRYPT_FAILED;
+    }
+    out.resize(out_len);
+    return RNP_SUCCESS;
+}
+
+static rnp_result_t
+aes_kw_dec(const std::vector<uint8_t> &kek,
+           const uint8_t *             in,
+           size_t                      in_len,
+           std::vector<uint8_t> &      out)
+{
+    char name[16];
+    snprintf(name, sizeof(name), "AES-%zu", 8 * kek.size());
+    out.resize(in_len);
+    size_t out_len = out.size();
+    if (botan_nist_kw_dec(name, 0, in, in_len, kek.data(), kek.size(), out.data(), &out_len)) {
+        return RNP_ERROR_DECRYPT_FAILED;
+    }
+    out.resize(out_len);
+    return RNP_SUCCESS;
+}
+
 rnp_result_t
 x25519_native_encrypt(rnp::RNG *                  rng,
                       const std::vector<uint8_t> &pubkey,
@@ -96,16 +130,7 @@ x25519_native_encrypt(rnp::RNG *                  rng,
 
     x_hkdf(derived_key, encrypted->eph_key, pubkey, shared_key, hkdf_x25519_info_str);
 
-    Botan::SymmetricKey kek(derived_key);
-    try {
-        encrypted->enc_sess_key = Botan::unlock(
-          Botan::rfc3394_keywrap(Botan::secure_vector<uint8_t>(in, in + in_len), kek));
-    } catch (const std::exception &e) {
-        RNP_LOG("Keywrap failed: %s", e.what());
-        return RNP_ERROR_ENCRYPT_FAILED;
-    }
-
-    return RNP_SUCCESS;
+    return aes_kw_enc(derived_key, in, in_len, encrypted->enc_sess_key);
 }
 
 rnp_result_t
@@ -125,7 +150,6 @@ x25519_native_decrypt(rnp::RNG *                    rng,
         return RNP_ERROR_BAD_FORMAT;
     }
     if (!encrypted->enc_sess_key.size()) {
-        // TODO: could do a check for possible sizes
         RNP_LOG("No encrypted session key provided");
         return RNP_ERROR_BAD_FORMAT;
     }
@@ -140,11 +164,12 @@ x25519_native_decrypt(rnp::RNG *                    rng,
 
     x_hkdf(derived_key, encrypted->eph_key, keypair.pub, shared_key, hkdf_x25519_info_str);
 
-    Botan::SymmetricKey kek(derived_key);
-    auto                tmp_out =
-      Botan::rfc3394_keyunwrap(Botan::secure_vector<uint8_t>(encrypted->enc_sess_key.begin(),
-                                                             encrypted->enc_sess_key.end()),
-                               kek);
+    std::vector<uint8_t> tmp_out;
+    ret = aes_kw_dec(
+      derived_key, encrypted->enc_sess_key.data(), encrypted->enc_sess_key.size(), tmp_out);
+    if (ret != RNP_SUCCESS) {
+        return ret;
+    }
     if (*decbuf_len < tmp_out.size()) {
         RNP_LOG("buffer for decryption result too small");
         return RNP_ERROR_DECRYPT_FAILED;
@@ -158,22 +183,22 @@ x25519_native_decrypt(rnp::RNG *                    rng,
 rnp_result_t
 x25519_validate_key_native(rnp::RNG *rng, const pgp_x25519_key_t *key, bool secret)
 {
-    bool valid_pub;
-    bool valid_priv;
-
-    Botan::X25519_PublicKey pub_key(key->priv);
-    valid_pub = pub_key.check_key(*(rng->obj()), false);
-
-    if (secret) {
-        Botan::X25519_PrivateKey priv_key(
-          Botan::secure_vector<uint8_t>(key->priv.begin(), key->priv.end()));
-        valid_priv = priv_key.check_key(*(rng->obj()), false);
-    } else {
-        valid_priv = true;
+    if (key->priv.size() != 32) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-
-    // check key returns true for successful check
-    return (valid_pub && valid_priv) ? RNP_SUCCESS : RNP_ERROR_BAD_PARAMETERS;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_x25519(&pub_key.get(), key->priv.data()) ||
+        botan_pubkey_check_key(pub_key.get(), rng->handle(), 0)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    if (secret) {
+        rnp::botan::Privkey priv_key;
+        if (botan_privkey_load_x25519(&priv_key.get(), key->priv.data()) ||
+            botan_privkey_check_key(priv_key.get(), rng->handle(), 0)) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+    }
+    return RNP_SUCCESS;
 }
 
 rnp_result_t
@@ -181,10 +206,23 @@ generate_x25519_native(rnp::RNG *            rng,
                        std::vector<uint8_t> &privkey,
                        std::vector<uint8_t> &pubkey)
 {
-    Botan::X25519_PrivateKey priv_key(*(rng->obj()));
-    pubkey = priv_key.public_value();
-    privkey = Botan::unlock(priv_key.raw_private_key_bits());
-
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_create(&priv_key.get(), "X25519", NULL, rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    /* public value (32 bytes) */
+    pubkey.assign(32, 0);
+    size_t publen = pubkey.size();
+    if (botan_pk_op_key_agreement_export_public(priv_key.get(), pubkey.data(), &publen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    pubkey.resize(publen);
+    /* private scalar (32 bytes) */
+    privkey.assign(32, 0);
+    rnp_botan_view_buf vb{privkey.data(), privkey.size()};
+    if (botan_privkey_view_raw(priv_key.get(), &vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_GENERIC;
+    }
     return RNP_SUCCESS;
 }
 
@@ -194,9 +232,21 @@ generate_x448_native(rnp::RNG *            rng,
                      std::vector<uint8_t> &privkey,
                      std::vector<uint8_t> &pubkey)
 {
-    Botan::X448_PrivateKey priv_key(*(rng->obj()));
-    pubkey = priv_key.public_value();
-    privkey = Botan::unlock(priv_key.raw_private_key_bits());
+    rnp::botan::Privkey priv_key;
+    if (botan_privkey_create(&priv_key.get(), "X448", NULL, rng->handle())) {
+        return RNP_ERROR_GENERIC;
+    }
+    pubkey.assign(56, 0);
+    size_t publen = pubkey.size();
+    if (botan_pk_op_key_agreement_export_public(priv_key.get(), pubkey.data(), &publen)) {
+        return RNP_ERROR_GENERIC;
+    }
+    pubkey.resize(publen);
+    privkey.assign(56, 0);
+    rnp_botan_view_buf vb{privkey.data(), privkey.size()};
+    if (botan_privkey_view_raw(priv_key.get(), &vb, rnp_botan_view_bin)) {
+        return RNP_ERROR_GENERIC;
+    }
     return RNP_SUCCESS;
 }
 
@@ -216,7 +266,6 @@ x448_native_encrypt(rnp::RNG *                  rng,
         return RNP_ERROR_BAD_FORMAT;
     }
 
-    /* encapsulation */
     ecdh_kem_public_key_t ecdhkem_pubkey(pubkey, PGP_CURVE_448);
     ret = ecdhkem_pubkey.encapsulate(rng, encrypted->eph_key, shared_key);
     if (ret != RNP_SUCCESS) {
@@ -226,16 +275,7 @@ x448_native_encrypt(rnp::RNG *                  rng,
 
     x_hkdf(derived_key, encrypted->eph_key, pubkey, shared_key, hkdf_x448_info_str);
 
-    Botan::SymmetricKey kek(derived_key);
-    try {
-        encrypted->enc_sess_key = Botan::unlock(
-          Botan::rfc3394_keywrap(Botan::secure_vector<uint8_t>(in, in + in_len), kek));
-    } catch (const std::exception &e) {
-        RNP_LOG("Keywrap failed: %s", e.what());
-        return RNP_ERROR_ENCRYPT_FAILED;
-    }
-
-    return RNP_SUCCESS;
+    return aes_kw_enc(derived_key, in, in_len, encrypted->enc_sess_key);
 }
 
 rnp_result_t
@@ -255,12 +295,10 @@ x448_native_decrypt(rnp::RNG *                  rng,
         return RNP_ERROR_BAD_FORMAT;
     }
     if (!encrypted->enc_sess_key.size()) {
-        // TODO: could do a check for possible sizes
         RNP_LOG("No encrypted session key provided");
         return RNP_ERROR_BAD_FORMAT;
     }
 
-    /* decapsulate */
     ecdh_kem_private_key_t ecdhkem_privkey(keypair.priv, PGP_CURVE_448);
     ret = ecdhkem_privkey.decapsulate(rng, encrypted->eph_key, shared_key);
     if (ret != RNP_SUCCESS) {
@@ -270,11 +308,12 @@ x448_native_decrypt(rnp::RNG *                  rng,
 
     x_hkdf(derived_key, encrypted->eph_key, keypair.pub, shared_key, hkdf_x448_info_str);
 
-    Botan::SymmetricKey kek(derived_key);
-    auto                tmp_out =
-      Botan::rfc3394_keyunwrap(Botan::secure_vector<uint8_t>(encrypted->enc_sess_key.begin(),
-                                                             encrypted->enc_sess_key.end()),
-                               kek);
+    std::vector<uint8_t> tmp_out;
+    ret = aes_kw_dec(
+      derived_key, encrypted->enc_sess_key.data(), encrypted->enc_sess_key.size(), tmp_out);
+    if (ret != RNP_SUCCESS) {
+        return ret;
+    }
     if (*decbuf_len < tmp_out.size()) {
         RNP_LOG("buffer for decryption result too small");
         return RNP_ERROR_DECRYPT_FAILED;
@@ -288,21 +327,21 @@ x448_native_decrypt(rnp::RNG *                  rng,
 rnp_result_t
 x448_validate_key_native(rnp::RNG *rng, const pgp_x448_key_t *key, bool secret)
 {
-    bool valid_pub;
-    bool valid_priv;
-
-    Botan::X448_PublicKey pub_key(key->priv);
-    valid_pub = pub_key.check_key(*(rng->obj()), false);
-
-    if (secret) {
-        Botan::X448_PrivateKey priv_key(
-          Botan::secure_vector<uint8_t>(key->priv.begin(), key->priv.end()));
-        valid_priv = priv_key.check_key(*(rng->obj()), false);
-    } else {
-        valid_priv = true;
+    if (key->priv.size() != 56) {
+        return RNP_ERROR_BAD_PARAMETERS;
     }
-
-    // check key returns true for successful check
-    return (valid_pub && valid_priv) ? RNP_SUCCESS : RNP_ERROR_BAD_PARAMETERS;
+    rnp::botan::Pubkey pub_key;
+    if (botan_pubkey_load_x448(&pub_key.get(), key->priv.data()) ||
+        botan_pubkey_check_key(pub_key.get(), rng->handle(), 0)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    if (secret) {
+        rnp::botan::Privkey priv_key;
+        if (botan_privkey_load_x448(&priv_key.get(), key->priv.data()) ||
+            botan_privkey_check_key(priv_key.get(), rng->handle(), 0)) {
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+    }
+    return RNP_SUCCESS;
 }
 #endif


### PR DESCRIPTION
## Summary

Migrates the **Botan backend** off Botan's C++ API and onto the stable C FFI (`botan_*`), matching rnp's existing FFI discipline (which is what keeps rnp working across Botan 2.x/3.x). **Stacks on #2392** (`pqc-openssl`). Fixes the Botan 3.12 build breakage on that branch (native include-hygiene errors + deprecations).

All migrated files contain **zero** `Botan::` references:

- **Crypto-refresh / PQC** (CMake-gated to Botan 3.6+): `ec.cpp` (`ec_generate_generic_native`), `ed25519_ed448.cpp`, `x25519_x448.cpp`, `exdsa_ecdhkem.cpp`, `dilithium.cpp` (ML-DSA), `kyber.cpp` (ML-KEM), `sphincsplus.cpp` (SLH-DSA), `kyber_ecdh_composite.cpp` (RFC 3394 keywrap → `botan_nist_kw_*`), `botan_utils.hpp` (view callback + KEM op RAII wrappers)
- **Always-compiled core** (Botan 2.14+): `hash.cpp`/`hash_botan.hpp` (incl. CRC24 → `botan_hash_*`), `hkdf_botan.cpp` (`botan_kdf`), `s2k.cpp` (Argon2id → `botan_pwdhash`), `elgamal.cpp` (`botan_mp_*`/`botan_mp_powmod`), `backend_version.cpp` (`botan_version_*`), `rng.cpp`/`rng.h` (dropped the `Botan::RandomNumberGenerator` exposure; opaque `botan_rng_t` handle), `mem.h` (`rnp::secure_allocator` replacing `Botan::secure_vector`), and the always-compiled `ec.cpp`/`eddsa.cpp` keygen paths → `botan_*_view_raw`

OpenSSL-side `*_ossl.cpp` files are untouched.

## Version compatibility

rnp supports Botan 2.14 → 3.x, so any FFI symbol added after 2.14 is behind a version gate with an older-Botan fallback — the same pattern rnp already uses (e.g. `ecdh.cpp` for `botan_nist_kw_*`):
- `ec.cpp` `Key::generate_x25519` and `eddsa.cpp` `generate`: `#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3,6,0)` → `botan_*_view_raw`; `#else` → the legacy `botan_*_get_*` getters (2.x-safe).
- `botan_utils.hpp`: view callback guarded `>= 3.6.0`; KEM op wrappers guarded `#if defined(ENABLE_PQC)`.
- Everything else in the always-compiled core uses FFI available since ≤ 2.14 — no guard needed. The crypto-refresh/PQC files only compile under `ENABLE_CRYPTO_REFRESH`/`ENABLE_PQC` (which require 3.6+).

## `cipher_botan` is intentionally left native (NOT a blocker)

`cipher_botan.cpp/.hpp` stays on `Botan::Cipher_Mode`. The Botan FFI exposes only the streaming `botan_cipher_update` — there is no equivalent of `Botan::Cipher_Mode::process()` (raw per-block, immediate output) which rnp's cipher streaming is built on, and CBC-decrypt inherently buffers a block. A correct FFI cipher therefore needs a 1-block-delay buffering rewrite on rnp's side.

**This does not block the PR.** The native cipher compiles and works correctly everywhere; everything *else* in the Botan backend is now FFI-only. The cipher migration is a self-contained follow-up — and, like every other FFI symbol, it will be version-gated regardless of what upstream does, so waiting on Botan to expose a `process`-equivalent wouldn't change rnp's gating architecture. (Filed as a question to @randombit in a separate comment, out of genuine curiosity — not a merge dependency.)

## Test plan

- [x] `cmake -DCRYPTO_BACKEND=botan3 -DENABLE_CRYPTO_REFRESH=ON -DENABLE_PQC=ON` builds clean on Botan 3.12.
- [x] Full `rnp_tests`: **296/296 pass** locally (no regressions); all PQC tests pass — this also **fixes two PQC tests that failed against 3.12 on the native API** (`kyber_ecdh_roundtrip`, `test_ffi_pqc_gen_enc_sign`).
- [x] All migrated files contain zero `Botan::` references (cipher_botan excepted, by design).
- [x] `clang-format` (v11) clean on all changed files.
- [ ] CI across the Botan version matrix (2.x system, 3.3.0, 3.6+, head).

## Notes

- `pqc-openssl` at `origin` is a staging copy of kaie's fork branch, created only so this PR can target #2392. It can be deleted once #2392 and this PR are handled.
- Supersedes #2447.
