### PR TITLE
tests: treat gpg symmetric 'Checksum error' as transient under CI load

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -580,12 +580,14 @@ def gpg_symencrypt_file(src, dst, cipher=None, z=None, armor=False, aead=None):
 
 
 # gpg-agent occasionally misbehaves under parallel CI load (issue #2457):
-# "Corrupted protection" when unwrapping a just-imported protected key, or a
-# spurious "BAD signature" during verification. "Bad passphrase" is the same
-# agent-state failure as reported by some gpg versions. All of them recover
-# on a fresh invocation, so retry exactly these signatures and nothing else
-# -- genuine regressions must still fail.
-GPG_TRANSIENT_ERRORS = ['Corrupted protection', 'BAD signature', 'Bad passphrase']
+# "Corrupted protection" when unwrapping a just-imported protected key, a
+# spurious "BAD signature" during verification, "Bad passphrase" or a
+# symmetric session-key "Checksum error" - the same agent-state failure with
+# different wording across gpg versions. All of them recover on a fresh
+# invocation, so retry exactly these signatures and nothing else --
+# genuine regressions must still fail.
+GPG_TRANSIENT_ERRORS = [
+  'Corrupted protection', 'BAD signature', 'Bad passphrase', 'Checksum error']
 GPG_TRANSIENT_RETRIES = 3
 
 def run_gpg(params):


### PR DESCRIPTION
## Summary
- Follow-up to #2457/#2476/#2480: the gpg-agent state failure has a fourth wording - `decryption of the symmetrically encrypted session key failed: Checksum error` - seen failing `cli_tests-Encryption` on the Fedora rawhide leg. Added to `GPG_TRANSIENT_ERRORS` so the in-call retry + whole-test re-run machinery covers it.
- Deterministic failures still fail after all retry attempts.

## Test plan
- [ ] CI green
