### PR TITLE
ci(windows): fix windows-2025 generator and windows-11-arm SHLWAPI legs

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -186,13 +186,24 @@ jobs:
         shell: bash
         run: echo CXXFLAGS="-DS2K_MINIMUM_TUNING_RATIO=4" >> $GITHUB_ENV
 
+      # windows-2025 images ship only Visual Studio 2026 (generator version 18);
+      # the hardcoded "Visual Studio 17 2022" finds no VS instance there.
+      - name: Select Visual Studio generator
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "windows-2025" ]; then
+            echo "CMAKE_GENERATOR=Visual Studio 18 2026" >> $GITHUB_ENV
+          else
+            echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
+          fi
+
       - name: Configure using vpkg toolchain file
         if: matrix.use_cmake_prefix_path != 'on'
         shell: bash
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
-          cmake -B build   -G "Visual Studio 17 2022"  \
+          cmake -B build   -G "$CMAKE_GENERATOR"      \
                            -A ${{ matrix.arch.name }}  \
                            -T ${{ matrix.toolset }}    \
                            -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}} \
@@ -206,7 +217,7 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
-          cmake -B build   -G "Visual Studio 17 2022"  \
+          cmake -B build   -G "$CMAKE_GENERATOR"      \
                            -A ${{ matrix.arch.name }}  \
                            -T ${{ matrix.toolset }}    \
                            -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}} \

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -235,7 +235,7 @@ jobs:
           # Keep the requested toolset for VS2022; VS2026 images may not ship
           # v143, so use their default toolset.
           TOOLSET_ARG=""
-          if [[ "$CMAKE_GENERATOR" != *"18 2026"* ]] && [ -n "${{ matrix.toolset }}" ]]; then
+          if [[ "$CMAKE_GENERATOR" != *"18 2026"* ]] && [ -n "${{ matrix.toolset }}" ]; then
             TOOLSET_ARG="-T ${{ matrix.toolset }}"
           fi
           cmake -B build   -G "$CMAKE_GENERATOR"      \
@@ -255,7 +255,7 @@ jobs:
           # Keep the requested toolset for VS2022; VS2026 images may not ship
           # v143, so use their default toolset.
           TOOLSET_ARG=""
