### PR TITLE
cmake(botan): floor ENABLE_PQC at Botan 3.7.0; warn on 3.6.x arm64 EC crash

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -136,6 +136,17 @@ cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=o
 make install
 ----
 
+[NOTE]
+====
+When building against the Botan backend, avoid Botan 3.6.x on arm64:
+it has an upstream crash in the EC path (SIGBUS inside
+`Botan::BigInt::is_equal`) that breaks ordinary ECDSA/ECDH, and 3.6.0
+additionally signs SLH-DSA with the wrong (non-FIPS-compliant)
+deterministic variant. Botan 3.7.0 or newer is required for PQC
+(`-DENABLE_PQC=on`) and recommended everywhere on arm64. Botan 3.0 - 3.5
+works fine with PQC left off (the default).
+====
+
 == On Windows
 
 === Using MSYS/MinGW

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -234,25 +234,44 @@ if(CRYPTO_BACKEND_BOTAN)
   resolve_feature_state(ENABLE_IDEA "IDEA")
   resolve_feature_state(ENABLE_CRYPTO_REFRESH "HKDF;ED448;X448;ARGON2")
   # The PQC code paths use the FIPS 203/204/205 APIs (KyberMode::ML_KEM_*,
-  # DilithiumMode::ML_DSA_*, SLH_DSA_*), which only exist from Botan 3.6.0.
+  # DilithiumMode::ML_DSA_*, SLH_DSA_*), which first exist in Botan 3.6.0.
+  # The floor is 3.7.0, not 3.6.0:
+  #  - 3.6.0 signs SLH-DSA with the non-FIPS-compliant deterministic variant
+  #    (fixed upstream in 3.6.1, GH #4398);
+  #  - 3.6.0/3.6.1 crash in the BigInt/legacy-EC path on arm64 (verified:
+  #    rnp_tests.ecdsa_signverify_success and the ML-KEM/ECDH curve composites
+  #    die with SIGBUS inside Botan::BigInt::is_equal);
+  #  - the minimized-build module list (ci/botan3-pqc-modules) needs the
+  #    legacy_ec_point module, which only exists from 3.7.0.
   # The round-3 Kyber/Dilithium/SPHINCS+ variants of older Botan are different
   # algorithms, not renames: the draft-ietf-openpgp-pqc test vectors verify
-  # only with the final FIPS parameter sets. Enabling PQC there would pass
+  # only with the final FIPS parameter sets, so enabling PQC there would pass
   # configure (the legacy BOTAN_HAS_KYBER/DILITHIUM/SPHINCS_PLUS_* defines
-  # exist) and then fail compiling the missing APIs, so reject it upfront.
-  if(NOT Botan_VERSION VERSION_GREATER_EQUAL 3.6.0)
+  # exist) and then fail compiling the missing APIs. Reject it upfront.
+  if(NOT Botan_VERSION VERSION_GREATER_EQUAL 3.7.0)
     if(ENABLE_PQC)
       string(TOLOWER "${ENABLE_PQC}" _pqc)
       if(NOT _pqc STREQUAL "auto")
         message(FATAL_ERROR
-          "ENABLE_PQC requires Botan >= 3.6.0 (FIPS 203/204/205 APIs); older "
-          "Botan only provides the non-interoperable round-3 variants.")
+          "ENABLE_PQC requires Botan >= 3.7.0 (FIPS 203/204/205 APIs; 3.6.x "
+          "has an arm64 EC crash and an SLH-DSA signing bug); older Botan "
+          "only provides the non-interoperable round-3 variants.")
       endif()
       set(ENABLE_PQC Off CACHE STRING "Auto -> Off as no support" FORCE)
-      message(NOTICE "ENABLE_PQC requires Botan >= 3.6.0. Disabling.")
+      message(NOTICE "ENABLE_PQC requires Botan >= 3.7.0. Disabling.")
     endif()
   else()
     resolve_feature_state(ENABLE_PQC "HKDF;ML_KEM;ML_DSA;SLH_DSA_WITH_SHA2;SLH_DSA_WITH_SHAKE")
+  endif()
+  # Even without PQC, plain ECDSA/ECDH crash on arm64 with Botan 3.6.x (same
+  # upstream BigInt/legacy-EC bug); x86-64 3.6 builds are unaffected.
+  if(Botan_VERSION VERSION_GREATER_EQUAL 3.6.0
+     AND Botan_VERSION VERSION_LESS 3.7.0
+     AND (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64"))
+    message(WARNING
+      "Botan ${Botan_VERSION} has an upstream crash in the EC path on arm64 "
+      "(SIGBUS in BigInt::is_equal) that breaks ordinary ECDSA/ECDH. "
+      "Use Botan >= 3.7.0 on arm64 if possible.")
   endif()
   resolve_feature_state(ENABLE_BLOWFISH "BLOWFISH")
   resolve_feature_state(ENABLE_CAST5 "CAST_128")


### PR DESCRIPTION
## Summary

Follow-up to #2462. An audit against real builds of the Botan 3.x line (full locally-built 3.4.0 and 3.6.1, plus the CI-covered 2.x / 3.3.0 / 3.9.0 / 3.12 bands) found the **3.6.x band unsafe for rnp**, so the `ENABLE_PQC` floor moves from 3.6.0 to 3.7.0.

### Why 3.6.x is excluded

1. **3.6.0 signs SLH-DSA with the non-FIPS-compliant deterministic variant** (fixed upstream in 3.6.1, Botan GH #4398) — wrong signatures from a "supported" configuration.
2. **3.6.0/3.6.1 crash in the BigInt/legacy-EC path on arm64** — reproduced against a full 3.6.1 build on Apple Silicon: `rnp_tests.ecdsa_signverify_success` (plain ECDSA, no PQC involved) and `kyber_ecdh_roundtrip` / `dilithium_exdsa_*` (the NIST-curve composites) die with SIGBUS inside `Botan::BigInt::is_equal`. This is not PQC-specific: ordinary ECDSA/ECDH is broken on arm64 with 3.6.x.
3. **The minimized-build reference list `ci/botan3-pqc-modules` already requires `legacy_ec_point`**, which only exists from 3.7.0 — so the project's own minimized builds cannot use 3.6 anyway.

### What changes

- `-DENABLE_PQC=on` with Botan < 3.7.0 now fails configure with an explanatory `FATAL_ERROR`; `auto`/default keeps auto-disabling with a `NOTICE` (unchanged behaviour for 3.0 - 3.5).
- New non-fatal `WARNING` when Botan 3.6.x is detected on an arm64 target (x86-64 3.6 builds are unaffected and keep working) — plain ECDSA/ECDH crashes there even without PQC.
- Installation guide documents the band.

### Verified

- [x] Botan 3.6.1 (full build) + `-DENABLE_PQC=on` → configure fails with the new message
- [x] Botan 3.6.1 default → configures cleanly with the arm64 warning, `ENABLE_PQC=OFF`
- [x] Botan 3.12 + `-DENABLE_PQC=on` → configures cleanly, no warning
- [x] Botan 3.4.0 (from the #2462 audit) → non-PQC path compiles and tests green
- [ ] CI

### Support matrix after this PR

| Botan | Status |
|---|---|
| 2.14 - 3.5 | supported, PQC auto-off / rejected if forced |
| 3.6.x | non-PQC works on x86-64; **arm64 crashes upstream** (warning); PQC rejected |
| >= 3.7 | fully supported incl. PQC |
