### PR TITLE
ci(windows-native): set os in include matrix entries

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -79,24 +79,27 @@ jobs:
         use_cmake_prefix_path: [ 'on', 'off' ]
         sanitizers: [ 'off' ]
         include:
-          - arch:  { name: 'x64',    triplet: 'x64-windows' }
-            toolset:                'v143'
-            backend:                'botan'
-            use_cmake_prefix_path:  'off'
-            shared_libs:            'off'
-            sanitizers:             'on'
-          - arch:  { name: 'Win32',  triplet: 'x86-windows' }
-            toolset:                'ClangCL'
-            backend:                'botan'
-            use_cmake_prefix_path:  'on'
-            shared_libs:            'off'
-            sanitizers:             'off'
-          - arch:  { name: 'Win32',  triplet: 'x86-windows' }
-            toolset:                'v143'
-            backend:                'openssl'
-            use_cmake_prefix_path:  'off'
-            shared_libs:            'off'
-            sanitizers:             'off'
+          - os:                    'windows-2022'
+            arch:                  { name: 'x64',    triplet: 'x64-windows' }
+            toolset:               'v143'
+            backend:               'botan'
+            use_cmake_prefix_path: 'off'
+            shared_libs:           'off'
+            sanitizers:            'on'
+          - os:                    'windows-2022'
+            arch:                  { name: 'Win32',  triplet: 'x86-windows' }
+            toolset:               'ClangCL'
+            backend:               'botan'
+            use_cmake_prefix_path: 'on'
+            shared_libs:           'off'
+            sanitizers:            'off'
+          - os:                    'windows-2022'
+            arch:                  { name: 'Win32',  triplet: 'x86-windows' }
+            toolset:               'v143'
+            backend:               'openssl'
+            use_cmake_prefix_path: 'off'
+            shared_libs:           'off'
+            sanitizers:            'off'
           # Windows Server 2025 (newer VS toolchain; preview of what windows-2022
           # deprecation will land on).
           - os:                    'windows-2025'

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -67,6 +67,15 @@ jobs:
   build_and_test:
     name: ${{ matrix.os }} [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
     runs-on: ${{ matrix.os }}
+    # windows-2025 and windows-11-arm are experimental preview legs (they were
+    # never exercised before: the workflow had been failing at matrix expansion
+    # since their introduction):
+    # - windows-2025 ships Visual Studio 2026, which the hardcoded
+    #   "Visual Studio 17 2022" generator and the v143 toolset cannot drive;
+    # - windows-11-arm fails at CMake generate time with SHLWAPI_LIBRARY
+    #   NOTFOUND (arm64 SDK library discovery).
+    # Keep them non-blocking until follow-ups make them pass.
+    continue-on-error: ${{ matrix.os == 'windows-2025' || matrix.os == 'windows-11-arm' }}
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       fail-fast: false
@@ -110,7 +119,7 @@ jobs:
             shared_libs:           'off'
             sanitizers:            'off'
           # Windows 11 ARM (preview runner; vcpkg ARM coverage has improved enough
-          # for our dependency set). Marked continue-on-error below.
+          # for our dependency set). Non-blocking at the job level above.
           - os:                    'windows-11-arm'
             arch:                  { name: 'ARM64', triplet: 'arm64-windows' }
             toolset:               'v143'
@@ -244,5 +253,3 @@ jobs:
           mkdir -p "build/Testing/Temporary"
           cp "cmake/CTestCostData.txt" "build/Testing/Temporary"
           ctest --parallel ${{ env.CORES }} --test-dir build -C Release --output-on-failure
-        # Windows 11 ARM is a preview runner; don't gate the build on it.
-        continue-on-error: ${{ matrix.os == 'windows-11-arm' }}


### PR DESCRIPTION
## What

CI-only fix for `windows-native`, which has been failing **fleet-wide** (main and every open PR) since #2416 merged — every run aborted before scheduling a single job:

> Error when evaluating 'runs-on' for job 'build_and_test'.
> .github/workflows/windows-native.yml (Line: 69, Col: 14): Unexpected value ''

## Why

#2416 added an `os` key to the base matrix and changed the job to `runs-on: ${{ matrix.os }}` (for the new windows-2025 / windows-11-arm legs). But three pre-existing `include:` entries did not set `os`:

- x64 / v143 / botan with sanitizers **on**
- Win32 / ClangCL / botan
- Win32 / v143 / openssl

Matrix combinations created via `include` get `''` for keys they don't specify, so those combinations evaluated `runs-on: ''` and GitHub failed the entire workflow.

## Fix

1. Add `os: windows-2022` to those three entries (same runner as the base matrix and the other include entries). Verified by simulating the matrix expansion: all 13 combinations resolve a non-empty `os`. The workflow's `pull_request` trigger explicitly re-includes this file (`!.github/workflows/windows-native.yml`), so this PR's own CI exercised the fix — all 13 jobs scheduled and ran.
2. Mark the two preview legs `continue-on-error` at the **job** level. Now that jobs run again, they fail for environment reasons that were never exercised before:
   - **windows-2025** ships Visual Studio 2026; the hardcoded `Visual Studio 17 2022` generator (and `v143` toolset) cannot drive it (`could not find any instance of Visual Studio` at configure).
   - **windows-11-arm** fails at CMake generate time with `SHLWAPI_LIBRARY` `NOTFOUND` for `rnp_tests` (arm64 SDK library discovery). Its previous `continue-on-error` only covered the Test step, so a configure failure still blocked.

   The 11 established combinations remain gating; making the preview legs blocking again will be handled in follow-ups.

Apologies for introducing the matrix bug in #2416 — the failure mode (workflow aborts with zero jobs) hid behind the merge-time reruns.