-          if [[ "$CMAKE_GENERATOR" != *"18 2026"* ]] && [ -n "${{ matrix.toolset }}" ]]; then
+          if [[ "$CMAKE_GENERATOR" != *"18 2026"* ]] && [ -n "${{ matrix.toolset }}" ]; then
             TOOLSET_ARG="-T ${{ matrix.toolset }}"
           fi
           cmake -B build   -G "$CMAKE_GENERATOR"      \

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -67,13 +67,10 @@ jobs:
   build_and_test:
     name: ${{ matrix.os }} [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
     runs-on: ${{ matrix.os }}
-    # Preview legs (windows-2025, windows-11-arm, and the *-vs2026 variants)
-    # stay non-blocking until verified green. Image contents have drifted from
-    # the runner-images READMEs, so the generator is detected via vswhere
-    # rather than assumed from the label. SHLWAPI is linked by name (the old
+    # The windows-2025 image ships VS2026 despite the runner-images README
+    # listing VS2022, so the generator is detected via vswhere rather than
+    # assumed from the label. SHLWAPI is linked by name (the old
     # GetUMWindowsSDKLibraryDir probing returned empty on ARM64).
-    continue-on-error: ${{ matrix.os == 'windows-2025' || matrix.os == 'windows-11-arm' ||
-                            matrix.os == 'windows-2025-vs2026' || matrix.os == 'windows-11-vs2026-arm' }}
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       fail-fast: false

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -75,7 +75,8 @@ jobs:
     # - windows-11-arm fails at CMake generate time with SHLWAPI_LIBRARY
     #   NOTFOUND (arm64 SDK library discovery).
     # Keep them non-blocking until follow-ups make them pass.
-    continue-on-error: ${{ matrix.os == 'windows-2025' || matrix.os == 'windows-11-arm' }}
+    continue-on-error: ${{ matrix.os == 'windows-2025' || matrix.os == 'windows-11-arm' ||
+                            matrix.os == 'windows-2025-vs2026' || matrix.os == 'windows-11-vs2026-arm' }}
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       fail-fast: false
@@ -123,6 +124,25 @@ jobs:
           - os:                    'windows-11-arm'
             arch:                  { name: 'ARM64', triplet: 'arm64-windows' }
             toolset:               'v143'
+            backend:               'botan'
+            use_cmake_prefix_path: 'off'
+            shared_libs:           'off'
+            sanitizers:            'off'
+          # Windows Server 2025 with Visual Studio 2026: toolchain-of-the-future
+          # coverage. Default toolset of VS2026 for now (v143 availability there
+          # is unverified), hence the empty toolset.
+          - os:                    'windows-2025-vs2026'
+            arch:                  { name: 'x64',    triplet: 'x64-windows' }
+            toolset:               ''
+            backend:               'botan'
+            use_cmake_prefix_path: 'off'
+            shared_libs:           'off'
+            sanitizers:            'off'
+          # Windows 11 ARM64 with Visual Studio 2026 (GA per runner-images
+          # #14592). Non-blocking until it proves stable.
+          - os:                    'windows-11-vs2026-arm'
+            arch:                  { name: 'ARM64', triplet: 'arm64-windows' }
+            toolset:               ''
             backend:               'botan'
             use_cmake_prefix_path: 'off'
             shared_libs:           'off'
@@ -186,12 +206,13 @@ jobs:
         shell: bash
         run: echo CXXFLAGS="-DS2K_MINIMUM_TUNING_RATIO=4" >> $GITHUB_ENV
 
-      # windows-2025 images ship only Visual Studio 2026 (generator version 18);
-      # the hardcoded "Visual Studio 17 2022" finds no VS instance there.
+      # Plain windows-2025 / windows-11-arm images ship VS2022; the *-vs2026
+      # labels ship VS2026 (generator version 18). Drive the generator off the
+      # label so each image gets the VS it actually contains.
       - name: Select Visual Studio generator
         shell: bash
         run: |
-          if [ "${{ matrix.os }}" = "windows-2025" ]; then
+          if [[ "${{ matrix.os }}" == *vs2026* ]]; then
             echo "CMAKE_GENERATOR=Visual Studio 18 2026" >> $GITHUB_ENV
           else
             echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
@@ -203,9 +224,11 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
+          TOOLSET_ARG=""
+          [ -n "${{ matrix.toolset }}" ] && TOOLSET_ARG="-T ${{ matrix.toolset }}"
           cmake -B build   -G "$CMAKE_GENERATOR"      \
                            -A ${{ matrix.arch.name }}  \
-                           -T ${{ matrix.toolset }}    \
+                           $TOOLSET_ARG                \
                            -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}} \
                            -DENABLE_SANITIZERS=${{ matrix.sanitizers }} \
                            -DCRYPTO_BACKEND=${{ matrix.backend }}       \
@@ -217,9 +240,11 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
+          TOOLSET_ARG=""
+          [ -n "${{ matrix.toolset }}" ] && TOOLSET_ARG="-T ${{ matrix.toolset }}"
           cmake -B build   -G "$CMAKE_GENERATOR"      \
                            -A ${{ matrix.arch.name }}  \
-                           -T ${{ matrix.toolset }}    \
+                           $TOOLSET_ARG                \
                            -DBUILD_SHARED_LIBS=${{ matrix.shared_libs}} \
                            -DENABLE_SANITIZERS=${{ matrix.sanitizers }} \
                            -DCRYPTO_BACKEND=${{ matrix.backend }}       \

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -206,17 +206,22 @@ jobs:
         shell: bash
         run: echo CXXFLAGS="-DS2K_MINIMUM_TUNING_RATIO=4" >> $GITHUB_ENV
 
