### PR TITLE
ci: fix Botan HEAD from-source build (BOTAN_UNUSED macro removed upstream)

### DIFF
--- a/.github/workflows/centos-and-fedora.yml
+++ b/.github/workflows/centos-and-fedora.yml
@@ -134,6 +134,11 @@ jobs:
       - name: Build botan head
         if:   matrix.image.botan_ver == 'head'
         run: |
+          # Botan HEAD removed the BOTAN_UNUSED macro but still references it
+          # in ffi_cert_ext.cpp and other FFI source files. Define it to
+          # nothing so the from-source build succeeds. Remove this shim once
+          # upstream Botan fixes the inconsistency.
+          export CXXFLAGS='-DBOTAN_UNUSED(...)='
           /opt/tools/tools.sh build_and_install_botan head
 
       - name: Build botan 3.6.0


### PR DESCRIPTION
## Summary

Botan HEAD removed the `BOTAN_UNUSED` macro (in favour of C++17 `[[maybe_unused]]`) but still references it in several FFI source files (`ffi_cert_ext.cpp` etc.), causing every CI leg that builds Botan from HEAD to fail with:

```
src/lib/ffi/ffi_cert_ext.cpp:90:4: error: 'BOTAN_UNUSED' was not declared in this scope
```

This affects the Fedora 40 head legs in `centos-and-fedora.yml` and the `fuzzing` workflow (which also builds Botan from HEAD).

## Fix

Define `BOTAN_UNUSED(...)`  to nothing via `CXXFLAGS` before calling `build_and_install_botan head`. The variadic macro takes args like `BOTAN_UNUSED(cert, asnum)` and expands to an empty statement, which is semantically equivalent to the old `(void)sizeof(...)` definition for the purpose of suppressing unused-variable warnings.

```yaml
export CXXFLAGS='-DBOTAN_UNUSED(...)='
/opt/tools/tools.sh build_and_install_botan head
```

This is a temporary compat shim — remove once upstream Botan fixes the inconsistency (either by re-adding the macro or by updating the FFI source to not use it).

## Test plan

- [ ] Fedora 40 head legs pass (were failing with `BOTAN_UNUSED was not declared`)
- [ ] Fuzzing workflow's Botan HEAD build passes
- [ ] No regressions on other legs
