### PR TITLE
tests: treat gpg 'Bad passphrase' as transient under CI load

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -581,10 +581,11 @@ def gpg_symencrypt_file(src, dst, cipher=None, z=None, armor=False, aead=None):
 
 # gpg-agent occasionally misbehaves under parallel CI load (issue #2457):
 # "Corrupted protection" when unwrapping a just-imported protected key, or a
-# spurious "BAD signature" during verification. Both recover on a fresh
-# invocation, so retry exactly these two signatures and nothing else --
-# genuine regressions must still fail.
-GPG_TRANSIENT_ERRORS = ['Corrupted protection', 'BAD signature']
+# spurious "BAD signature" during verification. "Bad passphrase" is the same
+# agent-state failure as reported by some gpg versions. All of them recover
+# on a fresh invocation, so retry exactly these signatures and nothing else
+# -- genuine regressions must still fail.
+GPG_TRANSIENT_ERRORS = ['Corrupted protection', 'BAD signature', 'Bad passphrase']
 GPG_TRANSIENT_RETRIES = 3
 
 def run_gpg(params):


### PR DESCRIPTION
## Summary
- Follow-up to #2457/#2476: the gpg-agent state failure that prints as `Corrupted protection` on some gpg versions surfaces as `Bad passphrase` on others - seen failing `cli_tests-Compression` on the debian-13 leg of #2478 (log: `gpg signing failed: Bad passphrase`, first occurrence, no code relation to that PR).
- Added to `GPG_TRANSIENT_ERRORS` so the existing in-call retry + whole-test re-run machinery covers it. Deterministic passphrase failures (genuine regressions) still fail after all attempts - the retry only converts single-shot agent hiccups into passes.

## Test plan
- [ ] CI green
- [ ] No behavior change for deterministic gpg failures (3 attempts then fail)