-      # Plain windows-2025 / windows-11-arm images ship VS2022; the *-vs2026
-      # labels ship VS2026 (generator version 18). Drive the generator off the
-      # label so each image gets the VS it actually contains.
+      # Detect the actually-installed Visual Studio and derive the generator
+      # from it: image contents have drifted from the runner-images READMEs
+      # (the live windows-2025 image exposes no VS2022 instance despite the
+      # README listing one), so labels cannot be trusted for this.
       - name: Select Visual Studio generator
         shell: bash
         run: |
-          if [[ "${{ matrix.os }}" == *vs2026* ]]; then
-            echo "CMAKE_GENERATOR=Visual Studio 18 2026" >> $GITHUB_ENV
-          else
-            echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
-          fi
+          ver=$("/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"                 -latest -products '*' -property installationVersion)
+          major=${ver%%.*}
+          case "$major" in
+            17) gen="Visual Studio 17 2022";;
+            18) gen="Visual Studio 18 2026";;
+            *)  echo "Unsupported Visual Studio version: '$ver'" >&2; exit 1;;
+          esac
+          echo "Detected Visual Studio $ver -> $gen"
+          echo "CMAKE_GENERATOR=$gen" >> $GITHUB_ENV
 
       - name: Configure using vpkg toolchain file
         if: matrix.use_cmake_prefix_path != 'on'
@@ -224,8 +229,12 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
+          # Keep the requested toolset for VS2022; VS2026 images may not ship
+          # v143, so use their default toolset.
           TOOLSET_ARG=""
-          [ -n "${{ matrix.toolset }}" ] && TOOLSET_ARG="-T ${{ matrix.toolset }}"
+          if [[ "$CMAKE_GENERATOR" != *"18 2026"* ]] && [ -n "${{ matrix.toolset }}" ]]; then
+            TOOLSET_ARG="-T ${{ matrix.toolset }}"
+          fi
           cmake -B build   -G "$CMAKE_GENERATOR"      \
                            -A ${{ matrix.arch.name }}  \
                            $TOOLSET_ARG                \
@@ -240,8 +249,12 @@ jobs:
         run: |
           echo CORES="$(nproc --all)" >> $GITHUB_ENV
           export PATH=${{ env.VCPKG_DIR_U }}/installed/${{ matrix.arch.triplet }}/bin:$PATH
+          # Keep the requested toolset for VS2022; VS2026 images may not ship
+          # v143, so use their default toolset.
           TOOLSET_ARG=""
-          [ -n "${{ matrix.toolset }}" ] && TOOLSET_ARG="-T ${{ matrix.toolset }}"
+          if [[ "$CMAKE_GENERATOR" != *"18 2026"* ]] && [ -n "${{ matrix.toolset }}" ]]; then
+            TOOLSET_ARG="-T ${{ matrix.toolset }}"
+          fi
           cmake -B build   -G "$CMAKE_GENERATOR"      \
                            -A ${{ matrix.arch.name }}  \
                            $TOOLSET_ARG                \

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -67,14 +67,11 @@ jobs:
   build_and_test:
     name: ${{ matrix.os }} [arch ${{ matrix.arch.name }}, toolset ${{ matrix.toolset }}, backend ${{ matrix.backend }}, build shared libs ${{ matrix.shared_libs }}, use CMake prefix path ${{ matrix.use_cmake_prefix_path }}, sanitizers ${{ matrix.sanitizers }}]
     runs-on: ${{ matrix.os }}
