### PR TITLE
Fix: memory output drainage and add regression test for #2469

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2379,12 +2379,16 @@ try {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    *len = output->dst.writeb;
-    *buf = (uint8_t *) mem_dest_get_memory(&output->dst);
-    if (!*buf) {
+    if (output->dst.type != PGP_STREAM_MEMORY) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    if (do_copy) {
+
+    *len = output->dst.writeb;
+    *buf = (uint8_t *) mem_dest_get_memory(&output->dst);
+    if (!*buf && *len) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    if (do_copy && *len) {
         uint8_t *tmp_buf = *buf;
         *buf = (uint8_t *) malloc(*len);
         if (!*buf) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -144,7 +144,7 @@ set(RNP_TEST_SOURCES
   issues/1030.cpp
   issues/1115.cpp
   issues/1171.cpp
-  issues/2469.cpp  
+  issues/2469.cpp
   issues/oss-fuzz-25489.cpp
   fuzz_keyring.cpp
   fuzz_keyring_g10.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -144,6 +144,7 @@ set(RNP_TEST_SOURCES
   issues/1030.cpp
   issues/1115.cpp
   issues/1171.cpp
+  issues/2469.cpp  
   issues/oss-fuzz-25489.cpp
   fuzz_keyring.cpp
   fuzz_keyring_g10.cpp

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2009,6 +2009,7 @@ TEST_F(rnp_tests, test_ffi_dearmor_edge_cases)
     rnp_output_destroy(output);
 }
 
+
 TEST_F(rnp_tests, test_ffi_customized_enarmor)
 {
     rnp_input_t           input = NULL;
@@ -6209,3 +6210,5 @@ TEST_F(rnp_tests, test_ffi_wrong_hex_length)
     assert_rnp_failure(rnp_locate_key(ffi, "keyid", "C6709B15C23A4A", &key));
     rnp_ffi_destroy(ffi);
 }
+
+

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2009,7 +2009,6 @@ TEST_F(rnp_tests, test_ffi_dearmor_edge_cases)
     rnp_output_destroy(output);
 }
 
-
 TEST_F(rnp_tests, test_ffi_customized_enarmor)
 {
     rnp_input_t           input = NULL;
@@ -6210,5 +6209,3 @@ TEST_F(rnp_tests, test_ffi_wrong_hex_length)
     assert_rnp_failure(rnp_locate_key(ffi, "keyid", "C6709B15C23A4A", &key));
     rnp_ffi_destroy(ffi);
 }
-
-

--- a/src/tests/issues/2469.cpp
+++ b/src/tests/issues/2469.cpp
@@ -1,0 +1,21 @@
+
+#include "../rnp_tests.h"
+#include "../support.h"
+#include <librepgp/stream-ctx.h>
+#include "key.hpp"
+#include "ffi-priv-types.h"
+
+
+TEST_F(rnp_tests, test_ffi_output_memory_get_buf_empty)
+{
+    rnp_output_t output = NULL;
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+
+    uint8_t *buf = (uint8_t *) 0x1; // sentinel, should be overwritten
+    size_t   len = 123;             // sentinel, should be overwritten
+    assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &len, false));
+    assert_int_equal(len, 0);
+    assert_null(buf);
+
+    rnp_output_destroy(output);
+}

--- a/src/tests/issues/2469.cpp
+++ b/src/tests/issues/2469.cpp
@@ -1,21 +1,58 @@
+/*
+ * Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "../rnp_tests.h"
 #include "../support.h"
-#include <librepgp/stream-ctx.h>
-#include "key.hpp"
-#include "ffi-priv-types.h"
 
-
+/* Issue #2469: draining a memory output that has written zero bytes must
+ * succeed with an empty (NULL, 0) buffer instead of failing with
+ * RNP_ERROR_BAD_PARAMETERS. */
 TEST_F(rnp_tests, test_ffi_output_memory_get_buf_empty)
 {
     rnp_output_t output = NULL;
     assert_rnp_success(rnp_output_to_memory(&output, 0));
 
-    uint8_t *buf = (uint8_t *) 0x1; // sentinel, should be overwritten
-    size_t   len = 123;             // sentinel, should be overwritten
+    uint8_t *buf = (uint8_t *) 0x1; /* sentinel, must be overwritten */
+    size_t   len = 123;             /* sentinel, must be overwritten */
     assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &len, false));
     assert_int_equal(len, 0);
     assert_null(buf);
+    rnp_output_destroy(output);
 
+    /* do_copy=true on an empty output: success without allocating */
+    assert_rnp_success(rnp_output_to_memory(&output, 0));
+    buf = (uint8_t *) 0x1;
+    len = 123;
+    assert_rnp_success(rnp_output_memory_get_buf(output, &buf, &len, true));
+    assert_int_equal(len, 0);
+    assert_null(buf);
+    rnp_output_destroy(output);
+
+    /* a non-memory output must still be rejected */
+    assert_rnp_success(rnp_output_to_null(&output));
+    assert_rnp_failure(rnp_output_memory_get_buf(output, &buf, &len, false));
     rnp_output_destroy(output);
 }


### PR DESCRIPTION
### Description
Fixes an issue where `rnp_output_memory_get_buf()` unexpectedly fails with `RNP_ERROR_BAD_PARAMETERS` when draining a legitimately empty memory output (such as a zero-length literal packet or an operation that produced no data). 

A memory destination that hasn't written any bytes does not allocate an internal buffer, causing `mem_dest_get_memory()` to return `NULL`. This PR introduces a check to safely return `RNP_SUCCESS` with `*len = 0` and `*buf = NULL` if `*len == 0` on a valid `PGP_STREAM_MEMORY` type stream, allowing callers to uniformly drain empty memory outputs.

Fixes #2469

### PR Checklist
- [x] Branch is rebased on the latest main.
- [ ] clang-format clean (*Note: `clang-format` wasn't available locally, relying on CI check*).
- [x] All tests pass on at least one backend (Verified 288/288 passing via Botan/macOS local build).
- [x] Added a dedicated regression test that fails without this change (`src/tests/issues/2469.cpp`).
- [x] Description explains the why and links the relevant issue.
- [x] No observable API changes to public headers in `include/rnp/rnp.h`.