### PR TITLE
fix: building with -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES

### DIFF
--- a/src/common/file-utils.cpp
+++ b/src/common/file-utils.cpp
@@ -29,8 +29,8 @@
 
 #include "file-utils.h"
 #include "config.h"
-#ifdef _MSC_VER
 #include <stdlib.h>
+#ifdef _MSC_VER
 #include <stdio.h>
 #include "uniwin.h"
 #include <errno.h>

--- a/src/lib/crypto/mem.h
+++ b/src/lib/crypto/mem.h
@@ -34,6 +34,7 @@
 #include <botan/secmem.h>
 #include <botan/ffi.h>
 #elif defined(CRYPTO_BACKEND_OPENSSL)
+#include <cstdlib>
 #include <openssl/crypto.h>
 #endif
 #include "str-utils.h"


### PR DESCRIPTION
Fixes these missing header errors when building with `clang++ -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`:

```
src/common/file-utils.cpp:346:24: error: use of undeclared identifier
      'getenv'
  346 |     const char *home = getenv("HOME");
      |                        ^~~~~~
1 error generated.
<...>
src/lib/crypto/mem.h:78:32: error: no member named 'calloc' in
      namespace 'std'; did you mean simply 'calloc'?
   78 |         ptr = static_cast<T *>(std::calloc(n, sizeof(T)));
      |                                ^~~~~~~~~~~
      |                                calloc
/usr/include/sched.h:83:8: note: 'calloc' declared here
   83 | void *(calloc)(size_t, size_t);
      |        ^
<...>
src/lib/crypto/mem.h:95:14: error: no type named 'free' in namespace
      'std'
   95 |         std::free(p);
      |         ~~~~~^
2 errors generated.
```