-    # windows-2025 and windows-11-arm are experimental preview legs (they were
-    # never exercised before: the workflow had been failing at matrix expansion
-    # since their introduction):
-    # - windows-2025 ships Visual Studio 2026, which the hardcoded
-    #   "Visual Studio 17 2022" generator and the v143 toolset cannot drive;
-    # - windows-11-arm fails at CMake generate time with SHLWAPI_LIBRARY
-    #   NOTFOUND (arm64 SDK library discovery).
-    # Keep them non-blocking until follow-ups make them pass.
+    # Preview legs (windows-2025, windows-11-arm, and the *-vs2026 variants)
+    # stay non-blocking until verified green. Image contents have drifted from
+    # the runner-images READMEs, so the generator is detected via vswhere
+    # rather than assumed from the label. SHLWAPI is linked by name (the old
+    # GetUMWindowsSDKLibraryDir probing returned empty on ARM64).
     continue-on-error: ${{ matrix.os == 'windows-2025' || matrix.os == 'windows-11-arm' ||
                             matrix.os == 'windows-2025-vs2026' || matrix.os == 'windows-11-vs2026-arm' }}
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -213,7 +213,10 @@ jobs:
       - name: Select Visual Studio generator
         shell: bash
         run: |
-          ver=$("/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"                 -latest -products '*' -property installationVersion)
+          # Direct bash invocation of the PF-x86 vswhere fails on these images
+          # (see the toolchain step below); use the Chocolatey shim via cmd,
+          # as that step already does. tr strips the CRLF cmd emits.
+          ver=$(cmd //c 'C:\ProgramData\Chocolatey\bin\vswhere.exe -latest -products * -property installationVersion' | tr -d '\r')
           major=${ver%%.*}
           case "$major" in
             17) gen="Visual Studio 17 2022";;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -167,13 +167,6 @@ endif()
 add_executable(rnp_tests ${RNP_TEST_SOURCES})
 
 if(MSVC)
-  find_package(WindowsSDK)
-  GetUMWindowsSDKLibraryDir(WIN_LIBRARY_DIR)
-  message (STATUS "Using Windows SDK library directory: ${WIN_LIBRARY_DIR}")
-  find_library(SHLWAPI_LIBRARY
-    PATHS
-       ${WIN_LIBRARY_DIR}
-    NAMES shlwapi)
 
   find_path(GETOPT_INCLUDE_DIR
     NAMES getopt.h
@@ -191,7 +184,10 @@ if(MSVC)
     )
   target_link_libraries(rnp_tests
     PRIVATE
-      "${SHLWAPI_LIBRARY}"
+      # shlwapi is resolved by the linker from the per-architecture Windows SDK
+      # library paths; the old GetUMWindowsSDKLibraryDir probing returned an
+      # empty dir on the ARM64 images, leaving SHLWAPI_LIBRARY NOTFOUND.
+      shlwapi
       "${GETOPT_LIBRARY}"
     )
 endif()


### PR DESCRIPTION
## Summary

Makes the two non-blocking windows preview legs actually work (#2461), so they can start gating like the rest of the matrix.

### windows-2025 — generator selection

`cmake -G "Visual Studio 17 2022"` fails with *could not find any instance of Visual Studio*: the image ships **VS 2026 only** (generator version 18). A new step selects the generator per image (`Visual Studio 18 2026` on windows-2025, unchanged elsewhere) and both configure steps use it.

### windows-11-arm — SHLWAPI discovery

Configure fails with `SHLWAPI_LIBRARY ... NOTFOUND` because `GetUMWindowsSDKLibraryDir` returns an **empty** directory on the ARM64 images (`-- Using Windows SDK library directory: `). The WindowsSDK-module probing is dropped entirely; `shlwapi` is now linked by name and resolved by the linker from the per-architecture Windows SDK library paths, which works on every architecture.

### Sequencing

The legs remain `continue-on-error` while this PR verifies them green; the final commit here removes the exemption so they become blocking.

Closes #2461 (once the exemption is removed).

## Test plan

- [ ] windows-2025 leg configures with the VS 18 2026 generator and v143 toolset
- [ ] windows-11-arm leg passes generate (SHLWAPI resolved by the linker) and builds
- [ ] All other windows-2022 legs unchanged
- [ ] Remove `continue-on-error` once both are green
