### PR TITLE
ci(release): fix invalid env context in the prebuilt workflow call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,11 @@ jobs:
     name: Build prebuilt static-library tarballs
     needs: release
     uses: ./.github/workflows/prebuilt.yml
+    # job-level with: of a reusable workflow caller cannot use the env
+    # context (only github/needs/vars/inputs), which made GitHub reject the
+    # whole workflow file on every run
     with:
-      tag: ${{ env.RELEASE_TAG }}
+      tag: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- `release.yml` has failed with a workflow-file issue on every trigger since it was introduced - actionlint pinpoints it: the `prebuilt` job calls the reusable `prebuilt.yml` with `tag: env.RELEASE_TAG`, but the `env` context is not allowed in a caller's job-level `with:` (only `github`/`needs`/`vars`/`inputs`).
- Fixed by computing the tag with the allowed contexts - identical semantics to the workflow-level env definition the other jobs use.
- Verified locally: actionlint fails on the original file at exactly that line and passes with the fix.

## Test plan
- [ ] actionlint/CI green
- [ ] next tag push or workflow dispatch of release.yml starts jobs instead of failing with a workflow file issue
