### PR TITLE
cmake: link CMAKE_DL_LIBS into the static findopensslfeatures probe

### DIFF
--- a/cmake/Modules/FindOpenSSLFeatures.cmake
+++ b/cmake/Modules/FindOpenSSLFeatures.cmake
@@ -87,6 +87,9 @@ if (OpenSSL::applink)
 endif(OpenSSL::applink)
 if(CMAKE_CROSSCOMPILING_EMULATOR)
   target_link_options(findopensslfeatures PRIVATE -static)
+  # A static libcrypto may reference dlopen() & co (dso_dlfcn.o) while
+  # FindOpenSSL only adds CMAKE_DL_LIBS when pkg-config reports them
+  target_link_libraries(findopensslfeatures PRIVATE ${CMAKE_DL_LIBS})
 endif(CMAKE_CROSSCOMPILING_EMULATOR)
 if (WIN32 AND NOT MINGW)
   target_link_libraries(findopensslfeatures PRIVATE Crypt32 Ws2_32 Advapi32 User32)


### PR DESCRIPTION
Follow-up to #2396 (cross-compilation with the OpenSSL backend).

When `CMAKE_CROSSCOMPILING_EMULATOR` is set the `findopensslfeatures` probe is linked with `-static`. A static OpenSSL 1.1.1 `libcrypto.a` pulls in `dso_dlfcn.o`, which references `dlopen`/`dlsym`/`dlclose`/`dlerror`, and CMake's `FindOpenSSL` only appends `CMAKE_DL_LIBS` to `OpenSSL::Crypto` when pkg-config lists it in `Libs.private` — which a bare cross sysroot does not have. The probe then fails to link:

```
ld.lld: error: undefined symbol: dlopen
>>> referenced by dso_dlfcn.c
>>>               dso_dlfcn.o:(dlfcn_load) in archive .../sysroot/usr/lib/libcrypto.a
...
CMake Error at cmake/Modules/FindOpenSSLFeatures.cmake:149 (message):
  Error building findopensslfeatures
```

This links `${CMAKE_DL_LIBS}` explicitly in the same `CMAKE_CROSSCOMPILING_EMULATOR` branch that adds `-static`. It is added as a library rather than a link option so it is ordered after `libcrypto.a` for linkers that resolve archives in a single pass; where `CMAKE_DL_LIBS` is empty it is a no-op (`target_link_libraries(t PRIVATE )` is valid).

### Tested

Android NDK r29 (`aarch64-linux-android24-clang`, `ld.lld`), OpenSSL 1.1.1n static, `CRYPTO_BACKEND=openssl`, `CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-aarch64`, host CMake 3.28.3 — the RetroShare Android toolchain (RetroShare/libretroshare#376):

- `main` (ee97ed76): the four `undefined symbol: dl*` errors above, `Error building findopensslfeatures`.
- this branch: configures, the probe runs under qemu and enumerates the features, `librnp.a` builds and installs.

Native (non-cross) builds do not enter the branch and are unchanged.
