### PR TITLE
Support both asciidoctor and asciidoc-py for man pages

### DIFF
--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of rnp
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+name: man-pages
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - 'src/**/*.adoc'
+      - 'cmake/Modules/AdocMan.cmake'
+      - 'cmake/Modules/adoc-manpage.xsl'
+      - 'ci/check-man-pages.sh'
+      - '.github/workflows/man-pages.yml'
+  pull_request:
+    paths:
+      - 'src/**/*.adoc'
+      - 'cmake/Modules/AdocMan.cmake'
+      - 'cmake/Modules/adoc-manpage.xsl'
+      - 'ci/check-man-pages.sh'
+      - '.github/workflows/man-pages.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  dual-toolchain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install toolchains
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install asciidoctor asciidoc docbook-xsl xsltproc man-db
+
+      # Exercises both supported man page toolchains (asciidoctor and
+      # asciidoc-py, #2395) and fails on warnings or render divergence.
+      - name: Check man pages with both toolchains
+        run: ./ci/check-man-pages.sh

--- a/ci/check-man-pages.sh
+++ b/ci/check-man-pages.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Build the man pages with both supported toolchains (asciidoctor, and
+# classic asciidoc-py via docbook + xsltproc) and compare the rendered
+# output, so syntax that only one tool understands — or renders
+# differently — cannot creep into the .adoc sources (#2395).
+#
+# Modeled on git's ci/test-documentation.sh: any warning on stderr from
+# either toolchain fails the check.
+#
+# Requires: asciidoctor, asciidoc, xsltproc, docbook-xsl (registered in
+# the XML catalog), man-db.
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+PAGES="src/rnp/rnp.1.adoc src/rnpkeys/rnpkeys.1.adoc src/lib/librnp.3.adoc"
+VERSION="0.0.0-check"
+
+if command -v mandoc >/dev/null 2>&1; then
+  render() { mandoc -Tutf8 -Owidth=80 "$1" 2>/dev/null; }
+else
+  render() { MANWIDTH=80 man --nh --nj -l "$1" 2>/dev/null; }
+fi
+
+# The trailing AUTHOR section and page footer are dropped: their exact
+# shape (bold author, "Author." subheading, date format) differs between
+# the backends without being a content difference. mandoc -Tutf8 renders
+# bold via overstruck doubled characters, hence the .? between letters.
+normalize() {
+  sed -E -e 's#<(https?://[^>]*)>#\1#g' \
+      -e '/^[ \t]*(A.AU.UT.TH.HO.OR.R|AUTHOR)[ \t]*$/,$d' \
+    | tr -s '[:space:]' ' '
+}
+
+fail=0
+
+for page in $PAGES; do
+  name="$(basename "$page" .adoc)"
+
+  asciidoctor -b manpage -a component-version="$VERSION" -o "$name.ad" "$page" 2> "$name.ad.err"
+  asciidoc -b docbook -d manpage -a component-version="$VERSION" -o "$name.xml" "$page" 2> "$name.py.err"
+  # docbook-xsl names its output after the first NAME refname; run in a
+  # scratch dir so it lands on a known path.
+  mkdir -p "$name.py.d"
+  ( cd "$name.py.d" && xsltproc --nonet ../cmake/Modules/adoc-manpage.xsl "../$name.xml" ) 2> "$name.py.d.err"
+
+  for err in "$name.ad.err" "$name.py.err" "$name.py.d.err"; do
+    if [ -s "$err" ]; then
+      echo "error: $page: $(basename "$err") is not empty:" >&2
+      cat "$err" >&2
+      fail=1
+    fi
+  done
+
+  if ! diff -u \
+      <(render "$name.ad" | normalize | fold -w 80) \
+      <(render "$name.py.d/$name" | normalize | fold -w 80) > "$name.diff"; then
+    echo "error: $page renders differently under asciidoctor and asciidoc:" >&2
+    cat "$name.diff" >&2
+    fail=1
+  fi
+
+  rm -rf "$name.ad" "$name.ad.err" "$name.xml" "$name.py.err" "$name.py.d" "$name.py.d.err" "$name.diff"
+done
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "all man pages build warning-free and render identically with both toolchains"

--- a/ci/check-man-pages.sh
+++ b/ci/check-man-pages.sh
@@ -33,6 +33,13 @@ normalize() {
     | tr -s '[:space:]' ' '
 }
 
+# Toolchain noise that does not indicate a documentation problem:
+# asciidoc-py < 10.2.1 emits Python SyntaxWarnings from its own config
+# on Python 3.12+ (git's ci/test-documentation.sh filters the same).
+filter_err() {
+  sed -e '/SyntaxWarning: invalid escape sequence/d' "$1"
+}
+
 fail=0
 
 for page in $PAGES; do
@@ -46,7 +53,7 @@ for page in $PAGES; do
   ( cd "$name.py.d" && xsltproc --nonet ../cmake/Modules/adoc-manpage.xsl "../$name.xml" ) 2> "$name.py.d.err"
 
   for err in "$name.ad.err" "$name.py.err" "$name.py.d.err"; do
-    if [ -s "$err" ]; then
+    if [ -n "$(filter_err "$err")" ]; then
       echo "error: $page: $(basename "$err") is not empty:" >&2
       cat "$err" >&2
       fail=1

--- a/cmake/Modules/AdocMan.cmake
+++ b/cmake/Modules/AdocMan.cmake
@@ -38,35 +38,72 @@
 #
 
 set(ADOCCOMMAND_FOUND 0)
+set(ADOC_BACKEND "")
+set(ADOC_MANPAGE_XSL "${CMAKE_CURRENT_LIST_DIR}/adoc-manpage.xsl")
 
-# Man page generation requires the `manpage` backend, which is an
-# asciidoctor feature. Classic Python asciidoc has no manpage backend
-# (it fails with "missing backend conf file: manpage.conf" and needs the
-# docbook+xmlto/a2x pipeline instead), so it must NOT be picked up as an
-# automatic fallback — any environment with only asciidoc installed would
-# break the build at man-page generation time. Distros that don't ship
-# asciidoctor by default (e.g. Debian, #2395) can `apt install asciidoctor`,
-# or build with ENABLE_DOC=Off to skip man pages entirely.
+# Man page generation supports two toolchains (#2395):
+#  - asciidoctor with its native `manpage` backend (preferred, no extra deps);
+#  - classic Python asciidoc (asciidoc-py) which has no manpage backend:
+#    it goes through docbook XML and xsltproc/docbook-xsl instead
+#    (the same a2x pipeline git uses). cmake/Modules/adoc-manpage.xsl
+#    supplements stock docbook-xsl with the `<?asciidoc-br?>` handling
+#    and suppressions a2x's bundled sheet applies.
 find_program(ADOCCOMMAND_PATH
   NAMES asciidoctor
   DOC "Path to AsciiDoc processor. Used to generate man pages from AsciiDoc."
 )
+find_program(ADOC_ASCIIDOC_PATH
+  NAMES asciidoc
+  DOC "Path to classic Python asciidoc processor (man pages via docbook + xsltproc)."
+)
+find_program(ADOC_XSLTPROC_PATH
+  NAMES xsltproc
+  DOC "Path to xsltproc. Used with the asciidoc docbook backend to build man pages."
+)
 
-# Escape hatch for packagers who wire up a custom processor that does
-# support -b manpage (e.g. a vendored asciidoctor under a different name).
+# Escape hatch for packagers who wire up a custom processor. Setting
+# ASCIIDOC_TOOL=asciidoc selects the docbook+xsltproc backend; any other
+# value must be a processor supporting -b manpage (e.g. a vendored
+# asciidoctor under a different name).
 if(DEFINED ASCIIDOC_TOOL)
-  find_program(ADOCCOMMAND_PATH
-    NAMES ${ASCIIDOC_TOOL}
-    DOC "Path to AsciiDoc processor (forced via ASCIIDOC_TOOL=${ASCIIDOC_TOOL})."
-  )
+  if("${ASCIIDOC_TOOL}" STREQUAL "asciidoc")
+    set(ADOC_BACKEND "asciidoc")
+    find_program(ADOC_ASCIIDOC_PATH
+      NAMES ${ASCIIDOC_TOOL}
+      DOC "Path to asciidoc processor (forced via ASCIIDOC_TOOL=${ASCIIDOC_TOOL})."
+    )
+  else()
+    set(ADOC_BACKEND "asciidoctor")
+    find_program(ADOCCOMMAND_PATH
+      NAMES ${ASCIIDOC_TOOL}
+      DOC "Path to AsciiDoc processor (forced via ASCIIDOC_TOOL=${ASCIIDOC_TOOL})."
+    )
+  endif()
+elseif(ADOCCOMMAND_PATH)
+  set(ADOC_BACKEND "asciidoctor")
+elseif(ADOC_ASCIIDOC_PATH AND ADOC_XSLTPROC_PATH)
+  set(ADOC_BACKEND "asciidoc")
 endif()
 
-if(NOT EXISTS ${ADOCCOMMAND_PATH})
+if("${ADOC_BACKEND}" STREQUAL "asciidoc")
+  if(NOT ADOC_ASCIIDOC_PATH OR NOT ADOC_XSLTPROC_PATH)
+    message(FATAL_ERROR "ASCIIDOC_TOOL=asciidoc requires both asciidoc and xsltproc (plus the docbook-xsl stylesheets registered in the XML catalog).")
+  endif()
+  set(ADOCCOMMAND_FOUND 1)
+elseif("${ADOC_BACKEND}" STREQUAL "asciidoctor")
+  if(NOT EXISTS ${ADOCCOMMAND_PATH})
+    set(ADOC_BACKEND "")
+  else()
+    set(ADOCCOMMAND_FOUND 1)
+  endif()
+endif()
+
+if(NOT ADOC_BACKEND)
   if(EXISTS "${CMAKE_SOURCE_DIR}/docs/man")
     set(ADOC_USING_CACHE 1)
-    set(ADOC_MISSING_MSG "AsciiDoc processor not found; installing pre-generated man pages from docs/man/. Refresh them with ci/regen-man-pages.sh when the .adoc sources change.")
+    set(ADOC_MISSING_MSG "No AsciiDoc toolchain found (asciidoctor, or asciidoc + xsltproc); installing pre-generated man pages from docs/man/. Refresh them with ci/regen-man-pages.sh when the .adoc sources change.")
   else()
-    set(ADOC_MISSING_MSG "AsciiDoc processor not found and no pre-generated man pages in docs/man/. Install asciidoctor, or refresh the cache with ci/regen-man-pages.sh on a machine that has it.")
+    set(ADOC_MISSING_MSG "No AsciiDoc toolchain found (asciidoctor, or asciidoc + xsltproc) and no pre-generated man pages in docs/man/. Install a toolchain, or refresh the cache with ci/regen-man-pages.sh on a machine that has one.")
   endif()
 
   string(TOLOWER "${ENABLE_DOC}" ENABLE_DOC)
@@ -76,7 +113,7 @@ if(NOT EXISTS ${ADOCCOMMAND_PATH})
     message(FATAL_ERROR ${ADOC_MISSING_MSG})
   endif()
 else()
-  set(ADOCCOMMAND_FOUND 1)
+  message(STATUS "Man pages: ${ADOC_BACKEND} backend")
 endif()
 
 function(add_adoc_man SRC COMPONENT_VERSION)
@@ -146,7 +183,7 @@ function(add_adoc_man SRC COMPONENT_VERSION)
   # packagers don't need asciidoctor installed (#2395).
   set(MAN_CACHE "${CMAKE_SOURCE_DIR}/docs/man/${FILE_NAME_WE}.${MAN_NUM}")
 
-  if(${ADOCCOMMAND_FOUND})
+  if("${ADOC_BACKEND}" STREQUAL "asciidoctor")
     add_custom_command(
       OUTPUT ${DST}
       # Options must precede the source file: asciidoctor accepts any order,
@@ -156,6 +193,35 @@ function(add_adoc_man SRC COMPONENT_VERSION)
       DEPENDS ${SRC}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       COMMENT "Generating man page ${SUBDIR_PATH_DIRECTORY}/${SUBDIR_PATH_NAME_WLE}"
+      VERBATIM
+    )
+  elseif("${ADOC_BACKEND}" STREQUAL "asciidoc")
+    # docbook-xsl names its output file after the first refname of the NAME
+    # section, not after the source file, so the refname must equal the
+    # source file base name for the output to land on ${DST}.
+    file(READ ${SRC} ADOC_SRC)
+    string(REGEX MATCH "== NAME[^\n]*\n[^\n]*\n+[ \t]*([A-Za-z0-9_.+-]+)[ \t]+-" ADOC_NAME_MATCH "${ADOC_SRC}")
+    set(ADOC_REFNAME "${CMAKE_MATCH_1}")
+    if(NOT ADOC_REFNAME)
+      message(FATAL_ERROR "Cannot find the NAME section in ${FILE_NAME}; it is required for man page generation.")
+    endif()
+    if(NOT ADOC_REFNAME STREQUAL FILE_NAME_WE)
+      message(FATAL_ERROR "The NAME section of ${FILE_NAME} must start with '${FILE_NAME_WE}' (found '${ADOC_REFNAME}'): docbook-xsl names the man page after the first refname.")
+    endif()
+
+    set(ADOC_XML "${DST}.xml")
+    get_filename_component(DST_DIR ${DST} DIRECTORY)
+    # xsltproc resolves the stylesheet's docbook-xsl import through the system
+    # XML catalog (/etc/xml/catalog), where distro docbook-xsl packages
+    # register it; --nonet fails fast when the catalog is missing.
+    add_custom_command(
+      OUTPUT ${DST}
+      COMMAND ${ADOC_ASCIIDOC_PATH} -b docbook -d manpage -a component-version=${COMPONENT_VERSION} -o ${ADOC_XML} ${SRC}
+      COMMAND ${ADOC_XSLTPROC_PATH} --nonet ${ADOC_MANPAGE_XSL} ${ADOC_XML}
+      COMMAND ${CMAKE_COMMAND} -E remove ${ADOC_XML}
+      DEPENDS ${SRC} ${ADOC_MANPAGE_XSL}
+      WORKING_DIRECTORY ${DST_DIR}
+      COMMENT "Generating man page ${SUBDIR_PATH_DIRECTORY}/${SUBDIR_PATH_NAME_WLE} (asciidoc backend)"
       VERBATIM
     )
   elseif(EXISTS ${MAN_CACHE})

--- a/cmake/Modules/adoc-manpage.xsl
+++ b/cmake/Modules/adoc-manpage.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+  Man page stylesheet for the classic Python asciidoc (asciidoc-py) backend,
+  used by cmake/Modules/AdocMan.cmake as the asciidoctor alternative (#2395).
+
+  Imports the stock docbook-xsl manpages stylesheet (resolved through the
+  system XML catalog, never the network) and applies the same adjustments
+  as a2x's bundled manpage.xsl, plus the hard line break handling git needs
+  in its own dual-toolchain setup:
+    - `<?asciidoc-br?>` (asciidoc's `+` line break) becomes a roff .br
+      request; stock docbook-xsl drops it silently;
+    - ulink renders text only, without the auto-generated REFERENCES list;
+    - progress notes are silenced.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl"/>
+
+<xsl:param name="man.output.quietly" select="1"/>
+<xsl:param name="refentry.meta.get.quietly" select="1"/>
+
+<xsl:template match="processing-instruction('asciidoc-br')">
+<xsl:text>.br
+</xsl:text>
+</xsl:template>
+
+<!-- Only render the link text, no auto-generated REFERENCES section. -->
+<xsl:template match="ulink">
+  <xsl:variable name="content">
+    <xsl:apply-templates/>
+  </xsl:variable>
+  <xsl:value-of select="$content"/>
+</xsl:template>
+<xsl:template name="endnotes.list"></xsl:template>
+<xsl:template name="format.links.list"></xsl:template>
+
+</xsl:stylesheet>

--- a/docs/develop.adoc
+++ b/docs/develop.adoc
@@ -437,6 +437,39 @@ rnp_result_t
 rnp_do_operation(const char *param1, const int param2, int *size, char *buffer);
 --
 
+== Man pages
+
+Man pages are generated from AsciiDoc sources (`src/*/[name].[1-9].adoc`).
+Two toolchains are supported, and every man page source must build and
+render identically with both (`ci/check-man-pages.sh` enforces this in CI,
+modeled on git's dual-toolchain documentation check):
+
+* `asciidoctor -b manpage` (preferred, no extra dependencies), or
+* classic Python `asciidoc` (asciidoc-py) via docbook XML and
+  `xsltproc`/docbook-xsl, using `cmake/Modules/adoc-manpage.xsl`.
+
+CMake picks `asciidoctor` when available and falls back to
+`asciidoc` + `xsltproc`; `ASCIIDOC_TOOL` forces either one. When neither
+is installed, pre-generated pages from `docs/man/` are installed instead;
+refresh them with `ci/regen-man-pages.sh` (always with asciidoctor) after
+changing a man page source.
+
+To keep the sources compatible with both toolchains, stick to their
+common subset:
+
+* The NAME section must start with the page's own name
+  (e.g. `rnp - ...` for `rnp.1.adoc`); docbook-xsl names its output
+  after the first refname.
+* Prefer literal blocks (`----`) over `+` hard line breaks for verbatim
+  content such as headers and code; docbook-xsl drops `+` breaks inside
+  paragraphs unless they are plain text.
+* Do not nest quotes inside emphasis markers (`*"text"*`, `*"a@b.com"*`):
+  the tools disagree on where the span ends.
+* Avoid the `user@domain` and `<user@domain>` email shapes in running
+  text: asciidoctor turns them into email macros while asciidoc-py
+  leaves them as plain text. Wrap them in matched emphasis
+  (`_a@b.com_`) or monospace (`` `a@b.com` ``) instead.
+
 == OpenPGP protocol specification
 
 During development you'll need to reference OpenPGP protocol and related documents.

--- a/docs/man/librnp.3
+++ b/docs/man/librnp.3
@@ -2,12 +2,12 @@
 .\"     Title: librnp
 .\"    Author: RNP
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-08-01
+.\"      Date: 2026-09-02
 .\"    Manual: RNP Manual
 .\"    Source: RNP 0.18.1
 .\"  Language: English
 .\"
-.TH "LIBRNP" "3" "2026-08-01" "RNP 0.18.1" "RNP Manual"
+.TH "LIBRNP" "3" "2026-09-02" "RNP 0.18.1" "RNP Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -31,9 +31,14 @@
 librnp \- OpenPGP implementation, available via FFI interface.
 .SH "SYNOPSIS"
 .sp
-\fB#include <rnp/rnp.h>\fP
-.br
-\fB#include <rnp/rnp_err.h>\fP
+.if n .RS 4
+.nf
+.fam C
+#include <rnp/rnp.h>
+#include <rnp/rnp_err.h>
+.fam
+.fi
+.if n .RE
 .SH "DESCRIPTION"
 .sp
 \fBlibrnp\fP is part of the \fBRNP\fP suite and forms the basis for the \fIrnp(1)\fP and \fIrnpkeys(1)\fP command\-line utilities.

--- a/docs/man/rnp.1
+++ b/docs/man/rnp.1
@@ -2,12 +2,12 @@
 .\"     Title: rnp
 .\"    Author: RNP
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-08-01
+.\"      Date: 2026-09-02
 .\"    Manual: RNP Manual
 .\"    Source: RNP 0.18.1
 .\"  Language: English
 .\"
-.TH "RNP" "1" "2026-08-01" "RNP 0.18.1" "RNP Manual"
+.TH "RNP" "1" "2026-09-02" "RNP 0.18.1" "RNP Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -28,7 +28,7 @@
 .  LINKSTYLE blue R < >
 .\}
 .SH "NAME"
-RNP \- OpenPGP\-compatible signatures and encryption.
+rnp \- OpenPGP\-compatible signatures and encryption.
 .SH "SYNOPSIS"
 .sp
 \fBrnp\fP [\fI\-\-homedir\fP \fIdir\fP] [\fIOPTIONS\fP] \fICOMMAND\fP [\fIINPUT_FILE\fP, .\|.\|.] .\|.\|.
@@ -245,7 +245,7 @@ Additional options:
 .sp
 \fB\-\-output\fP
 .RS 4
-Override the default output selection with a file name or stdout specifier (\fB\fI\-\fP\fP). For the default output path selection see the \fBBASICS\fP section.
+Override the default output selection with a file name or stdout specifier (\fI\-\fP). For the default output path selection see the \fBBASICS\fP section.
 .RE
 .sp
 \fB\-\-password\fP, \fB\-\-pass\-fd\fP

--- a/docs/man/rnpkeys.1
+++ b/docs/man/rnpkeys.1
@@ -2,12 +2,12 @@
 .\"     Title: rnpkeys
 .\"    Author: RNP
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-08-01
+.\"      Date: 2026-09-02
 .\"    Manual: RNP Manual
 .\"    Source: RNP 0.18.1
 .\"  Language: English
 .\"
-.TH "RNPKEYS" "1" "2026-08-01" "RNP 0.18.1" "RNP Manual"
+.TH "RNPKEYS" "1" "2026-09-02" "RNP 0.18.1" "RNP Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -28,7 +28,7 @@
 .  LINKSTYLE blue R < >
 .\}
 .SH "NAME"
-RNPKEYS \- OpenPGP key management utility.
+rnpkeys \- OpenPGP key management utility.
 .SH "SYNOPSIS"
 .sp
 \fBrnpkeys\fP [\fI\-\-homedir\fP \fIdir\fP] [\fIOPTIONS\fP] \fICOMMAND\fP
@@ -156,9 +156,7 @@ It may be specified in one of the following ways:
 \fBuserid\fP
 .RS 4
 Or just part of the \fBuserid\fP.
-For \fB"Alice \c
-.MTO "alice\(atrnpgp.com" "" ""\fP,"
-the following methods are considered identical:
+For \fIalice@rnpgp.com\fP, the following methods are considered identical:
 .sp
 .RS 4
 .ie n \{\
@@ -867,9 +865,7 @@ To import all secret keys the following command should be used (please note, tha
 This example generates a new key with specified userid and expiration.
 Also it enables "expert" mode, allowing the selection of key/subkey algorithms.
 .sp
-\fBrnpkeys\fP \fB\-\-generate\fP \fB\-\-userid\fP \fB"\c
-.MTO "john\(atdoe.com" "" ""\fP"
-\fB\-\-expert\fP \fB\-\-expiration\fP \fB1y\fP
+\fBrnpkeys\fP \fB\-\-generate\fP \fB\-\-userid\fP \fIjohn@doe.com\fP \fB\-\-expert\fP \fB\-\-expiration\fP \fB1y\fP
 .SH "BUGS"
 .sp
 Please report \fIissues\fP via the RNP public issue tracker at:

--- a/src/lib/librnp.3.adoc
+++ b/src/lib/librnp.3.adoc
@@ -11,9 +11,10 @@ librnp - OpenPGP implementation, available via FFI interface.
 
 == SYNOPSIS
 
-*#include <rnp/rnp.h>* +
-*#include <rnp/rnp_err.h>*
-
+----
+#include <rnp/rnp.h>
+#include <rnp/rnp_err.h>
+----
 
 == DESCRIPTION
 

--- a/src/rnp/rnp.1.adoc
+++ b/src/rnp/rnp.1.adoc
@@ -7,7 +7,7 @@ RNP
 
 == NAME
 
-RNP - OpenPGP-compatible signatures and encryption.
+rnp - OpenPGP-compatible signatures and encryption.
 
 == SYNOPSIS
 
@@ -140,7 +140,7 @@ If the data is signed, signature verification information will be printed to _st
 Additional options:
 
 *--output*:::
-Override the default output selection with a file name or stdout specifier (*_-_*). For the default output path selection see the *BASICS* section.
+Override the default output selection with a file name or stdout specifier (_-_). For the default output path selection see the *BASICS* section.
 
 *--password*, *--pass-fd*:::
 Depending on encryption options, you may be asked for the password of one of your secret keys, or for the encryption password. These options override that behavior such that you can input the password through automated means.

--- a/src/rnpkeys/rnpkeys.1.adoc
+++ b/src/rnpkeys/rnpkeys.1.adoc
@@ -7,7 +7,7 @@ RNP
 
 == NAME
 
-RNPKEYS - OpenPGP key management utility.
+rnpkeys - OpenPGP key management utility.
 
 == SYNOPSIS
 
@@ -63,7 +63,7 @@ It may be specified in one of the following ways:
 
 *userid*::
 Or just part of the *userid*.
-For *"Alice <alice@rnpgp.com>"*, the following methods are considered identical:
+For _alice@rnpgp.com_, the following methods are considered identical:
 
 ** _alice_
 ** _alice@rnpgp_
@@ -420,7 +420,7 @@ To import all secret keys the following command should be used (please note, tha
 This example generates a new key with specified userid and expiration.
 Also it enables "expert" mode, allowing the selection of key/subkey algorithms.
 
-*rnpkeys* *--generate* *--userid* *"john@doe.com"* *--expert* *--expiration* *1y*
+*rnpkeys* *--generate* *--userid* _john@doe.com_ *--expert* *--expiration* *1y*
 
 == BUGS
 


### PR DESCRIPTION
## Summary

Implements #2395 the "git way": man pages can now be generated with either supported AsciiDoc toolchain, and CI keeps the sources honest about it.

- `cmake/Modules/AdocMan.cmake` now picks a backend: `asciidoctor -b manpage` (preferred, no extra deps) → `asciidoc` + `xsltproc` (the a2x docbook pipeline distros already ship) → pre-generated `docs/man/` cache. `ASCIIDOC_TOOL=asciidoc` forces the docbook pipeline.
- New `cmake/Modules/adoc-manpage.xsl`: stock docbook-xsl manpages sheet plus the adjustments a2x's bundled sheet applies (ulink text-only, no auto-REFERENCES, quiet output), and a template mapping the `<?asciidoc-br?>` PI (`+` hard line breaks, which stock docbook-xsl silently drops) to roff `.br`.
- Man page sources brought into the common asciidoc/asciidoctor subset:
  - NAME sections start with the page's own name (`rnp`, `rnpkeys`, `librnp`) — required because docbook-xsl names its output after the first refname, and the correct whatis name anyway;
  - `librnp(3)` SYNOPSIS uses a literal block instead of `+`-joined bold lines;
  - removed constructs the two tools render differently: `*"quoted text"*` / `*_-_*` (span-end disagreement) and bare `<user@domain>` / `user@domain` shapes in running text (asciidoctor macro-ifies emails, asciidoc-py does not).
- `ci/check-man-pages.sh` + new `man-pages` workflow: builds all three pages with **both** toolchains, fails on any stderr output (like git's `ci/test-documentation.sh`), and diffs the normalized rendered output so silent divergence cannot creep in.
- `docs/develop.adoc` documents the two toolchains and the common-subset rules; `docs/man/` cache refreshed (asciidoctor stays canonical for the cache).

Rendered output from both toolchains is verified identical modulo known cosmetics (sentence spacing, footer date format, AUTHOR section shape), which the check normalizes away.

## Test plan

- [x] `cmake -DASCIIDOC_TOOL=asciidoc` build + `DESTDIR` install of all three man pages via asciidoc-py 10.2.1 + docbook-xsl 1.79.2
- [x] Default configure picks asciidoctor; `--no-toolchain` configure falls back to the `docs/man` cache
- [x] `ci/check-man-pages.sh` passes (both toolchains, zero warnings, identical normalized renders); shellcheck clean
- [ ] CI `man-pages` workflow green on ubuntu (apt asciidoctor + asciidoc + docbook-xsl)

Closes #2395
