### PR TITLE
fix: make PQC work with minimized Botan 3.6 builds

### DIFF
--- a/ci/botan3-pqc-modules
+++ b/ci/botan3-pqc-modules
@@ -62,5 +62,7 @@ dilithium
 ml_dsa
 sphincsplus_sha2
 sphincsplus_shake
+slh_dsa_sha2
+slh_dsa_shake
 hkdf
 kmac

--- a/ci/botan3-pqc-modules
+++ b/ci/botan3-pqc-modules
@@ -57,7 +57,9 @@ sp800_56a
 twofish
 x448
 kyber
+ml_kem
 dilithium
+ml_dsa
 sphincsplus_sha2
 sphincsplus_shake
 hkdf

--- a/ci/botan3-pqc-modules
+++ b/ci/botan3-pqc-modules
@@ -17,6 +17,7 @@ dl_group
 dsa
 eax
 ecc_key
+legacy_ec_point
 ecdh
 ecdsa
 pcurves_secp192r1

--- a/ci/prebuilt-versions.env
+++ b/ci/prebuilt-versions.env
@@ -18,5 +18,10 @@
 ZLIB_VERSION=1.3.1
 BZIP2_VERSION=1.0.8
 JSONC_VERSION=0.19
-BOTAN_VERSION=3.6.0
+# Botan 3.6.x is unsuitable for minimized builds: 3.6.0 signs SLH-DSA
+# with the non-FIPS deterministic variant (fixed in 3.6.1, GH #4398),
+# and 3.6.0/3.6.1 crash in the legacy EC path on arm64. The module
+# list (ci/botan3-pqc-modules) also relies on the legacy_ec_point
+# module, which only exists from Botan 3.7.0.
+BOTAN_VERSION=3.12.0
 OPENSSL_VERSION=3.6.0

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -233,7 +233,18 @@ if(CRYPTO_BACKEND_BOTAN)
   resolve_feature_state(ENABLE_TWOFISH "TWOFISH")
   resolve_feature_state(ENABLE_IDEA "IDEA")
   resolve_feature_state(ENABLE_CRYPTO_REFRESH "HKDF;ED448;X448;ARGON2")
-  resolve_feature_state(ENABLE_PQC "HKDF;DILITHIUM;KYBER;SPHINCS_PLUS_WITH_SHA2;SPHINCS_PLUS_WITH_SHAKE")
+  # The PQC code paths use the FIPS 203/204/205 APIs (KyberMode::ML_KEM_*,
+  # DilithiumMode::ML_DSA_*, SLH_DSA_*), which Botan activates via the
+  # ml_kem/ml_dsa/slh_dsa_* modules — not the legacy kyber/dilithium/
+  # sphincsplus_* ones. Check the corresponding BOTAN_HAS_* defines so a
+  # minimized Botan without those modules disables PQC at configure time
+  # instead of failing the build (all of them exist since Botan 3.6.0,
+  # the minimum for ENABLE_CRYPTO_REFRESH).
+  if(Botan_VERSION VERSION_GREATER_EQUAL 3.6.0)
+    resolve_feature_state(ENABLE_PQC "HKDF;ML_KEM;ML_DSA;SLH_DSA_WITH_SHA2;SLH_DSA_WITH_SHAKE")
+  else()
+    resolve_feature_state(ENABLE_PQC "HKDF;DILITHIUM;KYBER;SPHINCS_PLUS_WITH_SHA2;SPHINCS_PLUS_WITH_SHAKE")
+  endif()
   resolve_feature_state(ENABLE_BLOWFISH "BLOWFISH")
   resolve_feature_state(ENABLE_CAST5 "CAST_128")
   resolve_feature_state(ENABLE_RIPEMD160 "RIPEMD_160")

--- a/src/lib/crypto/sphincsplus.cpp
+++ b/src/lib/crypto/sphincsplus.cpp
@@ -26,51 +26,43 @@
  */
 
 #include "sphincsplus.h"
