### PR TITLE
ci: add conditional ccache to container-based workflows

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -87,6 +87,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-
       - name: Setup environment
         shell: bash
         run: |
@@ -107,6 +114,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=ON                             \
                 -DCRYPTO_BACKEND=${{ matrix.image.backend }}       \
                 -DDOWNLOAD_GTEST=ON                                \
+                ${RNP_CCACHE_LAUNCHER:-}                           \
                 -DCMAKE_BUILD_TYPE=Release                         \
                 -DCMAKE_CXX_FLAGS_RELEASE="-UNDEBUG"               \
                 -DCMAKE_C_FLAGS_RELEASE="-UNDEBUG"                 \

--- a/.github/workflows/centos-and-fedora.yml
+++ b/.github/workflows/centos-and-fedora.yml
@@ -125,6 +125,13 @@ jobs:
         with:
           submodules: true  
 
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-
       - name: Setup environment
         run: |
           set -o errexit -o pipefail -o noclobber -o nounset
@@ -143,6 +150,15 @@ jobs:
 
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
 
+          # Use ccache if available (container-agnostic: falls back gracefully)
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --set-config=max_size=500M 2>/dev/null || true
+            ccache --set-config=compression=true 2>/dev/null || true
+            echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+            echo "RNP_CCACHE_LAUNCHER=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          else
+            echo "RNP_CCACHE_LAUNCHER=" >> $GITHUB_ENV
+          fi
           useradd rnpuser
           printf "\nrnpuser\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/rnpuser
           printf "\nrnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf
@@ -183,6 +199,7 @@ jobs:
           cmake -B build                                           \
                 -DBUILD_SHARED_LIBS=${{ env.SHARED_LIBS }}         \
                 -DDOWNLOAD_GTEST=ON                                \
+                ${RNP_CCACHE_LAUNCHER:-}                           \
                 -DCMAKE_BUILD_TYPE=Release                         \
                 -DCRYPTO_BACKEND=${{ matrix.image.backend }}       \
                 ${sm2_opt:-} ${idea_opt:-} ${two_opt:-} ${blow_opt:-} ${rmd_opt:-} ${bp_opt:-} ${pqc_opt[@]:-} ${cov_opt:-} ${san_opt:-} .

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -79,12 +79,28 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-
       - name: Setup environment
         shell: bash
         # rnpuser is only needed for rnpkeys_generatekey_verifykeyHomeDirNoPermission test
         run: |
           echo "ENABLE_PQC=${{ matrix.image.pqc }}" >> $GITHUB_ENV
 
+          # Use ccache if available (container-agnostic: falls back gracefully)
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --set-config=max_size=500M 2>/dev/null || true
+            ccache --set-config=compression=true 2>/dev/null || true
+            echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+            echo "RNP_CCACHE_LAUNCHER=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          else
+            echo "RNP_CCACHE_LAUNCHER=" >> $GITHUB_ENV
+          fi
           useradd rnpuser
           printf "\nrnpuser\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/rnpuser
           printf "\nrnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf
@@ -99,6 +115,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=ON                             \
                 -DCRYPTO_BACKEND=${{ matrix.image.backend }}       \
                 -DDOWNLOAD_GTEST=ON                                \
+                ${RNP_CCACHE_LAUNCHER:-}                           \
                 -DCMAKE_BUILD_TYPE=Release                         \
                 -DCMAKE_CXX_FLAGS_RELEASE="-UNDEBUG"               \
                 -DCMAKE_C_FLAGS_RELEASE="-UNDEBUG"                 \

--- a/.github/workflows/time-machine.yml
+++ b/.github/workflows/time-machine.yml
@@ -90,6 +90,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.image.container }}-${{ matrix.env.CC }}-
       - name: Setup environment
         run: |
           set -o errexit -o pipefail -o noclobber -o nounset
@@ -100,6 +107,15 @@ jobs:
 
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
 
+          # Use ccache if available (container-agnostic: falls back gracefully)
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --set-config=max_size=500M 2>/dev/null || true
+            ccache --set-config=compression=true 2>/dev/null || true
+            echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+            echo "RNP_CCACHE_LAUNCHER=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          else
+            echo "RNP_CCACHE_LAUNCHER=" >> $GITHUB_ENV
+          fi
           useradd rnpuser
           printf "\nrnpuser\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/rnpuser
           printf "\nrnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf
@@ -109,6 +125,7 @@ jobs:
           cmake -B build                                           \
                 -DBUILD_SHARED_LIBS=ON                             \
                 -DDOWNLOAD_GTEST=ON                                \
+                ${RNP_CCACHE_LAUNCHER:-}                           \
                 -DCMAKE_BUILD_TYPE=Release                         \
                 -DCRYPTO_BACKEND=${{ matrix.image.backend }}
 
@@ -168,6 +185,15 @@ jobs:
 
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
 
+          # Use ccache if available (container-agnostic: falls back gracefully)
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --set-config=max_size=500M 2>/dev/null || true
+            ccache --set-config=compression=true 2>/dev/null || true
+            echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+            echo "RNP_CCACHE_LAUNCHER=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          else
+            echo "RNP_CCACHE_LAUNCHER=" >> $GITHUB_ENV
+          fi
           useradd rnpuser
           printf "\nrnpuser\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/rnpuser
           printf "\nrnpuser\tsoft\tnproc\tunlimited\n" > /etc/security/limits.d/30-rnpuser.conf


### PR DESCRIPTION
Adds ccache as an optional compilation accelerator to all container-based workflows.

## How it works

ccache caches at the **object file level**, keyed by preprocessed source hash + compiler + flags. Different PRs share cached `.o` files for unchanged source — only modified files get recompiled.

Example: a PR touching 1 of 200 source files rebuilds in seconds instead of minutes.

## Container-agnostic

- **ccache is conditional**: `if command -v ccache` — uses it if present, builds normally if not
- **`DOWNLOAD_GTEST=ON` always**: RNP downloads its own GTest, fully container-agnostic
- Cache persisted via `actions/cache` keyed by `container + compiler`

## Requires

rnp-ci-containers v2.0.0+ (ccache pre-installed). Already published to ghcr.io.

Follow-up to #2419 (CI alignment).