-#include <botan/sphincsplus.h>
+#include <botan/slh_dsa.h>
 #include <botan/pubkey.h>
 #include <cassert>
 #include "logging.h"
 #include "types.h"
 
-// Use the legacy Sphincs_* names from <botan/sphincsplus.h> rather than the
-// SLH_DSA_* aliases from <botan/slh_dsa.h>. ci/botan3-pqc-modules enables the
-// legacy sphincsplus_sha2/sphincsplus_shake module names (available in Botan
-// 3.6-3.12+), and Botan's Sphincs_Parameters::is_available() only activates:
-//   - SLHDSA* parameter sets when the slh_dsa_* modules are built, and
-//   - Sphincs* parameter sets when the sphincsplus_* modules are built.
-// Using the legacy spelling makes minimized builds work on every supported
-// Botan, while full system Botan builds activate both.
 namespace {
-Botan::Sphincs_Parameter_Set
+Botan::SLH_DSA_Parameter_Set
 rnp_sphincsplus_alg_to_botan_param(pgp_pubkey_alg_t alg)
 {
     switch (alg) {
     case PGP_PKA_SPHINCSPLUS_SHAKE_128f:
-        return Botan::Sphincs_Parameter_Set::Sphincs128Fast;
+        return Botan::SLH_DSA_Parameter_Set::SLHDSA128Fast;
     case PGP_PKA_SPHINCSPLUS_SHAKE_128s:
-        return Botan::Sphincs_Parameter_Set::Sphincs128Small;
+        return Botan::SLH_DSA_Parameter_Set::SLHDSA128Small;
     case PGP_PKA_SPHINCSPLUS_SHAKE_256s:
-        return Botan::Sphincs_Parameter_Set::Sphincs256Small;
+        return Botan::SLH_DSA_Parameter_Set::SLHDSA256Small;
     default:
         RNP_LOG("invalid algorithm ID given");
         throw rnp::rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
 }
 
-Botan::SphincsPlus_PublicKey
+Botan::SLH_DSA_PublicKey
 sphincsplus_pubkey_from_bytes(const std::vector<uint8_t> &key_encoded, pgp_pubkey_alg_t alg)
 {
-    return Botan::SphincsPlus_PublicKey(key_encoded,
-                                        rnp_sphincsplus_alg_to_botan_param(alg),
-                                        Botan::Sphincs_Hash_Type::Shake256);
+    return Botan::SLH_DSA_PublicKey(key_encoded,
+                                    rnp_sphincsplus_alg_to_botan_param(alg),
+                                    Botan::SLH_DSA_Hash_Type::Shake256);
 }
 
-Botan::SphincsPlus_PrivateKey
+Botan::SLH_DSA_PrivateKey
 sphincsplus_privkey_from_bytes(const uint8_t *key_data, size_t key_size, pgp_pubkey_alg_t alg)
 {
     Botan::secure_vector<uint8_t> priv_sv(key_data, key_data + key_size);
-    return Botan::SphincsPlus_PrivateKey(
-      priv_sv, rnp_sphincsplus_alg_to_botan_param(alg), Botan::Sphincs_Hash_Type::Shake256);
+    return Botan::SLH_DSA_PrivateKey(
+      priv_sv, rnp_sphincsplus_alg_to_botan_param(alg), Botan::SLH_DSA_Hash_Type::Shake256);
 }
 } // namespace
 
@@ -136,9 +128,9 @@ pgp_sphincsplus_public_key_t::verify(const pgp_sphincsplus_signature_t *sig,
 std::pair<pgp_sphincsplus_public_key_t, pgp_sphincsplus_private_key_t>
 sphincsplus_generate_keypair(rnp::RNG *rng, pgp_pubkey_alg_t alg)
 {
-    Botan::SphincsPlus_PrivateKey priv_key(*rng->obj(),
-                                           rnp_sphincsplus_alg_to_botan_param(alg),
-                                           Botan::Sphincs_Hash_Type::Shake256);
+    Botan::SLH_DSA_PrivateKey priv_key(*rng->obj(),
+                                       rnp_sphincsplus_alg_to_botan_param(alg),
+                                       Botan::SLH_DSA_Hash_Type::Shake256);
 
     std::unique_ptr<Botan::Public_Key> pub_key = priv_key.public_key();
     Botan::secure_vector<uint8_t>      priv_bits = priv_key.private_key_bits();

--- a/src/lib/crypto/sphincsplus.cpp
+++ b/src/lib/crypto/sphincsplus.cpp
@@ -26,43 +26,51 @@
  */
 
 #include "sphincsplus.h"
-#include <botan/slh_dsa.h>
+#include <botan/sphincsplus.h>
 #include <botan/pubkey.h>
 #include <cassert>
 #include "logging.h"
 #include "types.h"
 
+// Use the legacy Sphincs_* names from <botan/sphincsplus.h> rather than the
+// SLH_DSA_* aliases from <botan/slh_dsa.h>. ci/botan3-pqc-modules enables the
+// legacy sphincsplus_sha2/sphincsplus_shake module names (available in Botan
+// 3.6-3.12+), and Botan's Sphincs_Parameters::is_available() only activates:
+//   - SLHDSA* parameter sets when the slh_dsa_* modules are built, and
+//   - Sphincs* parameter sets when the sphincsplus_* modules are built.
+// Using the legacy spelling makes minimized builds work on every supported
+// Botan, while full system Botan builds activate both.
 namespace {
-Botan::SLH_DSA_Parameter_Set
+Botan::Sphincs_Parameter_Set
 rnp_sphincsplus_alg_to_botan_param(pgp_pubkey_alg_t alg)
 {
     switch (alg) {
     case PGP_PKA_SPHINCSPLUS_SHAKE_128f:
-        return Botan::SLH_DSA_Parameter_Set::SLHDSA128Fast;
+        return Botan::Sphincs_Parameter_Set::Sphincs128Fast;
     case PGP_PKA_SPHINCSPLUS_SHAKE_128s:
-        return Botan::SLH_DSA_Parameter_Set::SLHDSA128Small;
+        return Botan::Sphincs_Parameter_Set::Sphincs128Small;
     case PGP_PKA_SPHINCSPLUS_SHAKE_256s:
-        return Botan::SLH_DSA_Parameter_Set::SLHDSA256Small;
+        return Botan::Sphincs_Parameter_Set::Sphincs256Small;
     default:
         RNP_LOG("invalid algorithm ID given");
         throw rnp::rnp_exception(RNP_ERROR_BAD_PARAMETERS);
     }
 }
 
-Botan::SLH_DSA_PublicKey
+Botan::SphincsPlus_PublicKey
 sphincsplus_pubkey_from_bytes(const std::vector<uint8_t> &key_encoded, pgp_pubkey_alg_t alg)
 {
-    return Botan::SLH_DSA_PublicKey(key_encoded,
-                                    rnp_sphincsplus_alg_to_botan_param(alg),
-                                    Botan::SLH_DSA_Hash_Type::Shake256);
+    return Botan::SphincsPlus_PublicKey(key_encoded,
+                                        rnp_sphincsplus_alg_to_botan_param(alg),
+                                        Botan::Sphincs_Hash_Type::Shake256);
 }
 
-Botan::SLH_DSA_PrivateKey
+Botan::SphincsPlus_PrivateKey
 sphincsplus_privkey_from_bytes(const uint8_t *key_data, size_t key_size, pgp_pubkey_alg_t alg)
 {
     Botan::secure_vector<uint8_t> priv_sv(key_data, key_data + key_size);
-    return Botan::SLH_DSA_PrivateKey(
-      priv_sv, rnp_sphincsplus_alg_to_botan_param(alg), Botan::SLH_DSA_Hash_Type::Shake256);
+    return Botan::SphincsPlus_PrivateKey(
+      priv_sv, rnp_sphincsplus_alg_to_botan_param(alg), Botan::Sphincs_Hash_Type::Shake256);
 }
 } // namespace
 
@@ -128,9 +136,9 @@ pgp_sphincsplus_public_key_t::verify(const pgp_sphincsplus_signature_t *sig,
 std::pair<pgp_sphincsplus_public_key_t, pgp_sphincsplus_private_key_t>
 sphincsplus_generate_keypair(rnp::RNG *rng, pgp_pubkey_alg_t alg)
 {
-    Botan::SLH_DSA_PrivateKey priv_key(*rng->obj(),
-                                       rnp_sphincsplus_alg_to_botan_param(alg),
-                                       Botan::SLH_DSA_Hash_Type::Shake256);
+    Botan::SphincsPlus_PrivateKey priv_key(*rng->obj(),
+                                           rnp_sphincsplus_alg_to_botan_param(alg),
+                                           Botan::Sphincs_Hash_Type::Shake256);
 
     std::unique_ptr<Botan::Public_Key> pub_key = priv_key.public_key();
     Botan::secure_vector<uint8_t>      priv_bits = priv_key.private_key_bits();


### PR DESCRIPTION
## Summary

`ENABLE_PQC` with minimized Botan builds (oss-fuzz, prebuilt tarballs) using `ci/botan3-pqc-modules` was broken: ML-KEM/ML-DSA keygen failed at run time ("requested Kyber mode is not enabled in this build") and SLH-DSA failed to compile against Botan 3.6.

Root cause: the PQC code uses the FIPS 203/204/205 APIs (`KyberMode::ML_KEM_*`, `DilithiumMode::ML_DSA_*`, `SLH_DSA_*`), which Botan activates via the `ml_kem` / `ml_dsa` / `slh_dsa_sha2` / `slh_dsa_shake` modules — but the module list only enabled the legacy `kyber` / `dilithium` / `sphincsplus_*` names, and the CMake feature check also only looked at the legacy `BOTAN_HAS_*` defines.

**Changes:**

1. `ci/botan3-pqc-modules`: add `ml_kem`, `ml_dsa`, `slh_dsa_sha2`, `slh_dsa_shake` (all exist in Botan 3.6.0–3.12+, the versions rnp's PQC supports). Legacy names kept so nothing regresses.

2. `src/lib/CMakeLists.txt`: for Botan ≥ 3.6, `ENABLE_PQC` now checks `BOTAN_HAS_ML_KEM;ML_DSA;SLH_DSA_WITH_SHA2;SLH_DSA_WITH_SHAKE` — the defines the code actually uses — so a minimized Botan missing those modules disables PQC cleanly at configure time instead of breaking the build. Legacy list preserved for Botan < 3.6.

**Not done deliberately:** switching `sphincsplus.cpp` to the round-3 `Sphincs*` parameter sets — those are a *different algorithm variant* in Botan; the draft-ietf-openpgp-pqc sample vectors verify only with the FIPS 205 `SLHDSA*` sets (verified locally: the vectors fail with the round-3 sets).

**Recommendation for google/oss-fuzz#15882:** bump Botan 3.4.0 → **3.12.0** (not 3.6.x): 3.6.0 signs SLH-DSA non-FIPS-compliantly (GH randombit/botan#4398), and 3.6.0/3.6.1 crash in the legacy EC path on arm64 minimized builds.

## Test plan

- [x] Full Botan 3.12.0 (homebrew): all 5 PQC FFI tests pass, incl. `test_ffi_verify_detached_pqc_test_vector` with the draft sample vectors
- [x] Minimized Botan 3.12.0 built with exactly `ci/botan3-pqc-modules`: **all 5 PQC FFI tests pass** (incl. composite ML-DSA+EC keygen and the draft sample vectors)
- [x] Documented: minimized Botan 3.6.x is unsuitable — 3.6.0 SLH-DSA signing bug (GH #4398), 3.6.0/3.6.1 arm64 legacy-EC crash (reproduced with a 2-line test); prebuilt pinned to 3.12.0
- [x] Added `legacy_ec_point` to the module set (separate module in Botan 3.7+, required by `crypto/ec.cpp`)
- [x] OpenSSL backend still configures with `-DENABLE_PQC=ON`
- [x] clang-format 11 clean
- [ ] CI matrix
